### PR TITLE
Fix flavor sampling for initial states with same multiparticle

### DIFF
--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -5369,7 +5369,6 @@ class HelasMatrixElement(base_objects.PhysicsObject):
             for i in range(ninit):
                 pdg[i] = -pdg[i]
             init, final = pdg[:ninit], pdg[ninit:]
-            init.sort()
             final.sort()
             pdg = tuple(init + final)
             # check if we already computed this one

--- a/madgraph/iolibs/export_mg7.py
+++ b/madgraph/iolibs/export_mg7.py
@@ -187,16 +187,8 @@ class OneProcessExporterMG7(export_cpp.OneProcessExporterCPP):
                     sign = -1 if part_id < 0 else 1
                     pdg_color_types[sign * pdg] = sign * self.model.get_particle(part_id).get_color()
 
-        has_mirror_all = self.matrix_element.get("has_mirror_process")
-        same_initial_multiparticle = self.incoming[0] == self.incoming[1]
         flavors = [
-            {
-                "index": index,
-                "options": options,
-                "mirror": has_mirror_all or (
-                    same_initial_multiparticle and options[0][0] != options[0][1]
-                )
-            }
+            {"index": index, "options": options}
             for index, options in self.all_flavors_same_initial
         ]
         return {
@@ -210,4 +202,5 @@ class OneProcessExporterMG7(export_cpp.OneProcessExporterCPP):
             "pdg_color_types": pdg_color_types,
             "diagram_count": len(self.diagrams),
             "helicities": list(self.matrix_element.get_helicity_matrix()),
+            "has_mirror_process": self.matrix_element.get("has_mirror_process"),
         }

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -7960,21 +7960,10 @@ class ProcessExporterFortranMEGroup(ProcessExporterFortranME):
             flavors = me.get_external_flavors_with_iden()
             process = me.get('processes')[0]
 
-            same_initial_multiparticle = (
-                process.get_ninitial() == 2 and
-                get_initial_leg_signature(process, 1) ==
-                get_initial_leg_signature(process, 2)
-            )
             if me.get('has_mirror_process'):
                 lines.append("DATA (MIRRORPROCS(%i,I),I=1,%d)/%s/" % \
                             (i+1, len(flavors),
                       ",".join(['.true.' for flv in flavors])))
-            elif same_initial_multiparticle:
-                # If the two initial legs come from the same multiparticle
-                # definition, only mixed concrete flavors need mirror calls.
-                lines.append("DATA (MIRRORPROCS(%i,I),I=1,%d)/%s/" % \
-                            (i+1, len(flavors),
-                      ",".join([bool_dict[(flv[0][0] != flv[0][1])] for flv in flavors])))
             else:
                 lines.append("DATA (MIRRORPROCS(%i,I),I=1,%d)/%s/" % \
                         (i+1, len(flavors),

--- a/madgraph/iolibs/template_files/mg7/madevent.py
+++ b/madgraph/iolibs/template_files/mg7/madevent.py
@@ -800,7 +800,7 @@ class MadgraphSubprocess:
             devices = [devices]
         for device in devices:
             subproc_dir = os.path.dirname(subproc_path)
-            # 'cppauto' resolve quick fix
+            # 'cppauto' resolve quick fix 
             resolved = device
             if device == "cppauto":
                 out = subprocess.run(
@@ -1275,12 +1275,11 @@ class MadgraphSubprocess:
         flavors = []
         flavor_remap = []
         flavor_factors = []
-        flavor_mirror = []
         for flav in self.meta["flavors"]:
             flavors.append(flav["options"][0])
             flavor_remap.append(flav["index"])
             flavor_factors.append(len(flav["options"]))
-            flavor_mirror.append(flav["mirror"])
+        flavor_remap
         if self.matrix_element:
             matrix_element = ms.MatrixElement(
                 self.matrix_element,
@@ -1307,6 +1306,7 @@ class MadgraphSubprocess:
             pid_options=flavors,
             pdf1=pdf_arg,
             pdf2=pdf_arg,
+            has_mirror=self.meta["has_mirror_process"],
             input_momentum_fraction=True,
         )
         partial_weights = self.process.run_card["generation"]["systematics"]
@@ -1333,7 +1333,6 @@ class MadgraphSubprocess:
                 channel.active_flavors,
                 flavor_remap,
                 flavor_factors,
-                flavor_mirror,
             ))
         #print(integrands[0].function())
         #print(integrands[1].function())

--- a/madspace/include/madspace/phasespace/cross_section.hpp
+++ b/madspace/include/madspace/phasespace/cross_section.hpp
@@ -20,10 +20,12 @@ public:
         const nested_vector2<me_int_t>& pid_options = {},
         const std::variant<std::monostate, PdfGrid, CachedPdf>& pdf1 = std::monostate{},
         const std::variant<std::monostate, PdfGrid, CachedPdf>& pdf2 = std::monostate{},
+        bool has_mirror = false,
         bool input_momentum_fraction = true
     );
 
     const nested_vector2<me_int_t>& pid_options() const { return _pid_options; }
+    bool has_mirror() const { return _has_mirror; }
     bool has_pdf(std::size_t pdf_index) const { return _has_pdf.at(pdf_index); }
     const MatrixElement& matrix_element() const { return _matrix_element; }
     const std::optional<RunningCoupling>& running_coupling() const {
@@ -42,6 +44,7 @@ private:
     std::optional<RunningCoupling> _running_coupling;
     double _e_cm;
     std::variant<std::monostate, EnergyScale, CachedScale> _energy_scale;
+    bool _has_mirror;
     bool _input_momentum_fraction;
 };
 

--- a/madspace/include/madspace/phasespace/integrand.hpp
+++ b/madspace/include/madspace/phasespace/integrand.hpp
@@ -59,8 +59,7 @@ public:
         const std::vector<std::size_t>& channel_indices = {},
         const std::vector<std::size_t>& active_flavors = {},
         const std::vector<std::size_t>& flavor_remap = {},
-        const std::vector<double>& flavor_factors = {},
-        const std::vector<bool>& flavor_mirror = {}
+        const std::vector<double>& flavor_factors = {}
     );
     std::size_t particle_count() const { return _mapping.particle_count(); }
     bool madnis_training() const { return _madnis_training; }
@@ -136,8 +135,6 @@ private:
     std::vector<double> _active_flavors_mask;
     std::vector<me_int_t> _flavor_remap;
     std::vector<double> _flavor_factors;
-    std::vector<me_int_t> _flavor_mirror;
-    bool _has_mirror;
     NamedVector<Type> _channel_part_ret_types;
 
     friend class IntegrandProbability;

--- a/madspace/instruction_set.yaml
+++ b/madspace/instruction_set.yaml
@@ -2275,7 +2275,7 @@ sample_discrete:
       type: [float]
       desc:
     - name: option_count
-      type: [int]
+      type: [int, single]
       desc:
   outputs:
     - name: output

--- a/madspace/src/compgraphs/instruction_set_mixin.inc
+++ b/madspace/src/compgraphs/instruction_set_mixin.inc
@@ -138,7 +138,7 @@ InstructionOwner instructions[] {
     mi("rqs_inverse", 120, true, {{DataType::dt_float, false, {"n"}, false}, {DataType::dt_float, false, {"n", 6}, false}}, {{DataType::dt_float, false, {"n"}, false}, {DataType::dt_float, false, {"n"}, false}}),
     mi("softmax", 121, true, {{DataType::dt_float, false, {std::monostate{}}, false}}, {{DataType::dt_float, false, {std::monostate{}}, false}}),
     mi("softmax_prior", 122, true, {{DataType::dt_float, false, {"n"}, false}, {DataType::dt_float, false, {"n"}, false}}, {{DataType::dt_float, false, {"n"}, false}}),
-    mi("sample_discrete", 123, true, {{DataType::dt_float, false, {}, false}, {DataType::dt_int, false, {}, false}}, {{DataType::dt_int, false, {}, false}, {DataType::dt_float, false, {}, false}}),
+    mi("sample_discrete", 123, true, {{DataType::dt_float, false, {}, false}, {DataType::dt_int, true, {}, false}}, {{DataType::dt_int, false, {}, false}, {DataType::dt_float, false, {}, false}}),
     mi("sample_discrete_inverse", 124, true, {{DataType::dt_int, false, {}, false}, {DataType::dt_int, true, {}, false}}, {{DataType::dt_float, false, {}, false}, {DataType::dt_float, false, {}, false}}),
     mi("sample_discrete_probs", 125, true, {{DataType::dt_float, false, {}, false}, {DataType::dt_float, false, {"n"}, false}}, {{DataType::dt_int, false, {}, false}, {DataType::dt_float, false, {}, false}}),
     mi("sample_discrete_probs_inverse", 126, true, {{DataType::dt_int, false, {}, false}, {DataType::dt_float, false, {"n"}, false}}, {{DataType::dt_float, false, {}, false}, {DataType::dt_float, false, {}, false}}),

--- a/madspace/src/phasespace/base.cpp
+++ b/madspace/src/phasespace/base.cpp
@@ -145,9 +145,7 @@ Function Mapping::forward_function() const {
         {_input_types.keys(), fb.input_range(0, n_inputs)},
         {_condition_types.keys(), fb.input_range(n_inputs, arg_types.size())}
     );
-    NamedVector<Value> sorted_outputs = outputs.sort_like(_output_types.index_map());
-    check_types(sorted_outputs, _output_types, "Output");
-    fb.output_range(0, sorted_outputs.values());
+    fb.output_range(0, outputs.values());
     fb.output(n_outputs, det);
     return fb.function();
 }
@@ -165,9 +163,7 @@ Function Mapping::inverse_function() const {
         {_output_types.keys(), fb.input_range(0, n_outputs)},
         {_condition_types.keys(), fb.input_range(n_outputs, arg_types.size())}
     );
-    NamedVector<Value> sorted_outputs = outputs.sort_like(_input_types.index_map());
-    check_types(sorted_outputs, _input_types, "Output");
-    fb.output_range(0, sorted_outputs.values());
+    fb.output_range(0, outputs.values());
     fb.output(n_inputs, det);
     return fb.function();
 }
@@ -193,8 +189,6 @@ Function FunctionGenerator::function() const {
     auto outputs = build_function_impl(
         fb, {_arg_types.keys(), fb.input_range(0, _arg_types.size())}
     );
-    NamedVector<Value> sorted_outputs = outputs.sort_like(_return_types.index_map());
-    check_types(sorted_outputs, _return_types, "Output");
-    fb.output_range(0, sorted_outputs.values());
+    fb.output_range(0, outputs.values());
     return fb.function();
 }

--- a/madspace/src/phasespace/cross_section.cpp
+++ b/madspace/src/phasespace/cross_section.cpp
@@ -10,6 +10,7 @@ DifferentialCrossSection::DifferentialCrossSection(
     const nested_vector2<me_int_t>& pid_options,
     const std::variant<std::monostate, PdfGrid, CachedPdf>& pdf1,
     const std::variant<std::monostate, PdfGrid, CachedPdf>& pdf2,
+    bool has_mirror,
     bool input_momentum_fraction
 ) :
     FunctionGenerator(
@@ -29,6 +30,9 @@ DifferentialCrossSection::DifferentialCrossSection(
                 arg_types.push_back("x2", batch_float);
             }
             arg_types.push_back("pdf_id", batch_int);
+            if (has_mirror) {
+                arg_types.push_back("mirror", batch_int);
+            }
             bool uses_cached_pdf = false;
             auto add_pdf_args = [&](auto& pdf, int index) {
                 if (std::holds_alternative<CachedPdf>(pdf)) {
@@ -60,6 +64,7 @@ DifferentialCrossSection::DifferentialCrossSection(
     _running_coupling(running_coupling),
     _e_cm(cm_energy),
     _energy_scale(energy_scale),
+    _has_mirror(has_mirror),
     _input_momentum_fraction(input_momentum_fraction) {
     auto init_pdf = [&](auto& pdf, int index) {
         if (std::holds_alternative<PdfGrid>(pdf)) {
@@ -101,6 +106,10 @@ NamedVector<Value> DifferentialCrossSection::build_function_impl(
         x1x2 = fb.momenta_to_x1x2(momenta, _e_cm);
     }
     auto pdf_flavor_id = args.at(arg_index++);
+    if (_has_mirror) {
+        Value mirror_id = args.at(arg_index++);
+    }
+    // TODO: need to use mirror_id if we have two different PDFs
     NamedVector<Value> scales;
     if (std::holds_alternative<EnergyScale>(_energy_scale)) {
         scales = std::get<EnergyScale>(_energy_scale).build_function(fb, {momenta});

--- a/madspace/src/phasespace/discrete_sampler.cpp
+++ b/madspace/src/phasespace/discrete_sampler.cpp
@@ -40,7 +40,7 @@ NamedVector<Value> DiscreteHistogram::build_function_impl(
         results.push_back(values);
         results.push_back(counts);
     }
-    return {return_types().keys(), results};
+    return {arg_types().keys(), results};
 }
 
 DiscreteSampler::DiscreteSampler(

--- a/madspace/src/phasespace/integrand.cpp
+++ b/madspace/src/phasespace/integrand.cpp
@@ -28,8 +28,7 @@ Integrand::Integrand(
     const std::vector<std::size_t>& channel_indices,
     const std::vector<std::size_t>& active_flavors,
     const std::vector<std::size_t>& flavor_remap,
-    const std::vector<double>& flavor_factors,
-    const std::vector<bool>& flavor_mirror
+    const std::vector<double>& flavor_factors
 ) :
     FunctionGenerator(
         "Integrand",
@@ -127,8 +126,7 @@ Integrand::Integrand(
         mapping.random_dim() +               // phasespace
         (mapping.channel_count() > 1) +      // symmetric channel
         (diff_xs.pid_options().size() > 1) + // flavor
-        // flipped initial state/
-        std::any_of(flavor_mirror.begin(), flavor_mirror.end(), std::identity{})
+        diff_xs.has_mirror()                 // flipped initial state
     ),
     _flavor_remap(flavor_remap.begin(), flavor_remap.end()),
     _flavor_factors(flavor_factors),
@@ -155,12 +153,6 @@ Integrand::Integrand(
         }
     }
 
-    _flavor_mirror.reserve(flavor_mirror.size());
-    _has_mirror = false;
-    for (bool mirror : flavor_mirror) {
-        _flavor_mirror.push_back(mirror ? 2 : 1);
-        _has_mirror |= mirror;
-    }
     _channel_part_ret_types = compute_channel_part_ret_types();
 }
 
@@ -199,6 +191,7 @@ NamedVector<Type> Integrand::compute_channel_part_ret_types() const {
     };
 
     bool has_multi_flavor = _diff_xs.pid_options().size() > 1;
+    bool has_mirror = _diff_xs.has_mirror();
     int particle_count = static_cast<int>(_mapping.particle_count());
     int random_dim = static_cast<int>(_mapping.random_dim());
 
@@ -213,6 +206,12 @@ NamedVector<Type> Integrand::compute_channel_part_ret_types() const {
     ret.push_back("chan_index_in_group", batch_int);
     if (!_madnis_training) {
         ret.push_back("momenta", batch_four_vec_array(particle_count));
+        if (has_mirror) {
+            ret.push_back("momenta_mirror", batch_four_vec_array(particle_count));
+        }
+    }
+    if (has_mirror) {
+        ret.push_back("mirror_id", batch_int);
     }
     if (_madnis_training) {
         ret.push_back("extra_weight_before_cuts", batch_float);
@@ -221,12 +220,6 @@ NamedVector<Type> Integrand::compute_channel_part_ret_types() const {
     // outputs after cuts
     ret.push_back("indices_acc", Type(DataType::dt_int, acc_batch_size, {}));
     ret.push_back("momenta_acc", acc_four_vec_array(particle_count));
-    if (_has_mirror) {
-        if (!_madnis_training) {
-            ret.push_back("momenta_mirror_acc", acc_four_vec_array(particle_count));
-        }
-        ret.push_back("mirror_id_acc", acc_int);
-    }
     ret.push_back("x1_acc", acc_float);
     ret.push_back("x2_acc", acc_float);
     ret.push_back("flavor_id", acc_int);
@@ -256,6 +249,7 @@ NamedVector<Value> Integrand::build_channel_part(
 ) const {
     bool has_multi_flavor = _diff_xs.pid_options().size() > 1;
     bool has_permutations = _mapping.channel_count() > 1;
+    bool has_mirror = _diff_xs.has_mirror();
     auto batch_size_val = args.at("batch_size");
 
     Value r = fb.random(batch_size_val, _random_dim);
@@ -274,7 +268,7 @@ NamedVector<Value> Integrand::build_channel_part(
         r = r_rest;
         flavor_random = r_val;
     }
-    if (_has_mirror) {
+    if (has_mirror) {
         auto [r_rest, r_val] = fb.pop(r);
         r = r_rest;
         mirror_random = r_val;
@@ -350,6 +344,15 @@ NamedVector<Value> Integrand::build_channel_part(
     Value momenta = mapping_result["momenta"];
     Value x0 = mapping_result["x1"];
     Value x1 = mapping_result["x2"];
+
+    Value momenta_mirror, mirror_id;
+    if (has_mirror) {
+        auto [index, mirror_det] =
+            fb.sample_discrete(mirror_random, static_cast<me_int_t>(2));
+        mirror_id = index;
+        momenta_mirror = fb.mirror_momenta(momenta, mirror_id);
+        weights_before_cuts.push_back(mirror_det);
+    }
 
     // Filter events that pass cuts
     Value weight_before_cuts = fb.product(weights_before_cuts);
@@ -459,25 +462,6 @@ NamedVector<Value> Integrand::build_channel_part(
         }
     }
 
-    Value momenta_mirror_acc, mirror_id_acc;
-    if (_has_mirror) {
-        Value option_count;
-        if (std::all_of(
-                _flavor_mirror.begin(), _flavor_mirror.end(), [](me_int_t mirror) {
-                    return mirror == 2;
-                }
-            )) {
-            option_count = static_cast<me_int_t>(2);
-        } else {
-            option_count = fb.gather_int(flavor_id, _flavor_mirror);
-        }
-        Value mirror_random_acc = fb.batch_gather(indices_acc, mirror_random);
-        auto [index, mirror_det] = fb.sample_discrete(mirror_random_acc, option_count);
-        mirror_id_acc = index;
-        momenta_mirror_acc = fb.mirror_momenta(momenta_acc, mirror_id_acc);
-        weights_after_cuts.push_back(mirror_det);
-    }
-
     Value weight_after_cuts = weights_after_cuts.empty()
         ? fb.full({1., batch_size_acc})
         : fb.product(weights_after_cuts);
@@ -496,6 +480,12 @@ NamedVector<Value> Integrand::build_channel_part(
     out.push_back("chan_index_in_group", chan_index_in_group);
     if (!_madnis_training) {
         out.push_back("momenta", momenta);
+        if (has_mirror) {
+            out.push_back("momenta_mirror", momenta_mirror);
+        }
+    }
+    if (has_mirror) {
+        out.push_back("mirror_id", mirror_id);
     }
     if (_madnis_training) {
         out.push_back("extra_weight_before_cuts", extra_weight_before_cuts);
@@ -504,12 +494,6 @@ NamedVector<Value> Integrand::build_channel_part(
     // outputs after cuts
     out.push_back("indices_acc", indices_acc);
     out.push_back("momenta_acc", momenta_acc);
-    if (_has_mirror) {
-        if (!_madnis_training) {
-            out.push_back("momenta_mirror_acc", momenta_mirror_acc);
-        }
-        out.push_back("mirror_id_acc", mirror_id_acc);
-    }
     out.push_back("x1_acc", x_acc.at(0));
     out.push_back("x2_acc", x_acc.at(1));
     out.push_back("flavor_id", flavor_id);
@@ -538,6 +522,7 @@ NamedVector<Value> Integrand::build_common_part(
 ) const {
     bool has_multi_flavor = _diff_xs.pid_options().size() > 1;
     bool has_permutations = _mapping.channel_count() > 1;
+    bool has_mirror = _diff_xs.has_mirror();
     bool has_pdf_prior =
         (_pdfs.at(0) || _pdfs.at(1)) && _energy_scale && has_multi_flavor;
 
@@ -583,6 +568,9 @@ NamedVector<Value> Integrand::build_common_part(
     xs_args.push_back(x1_acc);
     xs_args.push_back(x2_acc);
     xs_args.push_back(flavor_id);
+    if (has_mirror) {
+        xs_args.push_back(args.at("mirror_id"));
+    }
     if (_diff_xs.has_pdf(0)) {
         xs_args.push_back(args.at("pdf1"));
     }
@@ -714,14 +702,10 @@ NamedVector<Value> Integrand::build_common_part(
         }
     } else {
         outputs.push_back("weight", optional_cut(weight));
-        if (_has_mirror) {
-            outputs.push_back(
-                "momenta",
-                scatter_or_drop(args.at("momenta"), args.at("momenta_mirror_acc"))
-            );
-        } else {
-            outputs.push_back("momenta", args.at("momenta"));
-        }
+        outputs.push_back(
+            "momenta",
+            optional_cut(has_mirror ? args.at("momenta_mirror") : args.at("momenta"))
+        );
         auto zeros_int = fb.full({static_cast<me_int_t>(0), batch_size_val});
         auto zeros_float = fb.full({0., batch_size_val});
         outputs.push_back("color_index", scatter_or_drop(zeros_int, dxs_vec.at(2)));

--- a/madspace/src/python/madspace.cpp
+++ b/madspace/src/python/madspace.cpp
@@ -1173,6 +1173,7 @@ PYBIND11_MODULE(_madspace_py, m) {
                     std::monostate,
                     PdfGrid,
                     DifferentialCrossSection::CachedPdf>&,
+                bool,
                 bool>(),
             py::arg("matrix_element"),
             py::arg("cm_energy"),
@@ -1181,9 +1182,11 @@ PYBIND11_MODULE(_madspace_py, m) {
             py::arg("pid_options") = nested_vector2<me_int_t>{},
             py::arg("pdf1") = std::monostate{},
             py::arg("pdf2") = std::monostate{},
+            py::arg("has_mirror") = false,
             py::arg("input_momentum_fraction") = true
         )
         .def("pid_options", &DifferentialCrossSection::pid_options)
+        .def("has_mirror", &DifferentialCrossSection::has_mirror)
         .def("matrix_element", &DifferentialCrossSection::matrix_element);
 
     py::classh<Unweighter, FunctionGenerator>(m, "Unweighter")
@@ -1210,8 +1213,7 @@ PYBIND11_MODULE(_madspace_py, m) {
                 const std::vector<std::size_t>&,
                 const std::vector<std::size_t>&,
                 const std::vector<std::size_t>&,
-                const std::vector<double>&,
-                const std::vector<bool>&>(),
+                const std::vector<double>&>(),
             py::arg("mapping"),
             py::arg("diff_xs"),
             py::arg("adaptive_map") = std::monostate{},
@@ -1231,8 +1233,7 @@ PYBIND11_MODULE(_madspace_py, m) {
             py::arg("channel_indices") = std::vector<std::size_t>{},
             py::arg("active_flavors") = std::vector<std::size_t>{},
             py::arg("flavor_remap") = std::vector<std::size_t>{},
-            py::arg("flavor_factors") = std::vector<double>{},
-            py::arg("flavor_mirror") = std::vector<bool>{}
+            py::arg("flavor_factors") = std::vector<double>{}
         )
         .def("particle_count", &Integrand::particle_count)
         .def("madnis_training", &Integrand::madnis_training)


### PR DESCRIPTION
Bug: For subprocesses with `_quark _quark` or `_anti_quark _anti_quark` initial states, there are in principle three configurations `d d`, `d u`, `u d`. This leads to two bugs:
- both Fortran and C++ matrix elements only map flavor indices to `d d` and `d u`. That means the contribution for certain diagrams is always zero, as the mirror index is not applied to the vector of flavors
- the channel-wide `active_flavors` in madspace sometimes miss active flavor configurations

Fixes:
- treat `d d`, `d u`, `u d` as independent flavors in the matrix element, only use mirroring for cases like `u u~`
- apply `active_flavors` per diagram instead of per channel in madspace 