### PR TITLE
Use hashes to ensure madspace compatibility, options to bundle madspace in gridpacks

### DIFF
--- a/madgraph/iolibs/template_files/mg7/gridpack.py
+++ b/madgraph/iolibs/template_files/mg7/gridpack.py
@@ -1,7 +1,15 @@
 #! /usr/bin/env python3
 
-import madspace as ms
 import os
+import sys
+from pathlib import Path
+
+# prefer madspace included in gridpack over system-wide package
+_GRIDPACK_DIR = Path(os.path.realpath(__file__)).parent.parent
+if (_GRIDPACK_DIR / "madspace").is_dir():
+    sys.path.insert(0, str(_GRIDPACK_DIR))
+
+import madspace as ms
 import glob
 import json
 import tomllib

--- a/madgraph/iolibs/template_files/mg7/gridpack.py
+++ b/madgraph/iolibs/template_files/mg7/gridpack.py
@@ -1,13 +1,29 @@
 #! /usr/bin/env python3
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
-# prefer madspace included in gridpack over system-wide package
+# search order for madspace package:
+#   1. a precompiled install (madspace/install/madspace)
+#   2. bundled source that still needs to be built (madspace/install.py)
+#   3. otherwise fall back to madspace is available in the environment
 _GRIDPACK_DIR = Path(os.path.realpath(__file__)).parent.parent
-if (_GRIDPACK_DIR / "madspace").is_dir():
-    sys.path.insert(0, str(_GRIDPACK_DIR))
+_LOCAL_MADSPACE_DIR = _GRIDPACK_DIR / "madspace"
+_LOCAL_INSTALL_DIR = _LOCAL_MADSPACE_DIR / "install"
+if (_LOCAL_INSTALL_DIR / "madspace").is_dir():
+    sys.path.insert(0, str(_LOCAL_INSTALL_DIR))
+elif (_LOCAL_MADSPACE_DIR / "install.py").is_file():
+    print()
+    print("You don't have madspace installed for this gridpack")
+    print("Running interactive madspace installation script")
+    print()
+
+    _result = subprocess.run([sys.executable, str(_LOCAL_MADSPACE_DIR / "install.py")])
+    if _result.returncode != 0:
+        raise RuntimeError("madspace installation failed — see output above")
+    sys.path.insert(0, str(_LOCAL_INSTALL_DIR))
 
 import madspace as ms
 import glob

--- a/madgraph/iolibs/template_files/mg7/gridpack.py
+++ b/madgraph/iolibs/template_files/mg7/gridpack.py
@@ -16,6 +16,14 @@ def main() -> None:
     param_card_path = os.path.join("Cards", "param_card.dat")
     with open(os.path.join("data", "data.json")) as f:
         madspace_data = json.load(f)
+    if madspace_data["source_hash"] != ms.SOURCE_HASH:
+        print()
+        print(
+            "\033[1m\033[31mWARNING\033[39m: The madspace version is not identical "
+            "to the one used to generate the gridpack. This can lead to errors or "
+            "incorrect results\033[0m"
+        )
+        print()
 
     # parse command line arguments
     parser = argparse.ArgumentParser()

--- a/madgraph/iolibs/template_files/mg7/madevent.py
+++ b/madgraph/iolibs/template_files/mg7/madevent.py
@@ -725,9 +725,17 @@ class MadgraphProcess:
         else:
             shutil.copytree("lib", lib_path)
 
+        if self.run_card["gridpack"]["include_madspace_source"]:
+            shutil.copytree(
+                _MADSPACE_DIR,
+                os.path.join(gridpack_path, "madspace"),
+                ignore=shutil.ignore_patterns("build", "install"),
+            )
+
         if self.run_card["gridpack"]["include_madspace"]:
             shutil.copytree(
-                _INSTALL_DIR / "madspace", os.path.join(gridpack_path, "madspace")
+                _INSTALL_DIR / "madspace",
+                os.path.join(gridpack_path, "madspace", "install", "madspace"),
             )
 
         matrix_elements = []

--- a/madgraph/iolibs/template_files/mg7/madevent.py
+++ b/madgraph/iolibs/template_files/mg7/madevent.py
@@ -697,7 +697,7 @@ class MadgraphProcess:
         )
 
     def save_gridpack(self) -> None:
-        if not self.run_card["run"]["save_gridpack"]:
+        if not self.run_card["gridpack"]["save_gridpack"]:
             return
 
         gridpack_path = os.path.join(self.run_path, "gridpack")
@@ -718,12 +718,17 @@ class MadgraphProcess:
             channel.save(os.path.join(channel_path, file))
 
         lib_path = os.path.join(gridpack_path, "lib")
-        if self.run_card["run"]["gridpack_include_source"]:
+        if self.run_card["gridpack"]["include_source"]:
             os.mkdir(lib_path)
             shutil.copytree("src", os.path.join(gridpack_path, "src"))
             shutil.copytree("SubProcesses", os.path.join(gridpack_path, "SubProcesses"))
         else:
             shutil.copytree("lib", lib_path)
+
+        if self.run_card["gridpack"]["include_madspace"]:
+            shutil.copytree(
+                _INSTALL_DIR / "madspace", os.path.join(gridpack_path, "madspace")
+            )
 
         matrix_elements = []
         for subproc in self.subprocess_data:

--- a/madgraph/iolibs/template_files/mg7/madevent.py
+++ b/madgraph/iolibs/template_files/mg7/madevent.py
@@ -51,6 +51,19 @@ import madspace as ms
 from models.check_param_card import ParamCard
 from madgraph.various import misc
 
+_source_hash = subprocess.run(
+    [sys.executable, str(_MADSPACE_DIR / "source_hash.py")],
+    capture_output=True, text=True, check=True,
+).stdout.strip()
+if _source_hash != ms.SOURCE_HASH:
+    print()
+    print(
+        "\033[1m\033[31mWARNING\033[39m: madspace source and installed binaries "
+        "are not compatible (source hash mismatch) — consider recompiling "
+        "madspace\033[0m"
+    )
+    print()
+
 logger = logging.getLogger("madevent7")
 
 
@@ -758,6 +771,7 @@ max_cut_repetitions = {self.run_card["generation"]["max_cut_repetitions"]}
         data = {
             "channels": channel_files,
             "matrix_elements": matrix_elements,
+            "source_hash": ms.SOURCE_HASH,
         }
         with open(os.path.join(data_path, "data.json"), "w") as f:
             json.dump(data, f)

--- a/madgraph/iolibs/template_files/mg7/run_card.toml
+++ b/madgraph/iolibs/template_files/mg7/run_card.toml
@@ -19,6 +19,7 @@ dummy_matrix_element = false
 save_gridpack = false
 include_source = false
 include_madspace = true
+include_madspace_source = false
 
 [beam]
 e_cm = 13000.0

--- a/madgraph/iolibs/template_files/mg7/run_card.toml
+++ b/madgraph/iolibs/template_files/mg7/run_card.toml
@@ -14,8 +14,11 @@ combine_thread_pool_size = -1
 output_format = "compact_npy" # options: compact_npy, lhe_npy, lhe
 verbosity = "pretty" # options: silent, pretty, log
 dummy_matrix_element = false
+
+[gridpack]
 save_gridpack = false
-gridpack_include_source = false
+include_source = false
+include_madspace = true
 
 [beam]
 e_cm = 13000.0

--- a/madspace/CMakeLists.txt
+++ b/madspace/CMakeLists.txt
@@ -432,3 +432,25 @@ python_add_library(
 target_link_libraries(_madspace_py PRIVATE pybind11::headers)
 target_link_libraries(_madspace_py PUBLIC madspace)
 install(TARGETS _madspace_py DESTINATION madspace)
+
+########################################################################################
+# Source hash                                                                          #
+########################################################################################
+
+# Runs at install time (after everything has been compiled), so the embedded
+# hash always reflects exactly what was just built rather than what was on
+# disk when CMake was configured.
+install(CODE "
+    execute_process(
+        COMMAND \"${Python_EXECUTABLE}\" \"${CMAKE_CURRENT_SOURCE_DIR}/source_hash.py\"
+        OUTPUT_VARIABLE MADSPACE_SOURCE_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE MADSPACE_SOURCE_HASH_RESULT
+    )
+    if(NOT \${MADSPACE_SOURCE_HASH_RESULT} EQUAL 0)
+        message(FATAL_ERROR \"Failed to compute madspace source hash\")
+    endif()
+    file(WRITE \"\${CMAKE_INSTALL_PREFIX}/madspace/_source_hash.py\"
+        \"SOURCE_HASH = \\\"\${MADSPACE_SOURCE_HASH}\\\"\\n\"
+    )
+")

--- a/madspace/madspace/__init__.py
+++ b/madspace/madspace/__init__.py
@@ -1,1 +1,2 @@
 from ._madspace_py_loader import *
+from ._source_hash import SOURCE_HASH

--- a/madspace/source_hash.py
+++ b/madspace/source_hash.py
@@ -1,0 +1,44 @@
+import hashlib
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent
+
+_SOURCE_DIRS = ("src", "include", "madspace")
+_SOURCE_FILES = ("CMakeLists.txt", "instruction_set.yaml", "pyproject.toml")
+
+# Artifacts that can appear on disk (e.g. compiled bytecode) but are not
+# actually part of the source, and would otherwise make the hash depend on
+# the local environment instead of just the source tree.
+_IGNORED_DIR_NAMES = {"__pycache__"}
+_IGNORED_FILE_NAMES = {".DS_Store"}
+_IGNORED_SUFFIXES = {".pyc", ".pyo"}
+
+
+def _iter_source_files():
+    for dir_name in _SOURCE_DIRS:
+        for path in (_ROOT / dir_name).rglob("*"):
+            if not path.is_file():
+                continue
+            if _IGNORED_DIR_NAMES & set(path.relative_to(_ROOT).parts):
+                continue
+            if path.name in _IGNORED_FILE_NAMES or path.suffix in _IGNORED_SUFFIXES:
+                continue
+            yield path
+    for file_name in _SOURCE_FILES:
+        yield _ROOT / file_name
+
+
+def compute_source_hash() -> str:
+    paths = sorted(_iter_source_files(), key=lambda p: p.relative_to(_ROOT).as_posix())
+    digest = hashlib.sha256()
+    for path in paths:
+        digest.update(path.relative_to(_ROOT).as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        with open(path, "rb") as f:
+            digest.update(hashlib.file_digest(f, "sha256").digest())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+if __name__ == "__main__":
+    print(compute_source_hash())


### PR DESCRIPTION
Use hashes of madspace source files to ensure compatibilty
- of installed madspace and madspace source
- of madspace used to generated and run a gridpack

Options to include madspace in gridpacks:
- use system-wide installation
- include madspace build
- include madspace source (also in addition to build)