### PR TITLE
mg7 CI: add a reweighting acceptance test (mirrors test_mass_reweight…

### DIFF
--- a/.github/workflows/acceptancetest_mg7.yml
+++ b/.github/workflows/acceptancetest_mg7.yml
@@ -296,7 +296,7 @@ jobs:
   # mg7 post-processing chaining (command interface + new output).
   #
   # Each job below runs a full mg7 generation and then chains one post-processing
-  # tool (time-of-flight, Pythia8, Rivet, MadSpin) through the mg7 command
+  # tool (time-of-flight, Pythia8, Rivet, MadSpin, reweighting) through the mg7 command
   # interface (bin/generate_events -> the merged tool-selection question ->
   # run_selected_tools -> MG7RunCmd), giving at least one CI check that every
   # tool still works with the default output. The tools come from the combined
@@ -356,6 +356,25 @@ jobs:
             cd $GITHUB_WORKSPACE
             export PATH="$HOME/.cache/HEPtools/bin:$PATH"
             ./tests/test_manager.py test_rivet_from_file_mg7 -pA -t0 -l INFO
+
+  acceptancetest_mg7_reweight:
+    needs: build_madspace
+    # Matrix-element reweighting ships with MG5 (no external tool); it only needs
+    # the madspace + LHAPDF(NNPDF23) stack (and a Fortran compiler for the
+    # standalone reweighting matrix element, which the runner provides).
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout_mg5
+      - uses: ./.github/actions/install_madspace
+      - uses: ./.github/actions/restore-pip-cache
+      - uses: ./.github/actions/restore_heptools
+      - name: test one of the test test_mass_reweighting_mg7
+        run: |
+            cd $GITHUB_WORKSPACE
+            export PATH="$HOME/.cache/HEPtools/bin:$PATH"
+            ./tests/test_manager.py test_mass_reweighting_mg7 -pA -t0 -l INFO
 
   acceptancetest_mg7_madspin:
     needs: build_madspace

--- a/tests/acceptance_tests/test_cmd_madevent.py
+++ b/tests/acceptance_tests/test_cmd_madevent.py
@@ -2985,6 +2985,47 @@ set draw_rivet_plots True
         self.assertTrue(os.path.exists(pjoin(run, 'rivet_result.yoda')),
                         'mg7 Rivet run produced no yoda output in %s' % run)
 
+    def test_mass_reweighting_mg7(self):
+        """Matrix-element reweighting chained on the mg7 output through the
+        command interface (mirrors test_mass_reweighting): p p > t t~ is
+        generated with the mg7 output and reweighted to a heavier top by the
+        reused madevent reweight driver (reweight -from_cards).
+
+        The reweight module rebuilds the matrix element from the model/process
+        stored in the LHE banner, so this also covers the banner's proc_card."""
+        datadir = _mg7_datadir_or_skip(self)
+        # one reweight point: the same "heavier top" hypothesis as the madevent
+        # test. The default output mode adds the new weight to the events.
+        reweight_card = ("launch\n"
+                         "set mass mt 200\n")
+        run = _run_mg7_postproc(
+            self,
+            ['set automatic_html_opening False --no_save',
+             'import model sm',
+             'generate p p > t t~'],
+            pjoin(self.path, 'MG7_reweight'), datadir,
+            switch_lines=['reweight=ON'],
+            extra_cards=[(reweight_card, 'reweight_card.dat')],
+            events=100)
+
+        lhe_path = None
+        for name in ('unweighted_events.lhe.gz', 'unweighted_events.lhe',
+                     'events.lhe.gz', 'events.lhe'):
+            if os.path.exists(pjoin(run, name)):
+                lhe_path = pjoin(run, name)
+                break
+        self.assertTrue(lhe_path, 'no mg7 event file under %s' % run)
+
+        # every event must carry the extra reweighted weight
+        nb_event = 0
+        for evt in lhe_parser.EventFile(lhe_path):
+            rwgt = evt.parse_reweight()
+            self.assertIn('rwgt_1', rwgt,
+                          'mg7 reweight did not add the rwgt_1 weight to the events')
+            self.assertNotEqual(float(rwgt['rwgt_1']), 0.0)
+            nb_event += 1
+        self.assertGreater(nb_event, 0, 'no event found in %s' % lhe_path)
+
     def test_w_production_with_ms_decay_mg7(self):
         """MadSpin decay chained on the mg7 output through the command interface
         (mirrors test_w_production_with_ms_decay): p p > w+ z is generated with


### PR DESCRIPTION
…ing)

Drives matrix-element reweighting through the mg7 command interface: generate p p > t t~ with the mg7 output, select reweight=ON in the launch question and let run_selected_tools chain "reweight -from_cards" on the events, reweighting to a heavier top. Asserts every event carries the new rwgt_1 weight.

The reweight module rebuilds the matrix element from the model/process stored in the LHE banner, so this also exercises the banner proc_card.