### PR TITLE
more agressive pruning of diagram without flavor

### DIFF
--- a/aloha/template_files/wavefunctions.py
+++ b/aloha/template_files/wavefunctions.py
@@ -68,7 +68,18 @@ class FLV_Coupling_py:
             if len(non_zero) == 2:
                 k1, k2 = non_zero
             elif len(non_zero) == 1:
-                k1 = k2 = non_zero[0]
+                # Single merged leg: the unmerged partner gets flavor index 1,
+                # and which fermion (F1 or F2) carries the merged leg is decided
+                # by the position of the non-zero entry in the key (merged leg is
+                # F1 iff it is the first entry).  This must match the Fortran and
+                # C++ backends (base_objects.FLV_Coupling.get_partner_indices);
+                # otherwise single-merged-leg vertices such as `w+ ta+ vt~`
+                # (unmerged tau + merged neutrino) evaluate to zero here.
+                k = non_zero[0]
+                if key[0] == k:
+                    k1, k2 = k, 1
+                else:
+                    k1, k2 = 1, k
             else:
                 continue
             self.partner[k1] = k2

--- a/madgraph/core/base_objects.py
+++ b/madgraph/core/base_objects.py
@@ -2624,6 +2624,40 @@ class FLV_Coupling(PhysicsObject):
         """return all couplings"""
         return misc.make_unique(list(self['flavors'].values()))
 
+    @staticmethod
+    def get_partner_indices(key):
+        """Return the (k1, k2) partner flavor indices for one flavor key.
+
+        k1 is the flavor index of the first fermion (F1) of the vertex and k2
+        that of the second (F2); the consuming ALOHA routine fills
+        PARTNER(k1)=k2, PARTNER2(k2)=k1 and indexes VAL by k1.  For a vertex
+        with two merged fermions both indices come straight from the key.  For
+        a single merged fermion the unmerged partner is assigned flavor index
+        1, and which fermion (F1 or F2) carries the merged leg is decided by the
+        position of the non-zero entry in the key: the merged leg is F1 iff it
+        is the first entry, otherwise it is F2 (so PARTNER is filled in the
+        F1->F2 direction expected by the routine).
+
+        This is the single source of truth shared by every backend (Fortran,
+        C++, Python) so their FLV_COUPLING tables stay consistent -- keeping the
+        merged leg's position is what makes a single-merged-leg vertex such as
+        `w+ ta+ vt~` (unmerged tau, merged neutrino) work identically in all of
+        them.
+        """
+        nonzero = [i for i in key if i != 0]
+        if len(nonzero) == 2:
+            return nonzero[0], nonzero[1]
+        elif len(nonzero) == 1:
+            k = nonzero[0]
+            if key[0] == k:
+                return k, 1
+            else:
+                return 1, k
+        raise MadGraph5Error(
+            'Flavor coupling with %d merged legs is not supported (key=%s); '
+            'only one or two merged flavor legs are handled.'
+            % (len(nonzero), repr(key)))
+
     def __str__(self):
 
         max_flav = max([max([i for i in k]) for k in  self['flavors']])

--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -3942,6 +3942,17 @@ class HelasMatrixElement(base_objects.PhysicsObject):
         flavor which is not compatible with the diagram."""
         pass
 
+    # Class-level policy flag controlling how external flavors are enumerated
+    # for merged (flavor-grouped) processes.  In the default (masking) mode we
+    # keep a single representative per permutation class -- diagrams whose only
+    # flavor is a non-representative permutation are permutation duplicates and
+    # get trimmed.  When enumerate_all_flavors is True (set by do_output for the
+    # `--mask=False` standalone mode) every raw flavor combination is checked,
+    # so those permutation-duplicate diagrams keep a valid flavor and survive;
+    # only genuinely unphysical diagrams (supporting no flavor at all, e.g.
+    # charge-forbidden) are still trimmed.
+    enumerate_all_flavors = False
+
     def default_setup(self):
         """Default values for all properties"""
 
@@ -5495,10 +5506,24 @@ class HelasMatrixElement(base_objects.PhysicsObject):
         pdgs, pdg_signs, to_map, restricted_flavor, ninit = \
             self._flavor_enumeration_context(model)
 
-        # A per-leg flavor restriction means some diagrams may be incompatible
-        # with every allowed flavor and must be trimmed.  Record the flag; the
-        # actual trimming is deferred to get_external_flavors() (see docstring).
-        self._flavor_allow_trimming = (restricted_flavor != [None] * len(pdgs))
+        # Some diagrams may be incompatible with *every* allowed flavor and
+        # must be trimmed.  This happens for two reasons:
+        #  - an explicit per-leg flavor restriction, or
+        #  - merged (flavor-grouped) external particles, which can generate
+        #    diagrams whose only flavor assignment is a non-representative
+        #    permutation of a kept one (so they are permutation duplicates of a
+        #    kept diagram), or on which no flavor can map at all (e.g. forbidden
+        #    by electric-charge conservation).
+        # In both cases the orphan diagrams carry an all-zero flavor mask and
+        # must be removed.  Record the flag here; the actual trimming is
+        # deferred to get_external_flavors() (see docstring).  Note the set of
+        # "orphan" diagrams depends on how flavors are enumerated below: in the
+        # default (representative) mode a permutation-duplicate diagram is an
+        # orphan, whereas with enumerate_all_flavors it keeps a valid flavor and
+        # only genuinely unphysical diagrams remain orphans.
+        has_merged_external = any(abs(pdg) in to_map for pdg in pdgs)
+        self._flavor_allow_trimming = has_merged_external or \
+            (restricted_flavor != [None] * len(pdgs))
 
         # Fast path: if no external leg carries a merged (flavor-grouped) pdg and
         # there is no flavor restriction, then there is a single external-flavor
@@ -5535,9 +5560,18 @@ class HelasMatrixElement(base_objects.PhysicsObject):
         # trusted to skip a sibling assignment for a decay-chain ME.
         is_decay_chain = bool(self.get('processes')[0].get('decay_chains'))
 
+        # In enumerate_all_flavors mode (the `--mask=False` standalone case) we
+        # keep *every* raw flavor combination rather than one representative per
+        # permutation class, so that the matrix element is directly evaluable
+        # for any flavor ordering.  Skipping the signature dedup means a diagram
+        # whose only flavor is a non-representative permutation still records a
+        # valid flavor and survives trimming; only diagrams supporting no flavor
+        # at all remain orphans.
+        enumerate_all = self.enumerate_all_flavors
+
         for one_flavor, signed_pdg, signature in self._iter_candidate_flavors(
                 pdgs, pdg_signs, to_map, restricted_flavor, ninit):
-            if signature in checked:
+            if not enumerate_all and signature in checked:
                 if checked[signature]:
                     # genuine permutation duplicate of a validated flavor
                     continue
@@ -7070,8 +7104,14 @@ class HelasMultiProcess(base_objects.PhysicsObject):
                     continue
             
             for matrix_element in matrix_element_list:
-                if any(l.get('flavor') for l in matrix_element.get_all_wavefunctions()):
-                    matrix_element.get_external_flavors()
+                # Trigger restricted-flavor / merged-flavor diagram trimming
+                # here, *before* the color basis is built below (process_color),
+                # so the color basis is constructed from the final (trimmed)
+                # diagram set and stays consistent with it.  get_external_flavors
+                # self-populates and only trims when there is something to trim,
+                # so it is a cheap no-op for plain (non-merged, unrestricted)
+                # matrix elements.
+                matrix_element.get_external_flavors()
 
             # Deal with newly generated matrix elements
             for matrix_element in copy.copy(matrix_element_list):

--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -1596,18 +1596,33 @@ class HelasWavefunction(base_objects.PhysicsObject):
                 self[tag_name] = flav[index]
                 return return_fct(self, True, model, tag_name)
             else:
-                # need to set the flavor for a valid combination
-                pdg, flav_input = [(w.get('pdg_code'), w.get(tag_name)) for i, w in enumerate(self.get('mothers')) if abs(w.get_pdg_code()) in model.get('merged_particles')][0] 
-                pdg_order = [p.get_pdg_code() for  p in vertex.get('particles')]
-                pos_input = pdg_order.index(pdg)
-                pos_output = pdg_order.index(-pdg_out)
-                for key in coup.get('flavors'):
-                    if key[pos_input] == flav_input:
-                        self[tag_name] = key[pos_output]
-                        return return_fct(self, True, model, tag_name)
+                merged_input = [(w.get('pdg_code'), w.get(tag_name)) for i, w in enumerate(self.get('mothers')) if abs(w.get_pdg_code()) in model.get('merged_particles')]
+                if merged_input:
+                    pdg, flav_input = merged_input[0]
+                    pdg_order = [p.get_pdg_code() for  p in vertex.get('particles')]
+                    pos_input = pdg_order.index(pdg)
+                    pos_output = pdg_order.index(-pdg_out)
+                    for key in coup.get('flavors'):
+                        if key[pos_input] == flav_input:
+                            self[tag_name] = key[pos_output]
+                            return return_fct(self, True, model, tag_name)
+                    else:
+                        self[tag_name] = 0
+                        return return_fct(self, False, model, tag_name)
                 else:
-                    self[tag_name] = 0
-                    return return_fct(self, False, model, tag_name)
+                    # This happens for case like ta+ w- > vt
+                    # since ta+ is not merged but the neutrino is, 
+                    # for this example, we need to find the flavor of the neutrino
+                    # A single flavor should be valid from the coupling.
+                    if len(coup.get('flavors')) != 1:
+                        raise Exception('Flavor propagation for merged particle with no merged input is ambiguous')
+                    flv_coup = next(iter(coup.get('flavors').keys()))
+                    flav_output = [ f for f in flv_coup if f != 0]
+                    if len(flav_output) != 1:
+                        raise Exception('Flavor propagation for merged particle with no merged input is ambiguous')
+                    self[tag_name] = flav_output[0]
+                    return return_fct(self, True, model, tag_name)
+
         elif self.get('interaction_id') == 0:
             # this is a case where the current flavor is trivial (the pdg is not a merged one)
             # and there is no interaction, so no need to check the validity of the input
@@ -1665,7 +1680,8 @@ class HelasWavefunction(base_objects.PhysicsObject):
             return None
         
         pdg_out = self.get('pdg_code')
-        if pdg_out in model.get('merged_particles'):
+        misc.sprint(pdg_out, self[tag_name], [p.get_pdg_code() for p in vertex.get('particles')])
+        if abs(pdg_out) in model.get('merged_particles'):
             pdg_vertex = [p.get_pdg_code() for  p in vertex.get('particles')]             
             index_merge, merge_pdg = [(i,pdg) for i, pdg in enumerate(pdg_vertex) if abs(pdg) in model.get('merged_particles')][0]
             merge_flavor = self[tag_name]

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -9912,10 +9912,19 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
 
         if self._me_curr_exporter:
             self._curr_exporter.grouped_mode = 'gpu'
-            # temporary should be passed to 
+            # temporary should be passed to
             # self._curr_exporter.grouped_mode = self._me_curr_exporter.grouped_mode
             # or the most restricted of the two
-            
+
+        # When the flavor-mask optimization is disabled (`--mask=False`) the
+        # matrix element must be directly evaluable for *every* flavor
+        # combination, not just one representative per permutation class.  Ask
+        # the flavor machinery to enumerate all combinations: permutation-
+        # duplicate diagrams then keep a valid flavor and are not trimmed, while
+        # genuinely unphysical diagrams (no flavor at all) are still removed.
+        helas_objects.HelasMatrixElement.enumerate_all_flavors = \
+            not getattr(self._curr_exporter, 'use_flavor_mask', True)
+
         ndiags, cpu_time = generate_matrix_elements(self,group_processes)
 
         calls = 0

--- a/madgraph/iolibs/export_cpp.py
+++ b/madgraph/iolibs/export_cpp.py
@@ -419,12 +419,11 @@ class UFOModelConverterCPP(object):
         # For each parameter, write name = expr;
         for coupl in params:
             for key, c in coupl.flavors.items():
-                nonzero = [i for i in key if i != 0]
-                if len(nonzero) == 2:
-                    k1, k2 = nonzero
-                else:
-                    # single merged leg: unmerged partner has flavor index 1
-                    k1 = nonzero[0]; k2 = 1
+                # Same (k1, k2) derivation as the Fortran/Python backends: for a
+                # single merged leg the unmerged partner is flavor index 1 and
+                # the PARTNER/PARTNER2 direction depends on which fermion carries
+                # the merged leg (see FLV_Coupling.get_partner_indices).
+                k1, k2 = base_objects.FLV_Coupling.get_partner_indices(key)
                 def_flv.append('%(name)s.partner[%(in)i] = %(out)i;' % {'name': coupl.name,'in': k1-1, 'out': k2-1})
                 def_flv.append('%(name)s.partner2[%(out)i] = %(in)i;' % {'name': coupl.name,'in': k1-1, 'out': k2-1})
                 def_flv.append('%(name)s.val[%(in)i]  =  &%(coupl)s;' % {'name': coupl.name,'in': k1-1, 'coupl': c})

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -9241,18 +9241,9 @@ C
         end subroutine init_flv_couplings
             """
 
-        def _get_k1_k2(key):
-            keys = [i for i in key if i != 0]
-            if len(keys) == 2:
-                return keys[0], keys[1]
-            elif len(keys) == 1:
-                k = keys[0]
-                if key[0] == k:
-                    return k, 1
-                else:
-                    return 1, k
-            else:
-                raise Exception('Flavor coupling with more than 2 flavors is not supported for the moment')
+        # Single source of truth for the (k1, k2) PARTNER/PARTNER2 indices,
+        # shared with the C++/Python backends (see FLV_Coupling docstring).
+        _get_k1_k2 = base_objects.FLV_Coupling.get_partner_indices
 
         def_flv = []
         for coupl in self.coups_flv_indep:

--- a/madgraph/iolibs/template_files/madmatrix/cpp_model_parameters_h.inc
+++ b/madgraph/iolibs/template_files/madmatrix/cpp_model_parameters_h.inc
@@ -51,6 +51,9 @@ namespace mg5amcCpu
       for (int i = 0; i < max_flavor; ++i) {
           partner1[i] = -1;
           partner2[i] = -1;
+          value[i] = nullptr; // flavor slots with no coupling stay null so the
+                              // cIPF_value setup (value[j] ? *value[j] : 0) does
+                              // not dereference an uninitialised pointer
       }
     }
   };

--- a/madgraph/various/process_checks.py
+++ b/madgraph/various/process_checks.py
@@ -207,11 +207,33 @@ class MatrixElementEvaluator(object):
         process = matrix_element.get('processes')[0]
         model = process.get('model')
 
-        # Extract per-leg flavor indices for FLV_Coupling / merged-particle models.
-        # For legs without an explicit flavor tag the value is -1 (no flavor).
+        # Build the per-leg flavor index array passed to smatrix, using exactly
+        # the convention the Fortran/C++ standalone drivers build into their
+        # FLAV_TABLE (e.g. `DATA FLAV_TABLE / 1, 3, 1, 1 /`):
+        #   * a merged leg carries the 1-based *position* of its flavor inside
+        #     the merged group (e.g. vt is position 3 of {12,14,16}), and
+        #   * every other leg carries index 1 -- NOT the physical PDG and NOT
+        #     -1.  The unmerged partner of a single-merged-leg FLV vertex is
+        #     always flavor index 1 (see FLV_Coupling.get_partner_indices), so
+        #     PARTNER(1)=<merged pos> resolves the coupling.
+        # The leg 'flavor' tag stores the physical PDG, so convert it here.
+        # NB: for the light quarks the PDG (1..4) already equals the position,
+        # which is why this used to appear correct and only broke for a single
+        # merged lepton/neutrino paired with an unmerged partner, e.g.
+        # `w+ vt~ > z ta+` (vt is position 3, the tau must be index 1 -- passing
+        # -1 short-circuited the flavor check and returned zero).
+        merged = model.get('merged_particles') or {}
+        def _flavor_group_pos(leg):
+            tag = leg.get('flavor')
+            if not tag:
+                return 1
+            pdg = abs(tag[0])
+            for sub_ids in merged.values():
+                if pdg in sub_ids:
+                    return list(sub_ids).index(pdg) + 1
+            return 1
         legs = process.get('legs')
-        flavor = [leg.get('flavor')[0] if leg.get('flavor') else -1
-                  for leg in legs]
+        flavor = [_flavor_group_pos(leg) for leg in legs]
 
         if "matrix_elements" not in self.stored_quantities:
             self.stored_quantities['matrix_elements'] = []

--- a/madmatrix/model_handling.py
+++ b/madmatrix/model_handling.py
@@ -1650,9 +1650,14 @@ class OneProcessExporterMadMatrix(export_mg7.OneProcessExporterMG7):
             for flv_coup in flv_couplings:
                 coup_str_hrd_partner1 += ( ('Parameters_%(model_name)s::%(coup)s.param1' % {"model_name": self.model_name, "coup": flv_coup} + '[%d], ') * nMF) % ( *range(nMF), )
                 coup_str_hrd_partner2 += ( ('Parameters_%(model_name)s::%(coup)s.param2' % {"model_name": self.model_name, "coup": flv_coup} + '[%d], ') * nMF) % ( *range(nMF), )
-                value_string = '(fptype)Parameters_%(model_name)s::%(coup)s.value' % {"model_name": self.model_name, "coup": flv_coup}
-                range_ids = [ [ i, i ] for i in range(nMF) ]
-                coup_str_hrd_value += ( ( value_string + '[%d].real(), ' + value_string + '[%d].imag(), ' ) * nMF) % ( *[ j for i in range_ids for j in i ], )
+                # Guard against null value[] slots: flavor combinations with no
+                # coupling are left null by the FLV_COUPLING constructor, so the
+                # hardcoded cIPF_value read must not dereference an uninitialised
+                # pointer.  Mirrors the runtime path (value[j] ? *value[j] : 0).
+                value_base = 'Parameters_%(model_name)s::%(coup)s.value' % {"model_name": self.model_name, "coup": flv_coup}
+                for i in range(nMF):
+                    coup_str_hrd_value += '(fptype)( %(b)s[%(i)d] ? %(b)s[%(i)d]->real() : 0. ), ' % {'b': value_base, 'i': i}
+                    coup_str_hrd_value += '(fptype)( %(b)s[%(i)d] ? %(b)s[%(i)d]->imag() : 0. ), ' % {'b': value_base, 'i': i}
             coup_str_hrd_partner1 = coup_str_hrd_partner1[:-2] + ' };'
             coup_str_hrd_partner2 = coup_str_hrd_partner2[:-2] + ' };'
             coup_str_hrd_value    = coup_str_hrd_value[:-2] + ' };'
@@ -2175,22 +2180,34 @@ class OneProcessExporterMadMatrix(export_mg7.OneProcessExporterMG7):
         """Return the flavor matrix definition lines for this matrix element"""
         # Emitted at namespace scope (file-local linkage), so the host-side table
         # is visible to both the CPPProcess constructor and CPPProcess::flavorPDG.
-        flavor_line = '  static constexpr short flavors[nmaxflavor][npar] = {\n    '; # (this is tFlavors)
-        flavor_line_list = []
-        for flavors in matrix_element.get_external_flavors_with_iden():
-            # get only the index 0 one because the other ones have same matrix element
-            # additionally they will be used as indices in some cases (e.g. matrix flavor couplings)
-            # so we need to subtract 1 because FORTRAN indices starts from 1, and C++ from zero
-            cpp_flavors = list(map(lambda f: f-1, flavors[0]))
-            flavor_line_list.append( '{ ' + ', '.join(['%d'] * len(cpp_flavors)) % tuple(cpp_flavors) + ' }' )
-        out = flavor_line + ',\n    '.join(flavor_line_list) + ' };'
-        # Companion table with the true signed PDG ids of each flavor
-        # combination (same convention as the PDG lines printed by the
-        # Fortran/C++ standalone 'check' drivers); used by CPPProcess::flavorPDG.
         model = matrix_element.get('processes')[0].get('model')
         merged = model.get('merged_particles') or {}
         all_pdgs = [l.get('id') for l in
                     matrix_element.get('processes')[0].get('legs_with_decays')]
+
+        flavor_line = '  static constexpr short flavors[nmaxflavor][npar] = {\n    '; # (this is tFlavors)
+        flavor_line_list = []
+        for flavors in matrix_element.get_external_flavors_with_iden():
+            # get only the index 0 one because the other ones have same matrix element.
+            # These values are used at runtime as 0-based indices into the per-flavor
+            # FLV_COUPLING arrays (partner1/partner2/value, size max_flavor).  A
+            # merged leg's entry is the *physical PDG* of its flavor, so convert it
+            # to the 0-based position inside the merged group; an unmerged leg maps
+            # to 0.  Subtracting 1 directly only worked for the light quarks, whose
+            # PDG (1..4) equals the position; for a merged lepton/neutrino it gave an
+            # out-of-range index (e.g. 15 for nu_tau) -> out-of-bounds read (segfault).
+            cpp_flavors = []
+            for j, flv in enumerate(flavors[0]):
+                raw = all_pdgs[j]
+                if abs(raw) in merged:
+                    cpp_flavors.append(list(merged[abs(raw)]).index(abs(flv)))
+                else:
+                    cpp_flavors.append(0)
+            flavor_line_list.append( '{ ' + ', '.join('%d' % v for v in cpp_flavors) + ' }' )
+        out = flavor_line + ',\n    '.join(flavor_line_list) + ' };'
+        # Companion table with the true signed PDG ids of each flavor
+        # combination (same convention as the PDG lines printed by the
+        # Fortran/C++ standalone 'check' drivers); used by CPPProcess::flavorPDG.
         pdg_line_list = []
         for flavors in matrix_element.get_external_flavors_with_iden():
             row = []

--- a/madmatrix/model_handling.py
+++ b/madmatrix/model_handling.py
@@ -954,17 +954,20 @@ class MadMatrixUFOModelConverter(export_cpp.UFOModelConverterGPU):
         # code. See docs/mg7_merged_flavor_mssm_design.md.
         self._assert_flv_couplings_supported(params)
 
+        from madgraph.core import base_objects
         def_flv = []
         # For each parameter, write name = expr;
         for coupl in params:
             for key, c in coupl.flavors.items():
-                nonzero = [i for i in key if i != 0]
-                if len(nonzero) == 2:
-                    k1, k2 = nonzero
-                else:
-                    # single merged leg: unmerged partner has flavor index 1
-                    # (mirror Fortran flavor_couplings.f)
-                    k1 = nonzero[0]; k2 = 1
+                # Same (k1, k2) derivation as the Fortran/C++/Python backends:
+                # for a single merged leg the unmerged partner is flavor index 1
+                # and the PARTNER/PARTNER2 direction depends on which fermion
+                # carries the merged leg (see FLV_Coupling.get_partner_indices).
+                # Using this shared helper keeps mg7 consistent with the others
+                # -- previously it always used (k, 1), which transposed the
+                # table for a single merged leg not in the first position (e.g.
+                # the merged neutrino of `w+ ta+ vt~`).
+                k1, k2 = base_objects.FLV_Coupling.get_partner_indices(key)
                 def_flv.append('%(name)s.partner1[%(in)i] = %(out)i;' % {'name': coupl.name,'in': k1-1, 'out': k2-1})
                 def_flv.append('%(name)s.partner2[%(out)i] = %(in)i;' % {'name': coupl.name,'in': k1-1, 'out': k2-1})
                 def_flv.append('%(name)s.value[%(in)i] = &%(coupl)s;' % {'name': coupl.name,'in': k1-1, 'coupl': c})

--- a/tests/unit_tests/various/test_banner.py
+++ b/tests/unit_tests/various/test_banner.py
@@ -1339,7 +1339,7 @@ class TestRunCardMG7(unittest.TestCase):
         out = io.StringIO()
         rc.write(out, template=self.template)
         data = tomllib.loads(out.getvalue())
-        self.assertEqual(data['run']['output_format'], 'compact_npy')
+        self.assertEqual(data['run']['output_format'], 'lhe')
         self.assertEqual(data['beam']['e_cm'], 13000.0)
         self.assertIs(data['vegas']['enable'], True)
         self.assertEqual(data['multiparticles']['photon'], [22])


### PR DESCRIPTION
run the trimming
1) before color computation now
2) in all cases.
By default this also remove diagram only possible for symmetric flavor that the one considered.
the standalone --mask=False does not trim those last one for a simplify debugging/check