### PR TITLE
mg7: fix gogo generation CI crash + add red mg7 xsec tracker

### DIFF
--- a/.github/workflows/acceptancetest_mg7.yml
+++ b/.github/workflows/acceptancetest_mg7.yml
@@ -178,10 +178,13 @@ jobs:
             ./tests/test_manager.py test_generation_heft_mg7 -pA -t0 -l INFO
 
   acceptancetest_mg7_mssm_gogo:
-    # mg7/madmatrix cannot yet generate the MSSM merged-flavor squark/gluino
-    # vertices (single-merged-leg / event-by-event flavored couplings); the
-    # output must refuse cleanly with InvalidCmd (not crash). The madevent
-    # counterpart is test_madevent_mssm_gogo in acceptancetest_madevent.yml.
+    # mg7/madmatrix now generates the MSSM merged-flavor squark/gluino vertices
+    # (single-merged-leg / event-by-event flavored couplings); standalone_mg7
+    # reproduces the Fortran standalone per-flavor |M|^2 (~1e-4). This is a
+    # matrix-element (standalone) check only -- full mg7 event generation for
+    # merged-flavor processes is not wired up yet (see test_madevent_merged_
+    # flavor_uq_mg7). The madevent counterpart is test_madevent_mssm_gogo in
+    # acceptancetest_madevent.yml.
     runs-on: ubuntu-24.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
@@ -192,5 +195,26 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE
             ./tests/test_manager.py test_standalone_mg7_mssm_gogo -pA -t0 -l INFO
+
+  acceptancetest_mg7_mssm_gogo_xsec:
+    # KNOWN-FAILING (not xfail): standalone_mg7 reproduces the per-flavor |M|^2
+    # for MSSM p p > go go (test_standalone_mg7_mssm_gogo), but full mg7 event
+    # generation for merged-flavor processes is not wired up yet -- the madspace
+    # integrator does not produce the cross-section. This pins the mg7 result to
+    # the madevent reference (4.541638 pb, run_01 of test_generation_from_file_1)
+    # and is expected to be red until the mg7 integrator handles merged-flavor
+    # p p > go go. Self-skips if the madspace + LHAPDF(NNPDF23) stack is absent.
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout_mg5
+      - uses: ./.github/actions/restore-pip-cache
+      - uses: ./.github/actions/restore_heptools_lhapdf
+      - name: test one of the test test_generation_from_file_1_mg7
+        run: |
+            cd $GITHUB_WORKSPACE
+            export PATH="$HOME/.cache/HEPtools/bin:$PATH"
+            ./tests/test_manager.py test_generation_from_file_1_mg7 -pA -t0 -l INFO
 
 

--- a/tests/acceptance_tests/test_cmd_madevent.py
+++ b/tests/acceptance_tests/test_cmd_madevent.py
@@ -2541,8 +2541,39 @@ class TestMEfromfile(unittest.TestCase):
         self.assertEqual(run_card['ptheavy'], 50)
         for event in events:
             event.check()
-        
-        
+
+    def test_generation_from_file_1_mg7(self):
+        """mg7 (madspace) cross-section for MSSM p p > go go, pinned to the
+        madevent reference from test_generation_from_file_1.
+
+        KNOWN-FAILING, intentionally NOT marked xfail: standalone_mg7 already
+        reproduces the per-flavor |M|^2 for p p > go go
+        (test_standalone_mg7_mssm_gogo, ~1e-4), but full mg7 event generation
+        for merged-flavor processes is not wired up yet -- the madspace
+        integrator does not currently produce the cross-section (cf. the SM
+        tracker test_madevent_merged_flavor_uq_mg7, which segfaults). This pins
+        the mg7 cross-section to the madevent reference (run_01 of
+        test_generation_from_file_1, 4.541638 pb) and is expected to fail until
+        the mg7 integrator handles merged-flavor p p > go go; it is left
+        undecorated so the gap stays visible in the mg7 workflow rather than
+        being silently swallowed by expectedFailure. (The mg7 default
+        run_card.toml uses a dynamical HT/2 scale rather than the madevent
+        run_card_matching.dat settings, so a residual scale-driven difference is
+        expected even once the integrator works.) Self-skips where the mg7
+        runtime stack is unavailable.
+        """
+        datadir = _mg7_datadir_or_skip(self)
+        cross, error = _run_mg7_xsec(self,
+            ['set automatic_html_opening False --no_save',
+             'import model MSSM_SLHA2',
+             'generate p p > go go'],
+            pjoin(self.path, 'MG7_mssm_gogo'), datadir)
+        # madevent reference (run_01 in test_generation_from_file_1)
+        target = 4.541638
+        self.assertLess(abs(cross - target) / target, 0.10,
+            'mg7 p p > go go cross-section %s far from madevent reference %s'
+            % (cross, target))
+
     def test_contur_from_file(self):
         """check that contur runs as expected"""
 

--- a/tests/input_files/test_mssm_generation
+++ b/tests/input_files/test_mssm_generation
@@ -2,7 +2,7 @@ import model MSSM_SLHA2
 set automatic_html_opening False --no-save
 set notification_center False --no-save
 generate p p > go go
-output %(dir_name)s
+output madevent %(dir_name)s
 launch -i
 set automatic_html_opening False --no-save
 set madanalysis_path None --no_save


### PR DESCRIPTION
## Summary

Fixes the CI crash in `test_generation_from_file_1` and adds the missing mg7 event-generation coverage for MSSM `p p > go go` as an explicit (intentionally red) tracker.

### Root cause of the crash
`test_generation_from_file_1` drives `generate_events` from the input file `tests/input_files/test_mssm_generation`, which used a bare `output` — and bare `output` now defaults to mg7 (`check_output(..., default='mg7')`). mg7 has no event-generation pipeline for this MSSM merged-flavor process, so the run crashed. The test's assertions (cross-sections 4.541638 / 4.41887317, banner `ptheavy`, LHE parsing) are MadEvent-specific, so the test belongs to the MadEvent path.

**Fix:** pin the input file to `output madevent`, matching the branch-wide convention for generate_events tests.

### New mg7 tracker
The Massaro merged-flavor commits made **standalone_mg7** reproduce the per-flavor |M|^2 for `p p > go go` (`test_standalone_mg7_mssm_gogo`), but full mg7 **event generation** for merged-flavor processes is not wired up yet — the madspace integrator does not produce the cross-section (cf. the existing SM tracker `test_madevent_merged_flavor_uq_mg7`).

- **`test_generation_from_file_1_mg7`** runs the full mg7 (madspace) pipeline for `p p > go go` and pins the cross-section to the madevent reference (4.541638 pb). Left undecorated (not @expectedFailure) so the gap stays visible, matching the other red mg7 trackers. Self-skips without the madspace + LHAPDF(NNPDF23) stack.
- New CI job **`acceptancetest_mg7_mssm_gogo_xsec`** runs it.

### Also
- Refreshed the stale `acceptancetest_mg7_mssm_gogo` job comment (mg7 no longer refuses MSSM gogo with InvalidCmd — it generates the matrix element and is checked per-flavor).

## Expected CI state
`acceptancetest_mg7_mssm_gogo_xsec` is **expected to be red** until the mg7 integrator handles merged-flavor `p p > go go`. This is intentional — keeping the missing-feature gap visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
