### PR TITLE
added input/output keys to umami and matrixelementapi 

### DIFF
--- a/madgraph/iolibs/template_files/madmatrix/umami.cc
+++ b/madgraph/iolibs/template_files/madmatrix/umami.cc
@@ -210,6 +210,40 @@ extern "C"
     return UMAMI_SUCCESS;
   }
 
+  UmamiStatus umami_supported_inputs( bool* supported )
+  {
+    for( int i = 0; i < UMAMI_INPUT_KEY_COUNT; ++i ) supported[i] = false;
+    supported[UMAMI_IN_MOMENTA] = true;
+    supported[UMAMI_IN_ALPHA_S] = true;
+    supported[UMAMI_IN_FLAVOR_INDEX] = true;
+    supported[UMAMI_IN_RANDOM_COLOR] = true;
+    supported[UMAMI_IN_RANDOM_HELICITY] = true;
+    supported[UMAMI_IN_RANDOM_DIAGRAM] = true;
+    supported[UMAMI_IN_DIAGRAM_INDEX] = true;
+    return UMAMI_SUCCESS;
+  }
+
+  UmamiStatus umami_required_inputs( bool* required )
+  {
+    for( int i = 0; i < UMAMI_INPUT_KEY_COUNT; ++i ) required[i] = false;
+    required[UMAMI_IN_MOMENTA] = true;
+    return UMAMI_SUCCESS;
+  }
+
+  UmamiStatus umami_supported_outputs( bool* supported )
+  {
+    for( int i = 0; i < UMAMI_OUTPUT_KEY_COUNT; ++i ) supported[i] = false;
+    supported[UMAMI_OUT_MATRIX_ELEMENT] = true;
+    supported[UMAMI_OUT_DIAGRAM_AMP2] = true;
+    supported[UMAMI_OUT_COLOR_INDEX] = true;
+    supported[UMAMI_OUT_HELICITY_INDEX] = true;
+    supported[UMAMI_OUT_DIAGRAM_INDEX] = true;
+#ifdef MGONGPUCPP_GPUIMPL
+    supported[UMAMI_OUT_GPU_STREAM] = true;
+#endif
+    return UMAMI_SUCCESS;
+  }
+
   UmamiStatus umami_initialize( UmamiHandle* handle, char const* param_card_path )
   {
     CPPProcess process;

--- a/madgraph/iolibs/template_files/madmatrix/umami.cc
+++ b/madgraph/iolibs/template_files/madmatrix/umami.cc
@@ -210,37 +210,34 @@ extern "C"
     return UMAMI_SUCCESS;
   }
 
-  UmamiStatus umami_supported_inputs( bool* supported )
+  UmamiStatus umami_supported_inputs( bool const** supported, int* count )
   {
-    for( int i = 0; i < UMAMI_INPUT_KEY_COUNT; ++i ) supported[i] = false;
-    supported[UMAMI_IN_MOMENTA] = true;
-    supported[UMAMI_IN_ALPHA_S] = true;
-    supported[UMAMI_IN_FLAVOR_INDEX] = true;
-    supported[UMAMI_IN_RANDOM_COLOR] = true;
-    supported[UMAMI_IN_RANDOM_HELICITY] = true;
-    supported[UMAMI_IN_RANDOM_DIAGRAM] = true;
-    supported[UMAMI_IN_DIAGRAM_INDEX] = true;
+    // MOMENTA, ALPHA_S, FLAVOR_INDEX, RANDOM_COLOR, RANDOM_HELICITY, RANDOM_DIAGRAM,
+    // HELICITY_INDEX=false, DIAGRAM_INDEX=true, CHANNEL_INDEX=false
+    static const bool data[UMAMI_INPUT_KEY_COUNT] = { true, true, true, true, true, true, false, true };
+    *supported = data;
+    *count = UMAMI_INPUT_KEY_COUNT;
     return UMAMI_SUCCESS;
   }
 
-  UmamiStatus umami_required_inputs( bool* required )
+  UmamiStatus umami_required_inputs( bool const** required, int* count )
   {
-    for( int i = 0; i < UMAMI_INPUT_KEY_COUNT; ++i ) required[i] = false;
-    required[UMAMI_IN_MOMENTA] = true;
+    static const bool data[UMAMI_INPUT_KEY_COUNT] = { true }; // MOMENTA only
+    *required = data;
+    *count = UMAMI_INPUT_KEY_COUNT;
     return UMAMI_SUCCESS;
   }
 
-  UmamiStatus umami_supported_outputs( bool* supported )
+  UmamiStatus umami_supported_outputs( bool const** supported, int* count )
   {
-    for( int i = 0; i < UMAMI_OUTPUT_KEY_COUNT; ++i ) supported[i] = false;
-    supported[UMAMI_OUT_MATRIX_ELEMENT] = true;
-    supported[UMAMI_OUT_DIAGRAM_AMP2] = true;
-    supported[UMAMI_OUT_COLOR_INDEX] = true;
-    supported[UMAMI_OUT_HELICITY_INDEX] = true;
-    supported[UMAMI_OUT_DIAGRAM_INDEX] = true;
+    // MATRIX_ELEMENT, DIAGRAM_AMP2, COLOR_INDEX, HELICITY_INDEX, DIAGRAM_INDEX, GPU_STREAM
 #ifdef MGONGPUCPP_GPUIMPL
-    supported[UMAMI_OUT_GPU_STREAM] = true;
+    static const bool data[UMAMI_OUTPUT_KEY_COUNT] = { true, true, true, true, true, true };
+#else
+    static const bool data[UMAMI_OUTPUT_KEY_COUNT] = { true, true, true, true, true };
 #endif
+    *supported = data;
+    *count = UMAMI_OUTPUT_KEY_COUNT;
     return UMAMI_SUCCESS;
   }
 

--- a/madgraph/iolibs/template_files/mg7/api.cpp
+++ b/madgraph/iolibs/template_files/mg7/api.cpp
@@ -26,31 +26,27 @@ UmamiStatus umami_get_meta(UmamiMetaKey meta_key, void* result) {
     return UMAMI_SUCCESS;
 }
 
-UmamiStatus umami_supported_inputs(bool* supported) {
-    for (int i = 0; i < UMAMI_INPUT_KEY_COUNT; ++i) supported[i] = false;
-    supported[UMAMI_IN_MOMENTA] = true;
-    supported[UMAMI_IN_ALPHA_S] = true;
-    supported[UMAMI_IN_FLAVOR_INDEX] = true;
-    supported[UMAMI_IN_RANDOM_COLOR] = true;
-    supported[UMAMI_IN_RANDOM_HELICITY] = true;
-    supported[UMAMI_IN_RANDOM_DIAGRAM] = true;
+UmamiStatus umami_supported_inputs(bool const** supported, int* count) {
+    // MOMENTA, ALPHA_S, FLAVOR_INDEX, RANDOM_COLOR, RANDOM_HELICITY, RANDOM_DIAGRAM
+    static const bool data[UMAMI_INPUT_KEY_COUNT] = { true, true, true, true, true, true };
+    *supported = data;
+    *count = UMAMI_INPUT_KEY_COUNT;
     return UMAMI_SUCCESS;
 }
 
-UmamiStatus umami_required_inputs(bool* required) {
-    for (int i = 0; i < UMAMI_INPUT_KEY_COUNT; ++i) required[i] = false;
-    required[UMAMI_IN_MOMENTA] = true;
-    required[UMAMI_IN_FLAVOR_INDEX] = true;
+UmamiStatus umami_required_inputs(bool const** required, int* count) {
+    // MOMENTA and FLAVOR_INDEX (both dereferenced unconditionally in umami_matrix_element)
+    static const bool data[UMAMI_INPUT_KEY_COUNT] = { true, false, true };
+    *required = data;
+    *count = UMAMI_INPUT_KEY_COUNT;
     return UMAMI_SUCCESS;
 }
 
-UmamiStatus umami_supported_outputs(bool* supported) {
-    for (int i = 0; i < UMAMI_OUTPUT_KEY_COUNT; ++i) supported[i] = false;
-    supported[UMAMI_OUT_MATRIX_ELEMENT] = true;
-    supported[UMAMI_OUT_DIAGRAM_AMP2] = true;
-    supported[UMAMI_OUT_COLOR_INDEX] = true;
-    supported[UMAMI_OUT_HELICITY_INDEX] = true;
-    supported[UMAMI_OUT_DIAGRAM_INDEX] = true;
+UmamiStatus umami_supported_outputs(bool const** supported, int* count) {
+    // MATRIX_ELEMENT, DIAGRAM_AMP2, COLOR_INDEX, HELICITY_INDEX, DIAGRAM_INDEX
+    static const bool data[UMAMI_OUTPUT_KEY_COUNT] = { true, true, true, true, true };
+    *supported = data;
+    *count = UMAMI_OUTPUT_KEY_COUNT;
     return UMAMI_SUCCESS;
 }
 

--- a/madgraph/iolibs/template_files/mg7/api.cpp
+++ b/madgraph/iolibs/template_files/mg7/api.cpp
@@ -26,6 +26,34 @@ UmamiStatus umami_get_meta(UmamiMetaKey meta_key, void* result) {
     return UMAMI_SUCCESS;
 }
 
+UmamiStatus umami_supported_inputs(bool* supported) {
+    for (int i = 0; i < UMAMI_INPUT_KEY_COUNT; ++i) supported[i] = false;
+    supported[UMAMI_IN_MOMENTA] = true;
+    supported[UMAMI_IN_ALPHA_S] = true;
+    supported[UMAMI_IN_FLAVOR_INDEX] = true;
+    supported[UMAMI_IN_RANDOM_COLOR] = true;
+    supported[UMAMI_IN_RANDOM_HELICITY] = true;
+    supported[UMAMI_IN_RANDOM_DIAGRAM] = true;
+    return UMAMI_SUCCESS;
+}
+
+UmamiStatus umami_required_inputs(bool* required) {
+    for (int i = 0; i < UMAMI_INPUT_KEY_COUNT; ++i) required[i] = false;
+    required[UMAMI_IN_MOMENTA] = true;
+    required[UMAMI_IN_FLAVOR_INDEX] = true;
+    return UMAMI_SUCCESS;
+}
+
+UmamiStatus umami_supported_outputs(bool* supported) {
+    for (int i = 0; i < UMAMI_OUTPUT_KEY_COUNT; ++i) supported[i] = false;
+    supported[UMAMI_OUT_MATRIX_ELEMENT] = true;
+    supported[UMAMI_OUT_DIAGRAM_AMP2] = true;
+    supported[UMAMI_OUT_COLOR_INDEX] = true;
+    supported[UMAMI_OUT_HELICITY_INDEX] = true;
+    supported[UMAMI_OUT_DIAGRAM_INDEX] = true;
+    return UMAMI_SUCCESS;
+}
+
 UmamiStatus umami_initialize(UmamiHandle* handle, char const* param_card_path) {
     CPPProcess* process = new CPPProcess(param_card_path);
     std::vector<double*>& momenta = process->getMomenta();

--- a/madgraph/iolibs/template_files/mg7/api.h
+++ b/madgraph/iolibs/template_files/mg7/api.h
@@ -102,49 +102,31 @@ typedef void* UmamiHandle;
 UmamiStatus umami_get_meta(UmamiMetaKey meta_key, void* result);
 
 /**
- * Reports which input keys can be passed to this matrix element implementation, to
- * be written by whoever implements the UMAMI interface. Implementing this function
- * is optional; a caller that fails to resolve it should treat it as unavailable.
+ * Reports which input keys can be passed to this matrix element implementation.
+ * Optional — callers that fail to resolve this symbol should treat it as unavailable.
  *
- * @param supported
- *     pointer to a caller-allocated array of `UMAMI_INPUT_KEY_COUNT` booleans.
- *     On return, element `i` is set to whether the input key with numeric value
- *     `i` (see `UmamiInputKey`) is accepted by this implementation.
- * @return
- *     UMAMI_SUCCESS on success, error code otherwise
+ * @param supported pointer set to an implementation-owned boolean array
+ * @param count pointer set to the length of `*supported`
  */
-UmamiStatus umami_supported_inputs(bool* supported);
+UmamiStatus umami_supported_inputs(bool const** supported, int* count);
 
 /**
- * Reports which input keys must be passed to this matrix element implementation for
- * `umami_matrix_element` to succeed, to be written by whoever implements the UMAMI
- * interface. This is a subset of the keys reported by `umami_supported_inputs`.
- * Implementing this function is optional; a caller that fails to resolve it should
- * treat it as unavailable.
+ * Reports which input keys are mandatory. Subset of `umami_supported_inputs`.
+ * Optional — callers that fail to resolve this symbol should treat it as unavailable.
  *
- * @param required
- *     pointer to a caller-allocated array of `UMAMI_INPUT_KEY_COUNT` booleans.
- *     On return, element `i` is set to whether the input key with numeric value
- *     `i` (see `UmamiInputKey`) is mandatory for this implementation.
- * @return
- *     UMAMI_SUCCESS on success, error code otherwise
+ * @param required pointer set to an implementation-owned boolean array
+ * @param count pointer set to the length of `*required`
  */
-UmamiStatus umami_required_inputs(bool* required);
+UmamiStatus umami_required_inputs(bool const** required, int* count);
 
 /**
- * Reports which output keys can be requested from this matrix element
- * implementation, to be written by whoever implements the UMAMI interface.
- * Implementing this function is optional; a caller that fails to resolve it should
- * treat it as unavailable.
+ * Reports which output keys can be requested from this matrix element implementation.
+ * Optional — callers that fail to resolve this symbol should treat it as unavailable.
  *
- * @param supported
- *     pointer to a caller-allocated array of `UMAMI_OUTPUT_KEY_COUNT` booleans.
- *     On return, element `i` is set to whether the output key with numeric value
- *     `i` (see `UmamiOutputKey`) can be produced by this implementation.
- * @return
- *     UMAMI_SUCCESS on success, error code otherwise
+ * @param supported pointer set to an implementation-owned boolean array
+ * @param count pointer set to the length of `*supported`
  */
-UmamiStatus umami_supported_outputs(bool* supported);
+UmamiStatus umami_supported_outputs(bool const** supported, int* count);
 
 /**
  * Creates an instance of the matrix element. Each instance is independent, so thread

--- a/madgraph/iolibs/template_files/mg7/api.h
+++ b/madgraph/iolibs/template_files/mg7/api.h
@@ -14,6 +14,7 @@
 #ifndef UMAMI_HEADER
 #define UMAMI_HEADER 1
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -66,6 +67,9 @@ typedef enum {
     UMAMI_IN_DIAGRAM_INDEX,
 } UmamiInputKey;
 
+/** Number of values in `UmamiInputKey` */
+#define UMAMI_INPUT_KEY_COUNT (UMAMI_IN_DIAGRAM_INDEX + 1)
+
 typedef enum {
     UMAMI_OUT_MATRIX_ELEMENT,
     UMAMI_OUT_DIAGRAM_AMP2,
@@ -76,6 +80,9 @@ typedef enum {
     // NLO: born, virtual, poles, counterterms
     // color: LC-ME, FC-ME
 } UmamiOutputKey;
+
+/** Number of values in `UmamiOutputKey` */
+#define UMAMI_OUTPUT_KEY_COUNT (UMAMI_OUT_GPU_STREAM + 1)
 
 typedef void* UmamiHandle;
 
@@ -93,6 +100,51 @@ typedef void* UmamiHandle;
  *     UMAMI_SUCCESS on success, error code otherwise
  */
 UmamiStatus umami_get_meta(UmamiMetaKey meta_key, void* result);
+
+/**
+ * Reports which input keys can be passed to this matrix element implementation, to
+ * be written by whoever implements the UMAMI interface. Implementing this function
+ * is optional; a caller that fails to resolve it should treat it as unavailable.
+ *
+ * @param supported
+ *     pointer to a caller-allocated array of `UMAMI_INPUT_KEY_COUNT` booleans.
+ *     On return, element `i` is set to whether the input key with numeric value
+ *     `i` (see `UmamiInputKey`) is accepted by this implementation.
+ * @return
+ *     UMAMI_SUCCESS on success, error code otherwise
+ */
+UmamiStatus umami_supported_inputs(bool* supported);
+
+/**
+ * Reports which input keys must be passed to this matrix element implementation for
+ * `umami_matrix_element` to succeed, to be written by whoever implements the UMAMI
+ * interface. This is a subset of the keys reported by `umami_supported_inputs`.
+ * Implementing this function is optional; a caller that fails to resolve it should
+ * treat it as unavailable.
+ *
+ * @param required
+ *     pointer to a caller-allocated array of `UMAMI_INPUT_KEY_COUNT` booleans.
+ *     On return, element `i` is set to whether the input key with numeric value
+ *     `i` (see `UmamiInputKey`) is mandatory for this implementation.
+ * @return
+ *     UMAMI_SUCCESS on success, error code otherwise
+ */
+UmamiStatus umami_required_inputs(bool* required);
+
+/**
+ * Reports which output keys can be requested from this matrix element
+ * implementation, to be written by whoever implements the UMAMI interface.
+ * Implementing this function is optional; a caller that fails to resolve it should
+ * treat it as unavailable.
+ *
+ * @param supported
+ *     pointer to a caller-allocated array of `UMAMI_OUTPUT_KEY_COUNT` booleans.
+ *     On return, element `i` is set to whether the output key with numeric value
+ *     `i` (see `UmamiOutputKey`) can be produced by this implementation.
+ * @return
+ *     UMAMI_SUCCESS on success, error code otherwise
+ */
+UmamiStatus umami_supported_outputs(bool* supported);
 
 /**
  * Creates an instance of the matrix element. Each instance is independent, so thread

--- a/madspace/include/madspace/driver/context.hpp
+++ b/madspace/include/madspace/driver/context.hpp
@@ -48,27 +48,36 @@ public:
     std::size_t index() const { return _index; }
     const std::string& file_name() const { return _file_name; }
     std::vector<bool> supported_inputs() const {
-        bool supported[UMAMI_INPUT_KEY_COUNT];
-        check_umami_status(_supported_inputs(supported));
-        return std::vector<bool>(supported, supported + UMAMI_INPUT_KEY_COUNT);
+        bool const* data; int count;
+        check_umami_status(_supported_inputs(&data, &count));
+        std::vector<bool> result(UMAMI_INPUT_KEY_COUNT, false);
+        for (int i = 0; i < count && i < UMAMI_INPUT_KEY_COUNT; ++i)
+            result[i] = data[i];
+        return result;
     }
     std::vector<bool> required_inputs() const {
-        bool required[UMAMI_INPUT_KEY_COUNT];
-        check_umami_status(_required_inputs(required));
+        bool const* data; int count;
+        check_umami_status(_required_inputs(&data, &count));
         std::vector<bool> supported = supported_inputs();
-        for (std::size_t i = 0; i < UMAMI_INPUT_KEY_COUNT; ++i) {
-            if (required[i] && !supported[i]) {
+        for (int i = 0; i < count && i < UMAMI_INPUT_KEY_COUNT; ++i) {
+            if (data[i] && !supported[i]) {
                 throw_error(std::format(
                     "input key {} is reported as required but not as supported", i
                 ));
             }
         }
-        return std::vector<bool>(required, required + UMAMI_INPUT_KEY_COUNT);
+        std::vector<bool> result(UMAMI_INPUT_KEY_COUNT, false);
+        for (int i = 0; i < count && i < UMAMI_INPUT_KEY_COUNT; ++i)
+            result[i] = data[i];
+        return result;
     }
     std::vector<bool> supported_outputs() const {
-        bool supported[UMAMI_OUTPUT_KEY_COUNT];
-        check_umami_status(_supported_outputs(supported));
-        return std::vector<bool>(supported, supported + UMAMI_OUTPUT_KEY_COUNT);
+        bool const* data; int count;
+        check_umami_status(_supported_outputs(&data, &count));
+        std::vector<bool> result(UMAMI_OUTPUT_KEY_COUNT, false);
+        for (int i = 0; i < count && i < UMAMI_OUTPUT_KEY_COUNT; ++i)
+            result[i] = data[i];
+        return result;
     }
 
     void call(

--- a/madspace/include/madspace/driver/context.hpp
+++ b/madspace/include/madspace/driver/context.hpp
@@ -47,6 +47,29 @@ public:
     }
     std::size_t index() const { return _index; }
     const std::string& file_name() const { return _file_name; }
+    std::vector<bool> supported_inputs() const {
+        bool supported[UMAMI_INPUT_KEY_COUNT];
+        check_umami_status(_supported_inputs(supported));
+        return std::vector<bool>(supported, supported + UMAMI_INPUT_KEY_COUNT);
+    }
+    std::vector<bool> required_inputs() const {
+        bool required[UMAMI_INPUT_KEY_COUNT];
+        check_umami_status(_required_inputs(required));
+        std::vector<bool> supported = supported_inputs();
+        for (std::size_t i = 0; i < UMAMI_INPUT_KEY_COUNT; ++i) {
+            if (required[i] && !supported[i]) {
+                throw_error(std::format(
+                    "input key {} is reported as required but not as supported", i
+                ));
+            }
+        }
+        return std::vector<bool>(required, required + UMAMI_INPUT_KEY_COUNT);
+    }
+    std::vector<bool> supported_outputs() const {
+        bool supported[UMAMI_OUTPUT_KEY_COUNT];
+        check_umami_status(_supported_outputs(supported));
+        return std::vector<bool>(supported, supported + UMAMI_OUTPUT_KEY_COUNT);
+    }
 
     void call(
         UmamiHandle handle,
@@ -89,6 +112,9 @@ private:
     [[noreturn]] void throw_error(const std::string& message) const;
     std::unique_ptr<void, std::function<void(void*)>> _shared_lib;
     decltype(&umami_get_meta) _get_meta;
+    decltype(&umami_supported_inputs) _supported_inputs;
+    decltype(&umami_required_inputs) _required_inputs;
+    decltype(&umami_supported_outputs) _supported_outputs;
     decltype(&umami_initialize) _initialize;
     decltype(&umami_matrix_element) _matrix_element;
     decltype(&umami_free) _free;

--- a/madspace/include/madspace/umami.h
+++ b/madspace/include/madspace/umami.h
@@ -14,6 +14,7 @@
 #ifndef UMAMI_HEADER
 #define UMAMI_HEADER 1
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -94,6 +95,9 @@ typedef enum {
     UMAMI_IN_CHANNEL_INDEX,
 } UmamiInputKey;
 
+/** Number of values in `UmamiInputKey` */
+#define UMAMI_INPUT_KEY_COUNT (UMAMI_IN_CHANNEL_INDEX + 1)
+
 typedef enum {
     /** value of the matrix element, type: `double`, shape: `()` */
     UMAMI_OUT_MATRIX_ELEMENT,
@@ -110,6 +114,9 @@ typedef enum {
     UMAMI_OUT_GPU_STREAM,
 } UmamiOutputKey;
 
+/** Number of values in `UmamiOutputKey` */
+#define UMAMI_OUTPUT_KEY_COUNT (UMAMI_OUT_GPU_STREAM + 1)
+
 /** Implementation-defined pointer to a matrix element instance */
 typedef void* UmamiHandle;
 
@@ -124,6 +131,51 @@ typedef void* UmamiHandle;
  *     UMAMI_SUCCESS on success, error code otherwise
  */
 UmamiStatus umami_get_meta(UmamiMetaKey meta_key, void* result);
+
+/**
+ * Reports which input keys can be passed to this matrix element implementation, to
+ * be written by whoever implements the UMAMI interface. Implementing this function
+ * is optional; a caller that fails to resolve it should treat it as unavailable.
+ *
+ * @param supported
+ *     pointer to a caller-allocated array of `UMAMI_INPUT_KEY_COUNT` booleans.
+ *     On return, element `i` is set to whether the input key with numeric value
+ *     `i` (see `UmamiInputKey`) is accepted by this implementation.
+ * @return
+ *     UMAMI_SUCCESS on success, error code otherwise
+ */
+UmamiStatus umami_supported_inputs(bool* supported);
+
+/**
+ * Reports which input keys must be passed to this matrix element implementation for
+ * `umami_matrix_element` to succeed, to be written by whoever implements the UMAMI
+ * interface. This is a subset of the keys reported by `umami_supported_inputs`.
+ * Implementing this function is optional; a caller that fails to resolve it should
+ * treat it as unavailable.
+ *
+ * @param required
+ *     pointer to a caller-allocated array of `UMAMI_INPUT_KEY_COUNT` booleans.
+ *     On return, element `i` is set to whether the input key with numeric value
+ *     `i` (see `UmamiInputKey`) is mandatory for this implementation.
+ * @return
+ *     UMAMI_SUCCESS on success, error code otherwise
+ */
+UmamiStatus umami_required_inputs(bool* required);
+
+/**
+ * Reports which output keys can be requested from this matrix element
+ * implementation, to be written by whoever implements the UMAMI interface.
+ * Implementing this function is optional; a caller that fails to resolve it should
+ * treat it as unavailable.
+ *
+ * @param supported
+ *     pointer to a caller-allocated array of `UMAMI_OUTPUT_KEY_COUNT` booleans.
+ *     On return, element `i` is set to whether the output key with numeric value
+ *     `i` (see `UmamiOutputKey`) can be produced by this implementation.
+ * @return
+ *     UMAMI_SUCCESS on success, error code otherwise
+ */
+UmamiStatus umami_supported_outputs(bool* supported);
 
 /**
  * Creates an instance of the matrix element. Each instance is independent, so thread

--- a/madspace/include/madspace/umami.h
+++ b/madspace/include/madspace/umami.h
@@ -138,13 +138,18 @@ UmamiStatus umami_get_meta(UmamiMetaKey meta_key, void* result);
  * is optional; a caller that fails to resolve it should treat it as unavailable.
  *
  * @param supported
- *     pointer to a caller-allocated array of `UMAMI_INPUT_KEY_COUNT` booleans.
- *     On return, element `i` is set to whether the input key with numeric value
- *     `i` (see `UmamiInputKey`) is accepted by this implementation.
+ *     pointer set on return to an implementation-owned array of booleans, where
+ *     element `i` indicates whether the input key with numeric value `i`
+ *     (see `UmamiInputKey`) is accepted by this implementation.
+ * @param count
+ *     pointer set on return to the number of elements in `*supported`, reflecting
+ *     the number of `UmamiInputKey` values known to this implementation. A caller
+ *     built against a newer header should treat any key index beyond `*count` as
+ *     not supported.
  * @return
  *     UMAMI_SUCCESS on success, error code otherwise
  */
-UmamiStatus umami_supported_inputs(bool* supported);
+UmamiStatus umami_supported_inputs(bool const** supported, int* count);
 
 /**
  * Reports which input keys must be passed to this matrix element implementation for
@@ -154,13 +159,17 @@ UmamiStatus umami_supported_inputs(bool* supported);
  * treat it as unavailable.
  *
  * @param required
- *     pointer to a caller-allocated array of `UMAMI_INPUT_KEY_COUNT` booleans.
- *     On return, element `i` is set to whether the input key with numeric value
- *     `i` (see `UmamiInputKey`) is mandatory for this implementation.
+ *     pointer set on return to an implementation-owned array of booleans, where
+ *     element `i` indicates whether the input key with numeric value `i`
+ *     (see `UmamiInputKey`) is mandatory for this implementation.
+ * @param count
+ *     pointer set on return to the number of elements in `*required`. A caller
+ *     built against a newer header should treat any key index beyond `*count` as
+ *     not required.
  * @return
  *     UMAMI_SUCCESS on success, error code otherwise
  */
-UmamiStatus umami_required_inputs(bool* required);
+UmamiStatus umami_required_inputs(bool const** required, int* count);
 
 /**
  * Reports which output keys can be requested from this matrix element
@@ -169,13 +178,17 @@ UmamiStatus umami_required_inputs(bool* required);
  * treat it as unavailable.
  *
  * @param supported
- *     pointer to a caller-allocated array of `UMAMI_OUTPUT_KEY_COUNT` booleans.
- *     On return, element `i` is set to whether the output key with numeric value
- *     `i` (see `UmamiOutputKey`) can be produced by this implementation.
+ *     pointer set on return to an implementation-owned array of booleans, where
+ *     element `i` indicates whether the output key with numeric value `i`
+ *     (see `UmamiOutputKey`) can be produced by this implementation.
+ * @param count
+ *     pointer set on return to the number of elements in `*supported`. A caller
+ *     built against a newer header should treat any key index beyond `*count` as
+ *     not supported.
  * @return
  *     UMAMI_SUCCESS on success, error code otherwise
  */
-UmamiStatus umami_supported_outputs(bool* supported);
+UmamiStatus umami_supported_outputs(bool const** supported, int* count);
 
 /**
  * Creates an instance of the matrix element. Each instance is independent, so thread

--- a/madspace/madspace/_madspace_py.pyi
+++ b/madspace/madspace/_madspace_py.pyi
@@ -1985,10 +1985,185 @@ class MatrixElement(FunctionGenerator):
     def particle_count(self) -> int: ...
 
 class MatrixElementApi:
+    class UmamiInputKey:
+        """
+        Members:
+
+          momenta_in
+
+          alpha_s_in
+
+          flavor_index_in
+
+          random_color_in
+
+          random_helicity_in
+
+          random_diagram_in
+
+          helicity_index_in
+
+          diagram_index_in
+
+          channel_index_in
+        """
+
+        __members__: typing.ClassVar[
+            dict[str, MatrixElementApi.UmamiInputKey]
+        ]  # value = {'momenta_in': <UmamiInputKey.momenta_in: 0>, 'alpha_s_in': <UmamiInputKey.alpha_s_in: 1>, 'flavor_index_in': <UmamiInputKey.flavor_index_in: 2>, 'random_color_in': <UmamiInputKey.random_color_in: 3>, 'random_helicity_in': <UmamiInputKey.random_helicity_in: 4>, 'random_diagram_in': <UmamiInputKey.random_diagram_in: 5>, 'helicity_index_in': <UmamiInputKey.helicity_index_in: 6>, 'diagram_index_in': <UmamiInputKey.diagram_index_in: 7>, 'channel_index_in': <UmamiInputKey.channel_index_in: 8>}
+        alpha_s_in: typing.ClassVar[
+            MatrixElementApi.UmamiInputKey
+        ]  # value = <UmamiInputKey.alpha_s_in: 1>
+        channel_index_in: typing.ClassVar[
+            MatrixElementApi.UmamiInputKey
+        ]  # value = <UmamiInputKey.channel_index_in: 8>
+        diagram_index_in: typing.ClassVar[
+            MatrixElementApi.UmamiInputKey
+        ]  # value = <UmamiInputKey.diagram_index_in: 7>
+        flavor_index_in: typing.ClassVar[
+            MatrixElementApi.UmamiInputKey
+        ]  # value = <UmamiInputKey.flavor_index_in: 2>
+        helicity_index_in: typing.ClassVar[
+            MatrixElementApi.UmamiInputKey
+        ]  # value = <UmamiInputKey.helicity_index_in: 6>
+        momenta_in: typing.ClassVar[
+            MatrixElementApi.UmamiInputKey
+        ]  # value = <UmamiInputKey.momenta_in: 0>
+        random_color_in: typing.ClassVar[
+            MatrixElementApi.UmamiInputKey
+        ]  # value = <UmamiInputKey.random_color_in: 3>
+        random_diagram_in: typing.ClassVar[
+            MatrixElementApi.UmamiInputKey
+        ]  # value = <UmamiInputKey.random_diagram_in: 5>
+        random_helicity_in: typing.ClassVar[
+            MatrixElementApi.UmamiInputKey
+        ]  # value = <UmamiInputKey.random_helicity_in: 4>
+        def __eq__(self, other: typing.Any) -> bool: ...
+        def __getstate__(self) -> int: ...
+        def __hash__(self) -> int: ...
+        def __index__(self) -> int: ...
+        @typing.overload
+        def __init__(self, value: typing.SupportsInt) -> None: ...
+        @typing.overload
+        def __init__(self, name: str) -> None: ...
+        def __int__(self) -> int: ...
+        def __ne__(self, other: typing.Any) -> bool: ...
+        def __repr__(self) -> str: ...
+        def __setstate__(self, state: typing.SupportsInt) -> None: ...
+        def __str__(self) -> str: ...
+        @property
+        def name(self) -> str: ...
+        @property
+        def value(self) -> int: ...
+
+    class UmamiOutputKey:
+        """
+        Members:
+
+          matrix_element_out
+
+          diagram_amp2_out
+
+          color_index_out
+
+          helicity_index_out
+
+          diagram_index_out
+
+          gpu_stream_out
+        """
+
+        __members__: typing.ClassVar[
+            dict[str, MatrixElementApi.UmamiOutputKey]
+        ]  # value = {'matrix_element_out': <UmamiOutputKey.matrix_element_out: 0>, 'diagram_amp2_out': <UmamiOutputKey.diagram_amp2_out: 1>, 'color_index_out': <UmamiOutputKey.color_index_out: 2>, 'helicity_index_out': <UmamiOutputKey.helicity_index_out: 3>, 'diagram_index_out': <UmamiOutputKey.diagram_index_out: 4>, 'gpu_stream_out': <UmamiOutputKey.gpu_stream_out: 5>}
+        color_index_out: typing.ClassVar[
+            MatrixElementApi.UmamiOutputKey
+        ]  # value = <UmamiOutputKey.color_index_out: 2>
+        diagram_amp2_out: typing.ClassVar[
+            MatrixElementApi.UmamiOutputKey
+        ]  # value = <UmamiOutputKey.diagram_amp2_out: 1>
+        diagram_index_out: typing.ClassVar[
+            MatrixElementApi.UmamiOutputKey
+        ]  # value = <UmamiOutputKey.diagram_index_out: 4>
+        gpu_stream_out: typing.ClassVar[
+            MatrixElementApi.UmamiOutputKey
+        ]  # value = <UmamiOutputKey.gpu_stream_out: 5>
+        helicity_index_out: typing.ClassVar[
+            MatrixElementApi.UmamiOutputKey
+        ]  # value = <UmamiOutputKey.helicity_index_out: 3>
+        matrix_element_out: typing.ClassVar[
+            MatrixElementApi.UmamiOutputKey
+        ]  # value = <UmamiOutputKey.matrix_element_out: 0>
+        def __eq__(self, other: typing.Any) -> bool: ...
+        def __getstate__(self) -> int: ...
+        def __hash__(self) -> int: ...
+        def __index__(self) -> int: ...
+        @typing.overload
+        def __init__(self, value: typing.SupportsInt) -> None: ...
+        @typing.overload
+        def __init__(self, name: str) -> None: ...
+        def __int__(self) -> int: ...
+        def __ne__(self, other: typing.Any) -> bool: ...
+        def __repr__(self) -> str: ...
+        def __setstate__(self, state: typing.SupportsInt) -> None: ...
+        def __str__(self) -> str: ...
+        @property
+        def name(self) -> str: ...
+        @property
+        def value(self) -> int: ...
+
+    alpha_s_in: typing.ClassVar[
+        MatrixElementApi.UmamiInputKey
+    ]  # value = <UmamiInputKey.alpha_s_in: 1>
+    channel_index_in: typing.ClassVar[
+        MatrixElementApi.UmamiInputKey
+    ]  # value = <UmamiInputKey.channel_index_in: 8>
+    color_index_out: typing.ClassVar[
+        MatrixElementApi.UmamiOutputKey
+    ]  # value = <UmamiOutputKey.color_index_out: 2>
+    diagram_amp2_out: typing.ClassVar[
+        MatrixElementApi.UmamiOutputKey
+    ]  # value = <UmamiOutputKey.diagram_amp2_out: 1>
+    diagram_index_in: typing.ClassVar[
+        MatrixElementApi.UmamiInputKey
+    ]  # value = <UmamiInputKey.diagram_index_in: 7>
+    diagram_index_out: typing.ClassVar[
+        MatrixElementApi.UmamiOutputKey
+    ]  # value = <UmamiOutputKey.diagram_index_out: 4>
+    flavor_index_in: typing.ClassVar[
+        MatrixElementApi.UmamiInputKey
+    ]  # value = <UmamiInputKey.flavor_index_in: 2>
+    gpu_stream_out: typing.ClassVar[
+        MatrixElementApi.UmamiOutputKey
+    ]  # value = <UmamiOutputKey.gpu_stream_out: 5>
+    helicity_index_in: typing.ClassVar[
+        MatrixElementApi.UmamiInputKey
+    ]  # value = <UmamiInputKey.helicity_index_in: 6>
+    helicity_index_out: typing.ClassVar[
+        MatrixElementApi.UmamiOutputKey
+    ]  # value = <UmamiOutputKey.helicity_index_out: 3>
+    matrix_element_out: typing.ClassVar[
+        MatrixElementApi.UmamiOutputKey
+    ]  # value = <UmamiOutputKey.matrix_element_out: 0>
+    momenta_in: typing.ClassVar[
+        MatrixElementApi.UmamiInputKey
+    ]  # value = <UmamiInputKey.momenta_in: 0>
+    random_color_in: typing.ClassVar[
+        MatrixElementApi.UmamiInputKey
+    ]  # value = <UmamiInputKey.random_color_in: 3>
+    random_diagram_in: typing.ClassVar[
+        MatrixElementApi.UmamiInputKey
+    ]  # value = <UmamiInputKey.random_diagram_in: 5>
+    random_helicity_in: typing.ClassVar[
+        MatrixElementApi.UmamiInputKey
+    ]  # value = <UmamiInputKey.random_helicity_in: 4>
     def diagram_count(self) -> int: ...
     def helicity_count(self) -> int: ...
     def index(self) -> int: ...
     def particle_count(self) -> int: ...
+    def required_inputs(self) -> list[bool]: ...
+    def supported_inputs(self) -> list[bool]: ...
+    def supported_outputs(self) -> list[bool]: ...
 
 class MomentumPreprocessing(FunctionGenerator):
     def __init__(self, particle_count: typing.SupportsInt) -> None: ...

--- a/madspace/src/driver/context.cpp
+++ b/madspace/src/driver/context.cpp
@@ -10,6 +10,10 @@
 using namespace madspace;
 using json = nlohmann::json;
 
+namespace {
+UmamiStatus umami_key_query_not_implemented(bool*) { return UMAMI_ERROR_NOT_IMPLEMENTED; }
+} // namespace
+
 MatrixElementApi::MatrixElementApi(
     const std::string& file,
     const std::string& param_card,
@@ -34,6 +38,30 @@ MatrixElementApi::MatrixElementApi(
         throw std::runtime_error(
             std::format("Did not find symbol umami_get_meta in shared object {}", file)
         );
+    }
+
+    // These symbols are optional: implementations may not report which keys they
+    // support, in which case queries for that information fail with
+    // UMAMI_ERROR_NOT_IMPLEMENTED instead of the constructor throwing.
+    _supported_inputs = reinterpret_cast<decltype(&umami_supported_inputs)>(
+        dlsym(_shared_lib.get(), "umami_supported_inputs")
+    );
+    if (_supported_inputs == nullptr) {
+        _supported_inputs = umami_key_query_not_implemented;
+    }
+
+    _required_inputs = reinterpret_cast<decltype(&umami_required_inputs)>(
+        dlsym(_shared_lib.get(), "umami_required_inputs")
+    );
+    if (_required_inputs == nullptr) {
+        _required_inputs = umami_key_query_not_implemented;
+    }
+
+    _supported_outputs = reinterpret_cast<decltype(&umami_supported_outputs)>(
+        dlsym(_shared_lib.get(), "umami_supported_outputs")
+    );
+    if (_supported_outputs == nullptr) {
+        _supported_outputs = umami_key_query_not_implemented;
     }
 
     _initialize = reinterpret_cast<decltype(&umami_initialize)>(

--- a/madspace/src/driver/context.cpp
+++ b/madspace/src/driver/context.cpp
@@ -11,7 +11,7 @@ using namespace madspace;
 using json = nlohmann::json;
 
 namespace {
-UmamiStatus umami_key_query_not_implemented(bool*) { return UMAMI_ERROR_NOT_IMPLEMENTED; }
+UmamiStatus umami_key_query_not_implemented(bool const**, int*) { return UMAMI_ERROR_NOT_IMPLEMENTED; }
 } // namespace
 
 MatrixElementApi::MatrixElementApi(


### PR DESCRIPTION
Minor additions to UMAMI and MatrixElementApi to allow querying required/supported input arguments and expected output returns from a library. Current implementation is optional and only flags an error if called when unavailable (may want to make mandatory)