### PR TITLE
Generate workflow summary report for MG7 cross-section checks

### DIFF
--- a/.github/scripts/build_xsec_summary.py
+++ b/.github/scripts/build_xsec_summary.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Build a GitHub Actions job summary for the systematic mg7 cross-section
+checks (.github/workflows/check_xsec_processes_mg7.yml).
+
+Reads the per-process JSON records written by
+tests/acceptance_tests/test_check_xsec_processes_mg7.py (one file per
+process, via $MG7_XSEC_RESULTS_DIR) plus the reference file that defines
+which processes should have been tested, and prints a markdown report:
+a table of every process (with pass/fail, cross-sections, deviation and
+pull), followed by the scraped error message for every process that did
+not succeed.
+
+Usage:
+    build_xsec_summary.py <reference.json> <results_dir> [--tolerance PCT] \
+        >> "$GITHUB_STEP_SUMMARY"
+"""
+import argparse
+import glob
+import json
+import math
+import os
+
+pjoin = os.path.join
+
+
+def fmt_value(x, sig=4):
+    if x is None:
+        return '—'
+    return '{:.{sig}g}'.format(x, sig=sig)
+
+
+def fmt_signed(x, decimals=2):
+    if x is None or math.isnan(x) or math.isinf(x):
+        return '—'
+    return '{:+.{d}f}'.format(x, d=decimals)
+
+
+def slug(section, id_):
+    return 'fail-%s-%s' % (section, id_)
+
+
+def load_results(results_dir):
+    """Return {(section, id): record} from every *.json under results_dir."""
+    results = {}
+    for path in sorted(glob.glob(pjoin(results_dir, '**', '*.json'), recursive=True)):
+        try:
+            with open(path) as f:
+                record = json.load(f)
+        except Exception:
+            continue
+        results[(record.get('section'), record.get('id'))] = record
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('reference', help='path to check_xsec_processes_reference.json')
+    parser.add_argument('results_dir', help='directory with the per-process result JSON files')
+    parser.add_argument('--tolerance', type=float, default=None,
+                         help='tolerance (fraction, e.g. 0.01) used for this run, for display only')
+    parser.add_argument('--events', default=None,
+                         help='events/process used for this run, for display only')
+    args = parser.parse_args()
+
+    with open(args.reference) as f:
+        ref = json.load(f)
+
+    results = load_results(args.results_dir)
+
+    rows = []
+    failures = []
+    n_pass = 0
+    n_fail = 0
+    for section, entries in ref['sections'].items():
+        for entry in entries:
+            key = (section, entry['id'])
+            record = results.get(key)
+            ref_cross = entry['cross']
+            ref_error = entry.get('error')
+
+            if record is None:
+                status = 'fail'
+                got = err = None
+                message = ('No result recorded for this process -- the job '
+                            'likely crashed or was cancelled before it '
+                            'completed. Check the workflow run log for '
+                            '`test_%s_%s_mg7`.' % (section, entry['id']))
+            else:
+                status = record.get('status', 'fail')
+                got = record.get('cross')
+                err = record.get('error')
+                message = record.get('message')
+
+            if status == 'pass':
+                n_pass += 1
+            else:
+                n_fail += 1
+
+            reldev_pct = None
+            pull = None
+            if got is not None and ref_cross:
+                reldev_pct = 100.0 * (got - ref_cross) / ref_cross
+            if got is not None and err is not None and ref_error is not None:
+                denom = math.sqrt(err ** 2 + ref_error ** 2)
+                if denom > 0:
+                    pull = (got - ref_cross) / denom
+
+            anchor = slug(section, entry['id'])
+            status_cell = '✅' if status == 'pass' else ('[❌](#%s)' % anchor)
+
+            rows.append({
+                'status_cell': status_cell,
+                'section': section,
+                'id': entry['id'],
+                'process': entry['process'],
+                'cross': fmt_value(got),
+                'error': fmt_value(err),
+                'ref_cross': fmt_value(ref_cross),
+                'ref_error': fmt_value(ref_error),
+                'reldev': fmt_signed(reldev_pct),
+                'pull': fmt_signed(pull),
+            })
+
+            if status != 'pass':
+                failures.append({
+                    'anchor': anchor,
+                    'section': section,
+                    'id': entry['id'],
+                    'process': entry['process'],
+                    'message': message or '(no error message captured)',
+                })
+
+    out = []
+    out.append('## Systematic cross-section checks (mg7)')
+    out.append('')
+    detail = []
+    if args.tolerance is not None:
+        detail.append('tolerance: %.2f%%' % (100 * args.tolerance))
+    if args.events is not None:
+        detail.append('events/process: %s' % args.events)
+    if detail:
+        out.append('_' + ' &middot; '.join(detail) + '_')
+        out.append('')
+    out.append('**%d/%d processes passed**' % (n_pass, n_pass + n_fail))
+    out.append('')
+    out.append('| | Section | Process | σ [pb] | ± σ | Ref σ [pb] | ± Ref | Δ [%] | Pull |')
+    out.append('|---|---|---|---|---|---|---|---|---|')
+    for r in rows:
+        out.append('| %s | %s | `%s`<br>%s | %s | %s | %s | %s | %s | %s |' % (
+            r['status_cell'], r['section'], r['id'], r['process'],
+            r['cross'], r['error'], r['ref_cross'], r['ref_error'],
+            r['reldev'], r['pull']))
+
+    if failures:
+        out.append('')
+        out.append('## Failure details')
+        for fr in failures:
+            out.append('')
+            out.append('### <a id="%s"></a>%s / `%s`' % (fr['anchor'], fr['section'], fr['id']))
+            out.append('')
+            out.append('`%s`' % fr['process'])
+            out.append('')
+            out.append('```')
+            out.append(fr['message'])
+            out.append('```')
+
+    print('\n'.join(out))
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/check_xsec_processes_mg7.yml
+++ b/.github/workflows/check_xsec_processes_mg7.yml
@@ -78,6 +78,41 @@ jobs:
       # Provides the NNPDF23 grid + LHAPDF_DATA_PATH the mg7 runtime needs.
       - uses: ./.github/actions/install_lhapdf_pdfset
       - name: run systematic cross-section test (${{ matrix.section }})
+        env:
+          MG7_XSEC_RESULTS_DIR: ${{ github.workspace }}/xsec_results/${{ matrix.section }}
         run: |
           cd $GITHUB_WORKSPACE
+          mkdir -p "$MG7_XSEC_RESULTS_DIR"
           ./tests/test_manager.py "test_${{ matrix.section }}_.*_mg7" -pA -t0 -l INFO
+
+      # Runs even if the test step above failed, so a crashed/timed-out
+      # section still contributes whatever per-process results it managed to
+      # record before dying.
+      - name: upload cross-section results (${{ matrix.section }})
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xsec-results-${{ matrix.section }}
+          path: xsec_results/${{ matrix.section }}/*.json
+          if-no-files-found: warn
+
+  xsec_summary:
+    needs: check_xsec_processes
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: download cross-section results
+        uses: actions/download-artifact@v5
+        with:
+          pattern: xsec-results-*
+          path: xsec_results
+          merge-multiple: true
+      - name: build job summary
+        run: |
+          python3 .github/scripts/build_xsec_summary.py \
+            tests/acceptance_tests/check_xsec_processes_reference.json \
+            xsec_results \
+            --tolerance "${{ inputs.tolerance || '0.01' }}" \
+            --events "${{ inputs.events || '100000' }}" \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/madgraph/iolibs/template_files/mg7/gridpack.py
+++ b/madgraph/iolibs/template_files/mg7/gridpack.py
@@ -31,6 +31,16 @@ import json
 import tomllib
 import argparse
 
+
+def resolve_verbosity(verbosity: str) -> str:
+    """Resolve the run_card "auto" verbosity to "pretty"/"log" depending on
+    whether stdout is attached to a terminal; other values pass through
+    unchanged."""
+    if verbosity == "auto":
+        return "pretty" if sys.stdout.isatty() else "log"
+    return verbosity
+
+
 def main() -> None:
     # load run card and metadata. Use the RunCardMG7 representation when the
     # madgraph package is importable; gridpacks are meant to be portable, so
@@ -70,7 +80,7 @@ def main() -> None:
         "--verbosity",
         type=str,
         default=run_args["verbosity"],
-        choices=["none", "pretty", "log"]
+        choices=["none", "pretty", "log", "auto"]
     )
     parser.add_argument(
         "--output_format",
@@ -133,7 +143,7 @@ def main() -> None:
     config.freeze_max_weight_after = args.freeze_max_weight_after
     config.cpu_batch_size = args.cpu_batch_size
     config.gpu_batch_size = args.gpu_batch_size
-    config.verbosity = args.verbosity
+    config.verbosity = resolve_verbosity(args.verbosity)
     config.combine_thread_count = run_args["combine_thread_pool_size"]
     config.cut_efficiency_threshold = gen_args["cut_efficiency_threshold"]
     config.max_cut_repetitions = gen_args["max_cut_repetitions"]

--- a/madgraph/iolibs/template_files/mg7/madevent.py
+++ b/madgraph/iolibs/template_files/mg7/madevent.py
@@ -97,6 +97,15 @@ def format_time(t: int, centi: bool = False):
         return f"{int(hours):02}:{int(minutes):02}:{seconds:02.0f}"
 
 
+def resolve_verbosity(verbosity: str) -> str:
+    """Resolve the run_card "auto" verbosity to "pretty"/"log" depending on
+    whether stdout is attached to a terminal; other values pass through
+    unchanged."""
+    if verbosity == "auto":
+        return "pretty" if sys.stdout.isatty() else "log"
+    return verbosity
+
+
 @dataclass
 class Channel:
     phasespace_mapping: ms.PhaseSpaceMapping
@@ -372,7 +381,7 @@ class MadgraphProcess:
         cfg.optimization_threshold = vegas_args["optimization_threshold"]
         cfg.cpu_batch_size = gen_args["cpu_batch_size"]
         cfg.gpu_batch_size = gen_args["gpu_batch_size"]
-        cfg.verbosity = run_args["verbosity"]
+        cfg.verbosity = resolve_verbosity(run_args["verbosity"])
         cfg.combine_thread_count = run_args["combine_thread_pool_size"]
         cfg.cut_efficiency_threshold = gen_args["cut_efficiency_threshold"]
         cfg.max_cut_repetitions = gen_args["max_cut_repetitions"]
@@ -492,7 +501,7 @@ class MadgraphProcess:
         run_args = self.run_card["run"]
 
         config = ms.MadnisConfig()
-        config.verbosity = run_args["verbosity"]
+        config.verbosity = resolve_verbosity(run_args["verbosity"])
         config.learning_rate = madnis_args["lr"]
         config.batches = madnis_args["train_batches"]
         config.log_interval = madnis_args["log_interval"]

--- a/madgraph/iolibs/template_files/mg7/run_card.toml
+++ b/madgraph/iolibs/template_files/mg7/run_card.toml
@@ -12,7 +12,7 @@ cpu_thread_pool_size = %(run.cpu_thread_pool_size)s
 gpu_thread_pool_size = %(run.gpu_thread_pool_size)s
 combine_thread_pool_size = %(run.combine_thread_pool_size)s
 output_format = %(run.output_format)s # options: compact_npy, lhe_npy, lhe
-verbosity = %(run.verbosity)s # options: silent, pretty, log
+verbosity = %(run.verbosity)s # options: silent, pretty, log, auto (pretty if attached to a terminal, log otherwise)
 dummy_matrix_element = %(run.dummy_matrix_element)s
 
 [gridpack]

--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -6446,8 +6446,8 @@ class RunCardMG7(RunCard):
         self.add_toml_param('run', 'combine_thread_pool_size', -1, gridpack=True)
         self.add_toml_param('run', 'output_format', "lhe", gridpack=True,
             allowed=['compact_npy', 'lhe_npy', 'lhe'])
-        self.add_toml_param('run', 'verbosity', "pretty", gridpack=True,
-            allowed=['silent', 'pretty', 'log'])
+        self.add_toml_param('run', 'verbosity', "auto", gridpack=True,
+            allowed=['silent', 'pretty', 'log', 'auto'])
         self.add_toml_param('run', 'dummy_matrix_element', False)
 
         # ---------------------------- [gridpack] ----------------------

--- a/tests/acceptance_tests/test_check_xsec_processes_mg7.py
+++ b/tests/acceptance_tests/test_check_xsec_processes_mg7.py
@@ -252,11 +252,14 @@ class CheckXsecProcessesMG7Test(unittest.TestCase):
         passed = reldiff <= _TOLERANCE
         message = None
         if not passed:
+            # A cross-section was successfully obtained here, just outside
+            # tolerance -- no need for the (noisy) log tail, the deviation
+            # itself is the useful diagnostic.
             message = (
                 '%s (%s): mg7 xsec %.6g +- %.3g pb differs from reference '
-                '%.6g pb by %.3f%% (> %.3f%% tolerance)\n\n%s'
+                '%.6g pb by %.3f%% (> %.3f%% tolerance)'
                 % (entry['id'], entry['process'], got, err, ref_x,
-                   100 * reldiff, 100 * _TOLERANCE, _tail(log)))
+                   100 * reldiff, 100 * _TOLERANCE))
         self._record_result(entry, section, 'pass' if passed else 'fail',
                              got=got, err=err, message=message)
         self.assertLessEqual(reldiff, _TOLERANCE, message)

--- a/tests/acceptance_tests/test_check_xsec_processes_mg7.py
+++ b/tests/acceptance_tests/test_check_xsec_processes_mg7.py
@@ -65,6 +65,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import traceback
 import unittest
 
 import madgraph.interface.master_interface as MGCmd
@@ -77,6 +78,29 @@ _REFERENCE = pjoin(_HERE, 'check_xsec_processes_reference.json')
 # the dynamically generated test methods pick up the CI-provided values.
 _TOLERANCE = float(os.environ.get('MG7_XSEC_TOLERANCE', 0.01))
 _EVENTS = int(os.environ.get('MG7_XSEC_EVENTS', 100000))
+
+# Optional: when set (by the CI workflow), one JSON result record per process
+# is written here so a later job can build a GitHub Actions job summary out of
+# them. The per-process run directory (and its log) is torn down at the end of
+# each test, so anything the summary needs -- including the tail of the log on
+# failure -- must be captured into this record before tearDown() runs.
+_RESULTS_DIR = os.environ.get('MG7_XSEC_RESULTS_DIR')
+
+
+# madspace renders a live-updating terminal UI (cursor moves, line clears,
+# colors) into the log; strip that so the tail is readable once scraped into
+# a plain-text summary.
+_ANSI_RE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]|\x1b[()][A-Za-z0-9]|\x1b[78]')
+
+
+def _tail(path, n=60):
+    """Return the last *n* (ANSI-stripped) lines of *path*, best effort."""
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+        return _ANSI_RE.sub('', ''.join(lines[-n:])).strip()
+    except Exception:
+        return ''
 
 
 def _mg7_datadir_or_skip(test):
@@ -143,9 +167,49 @@ class CheckXsecProcessesMG7Test(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.path, ignore_errors=True)
 
-    def _check_process(self, entry, defines):
+    def _record_result(self, entry, section, status, got=None, err=None,
+                        message=None):
+        """Persist a machine-readable record of this process' outcome (used
+        by the CI workflow to build a job summary). No-op unless
+        ``MG7_XSEC_RESULTS_DIR`` is set."""
+        if not _RESULTS_DIR:
+            return
+        try:
+            os.makedirs(_RESULTS_DIR, exist_ok=True)
+            record = {
+                'section': section,
+                'id': entry['id'],
+                'process': entry['process'],
+                'status': status,
+                'cross': got,
+                'error': err,
+                'ref_cross': entry['cross'],
+                'ref_error': entry.get('error'),
+                'message': message,
+            }
+            out = pjoin(_RESULTS_DIR, '%s_%s.json' % (section, entry['id']))
+            with open(out, 'w') as f:
+                json.dump(record, f)
+        except Exception:
+            # Recording the result must never mask the actual test outcome.
+            pass
+
+    def _check_process(self, entry, defines, section):
         """Generate + integrate a single process and assert its cross-section
         matches the reference within tolerance."""
+        try:
+            self._run_and_check(entry, defines, section)
+        except unittest.SkipTest:
+            raise
+        except AssertionError:
+            # Already recorded (with a precise message) by _run_and_check.
+            raise
+        except Exception:
+            self._record_result(entry, section, 'fail',
+                                 message=traceback.format_exc())
+            raise
+
+    def _run_and_check(self, entry, defines, section):
         datadir = _mg7_datadir_or_skip(self)
 
         run_dir = pjoin(self.path, entry['id'])
@@ -167,11 +231,17 @@ class CheckXsecProcessesMG7Test(unittest.TestCase):
             ret = subprocess.call(
                 [sys.executable, pjoin(run_dir, 'bin', 'generate_events'), '-f'],
                 cwd=run_dir, env=env, stdout=logfh, stderr=subprocess.STDOUT)
-        self.assertEqual(ret, 0, 'mg7 generate_events failed (see %s)' % log)
+        if ret != 0:
+            message = ('mg7 generate_events failed (exit %d)\n\n%s'
+                       % (ret, _tail(log)))
+            self._record_result(entry, section, 'fail', message=message)
+            self.fail('mg7 generate_events failed (see %s)' % log)
 
         infos = sorted(glob.glob(pjoin(run_dir, 'Events', '*', 'info.json')))
-        self.assertTrue(infos, 'no mg7 info.json under %s (see %s)'
-                        % (run_dir, log))
+        if not infos:
+            message = 'no mg7 info.json produced\n\n%s' % _tail(log)
+            self._record_result(entry, section, 'fail', message=message)
+            self.fail('no mg7 info.json under %s (see %s)' % (run_dir, log))
         with open(infos[-1]) as infofh:
             info = json.load(infofh)['process']
         got = float(info['mean'])
@@ -179,18 +249,23 @@ class CheckXsecProcessesMG7Test(unittest.TestCase):
 
         ref_x = entry['cross']
         reldiff = abs(got - ref_x) / ref_x if ref_x else float('inf')
-        self.assertLessEqual(
-            reldiff, _TOLERANCE,
-            '%s (%s): mg7 xsec %.6g +- %.3g pb differs from reference '
-            '%.6g pb by %.3f%% (> %.3f%% tolerance)'
-            % (entry['id'], entry['process'], got, err, ref_x,
-               100 * reldiff, 100 * _TOLERANCE))
+        passed = reldiff <= _TOLERANCE
+        message = None
+        if not passed:
+            message = (
+                '%s (%s): mg7 xsec %.6g +- %.3g pb differs from reference '
+                '%.6g pb by %.3f%% (> %.3f%% tolerance)\n\n%s'
+                % (entry['id'], entry['process'], got, err, ref_x,
+                   100 * reldiff, 100 * _TOLERANCE, _tail(log)))
+        self._record_result(entry, section, 'pass' if passed else 'fail',
+                             got=got, err=err, message=message)
+        self.assertLessEqual(reldiff, _TOLERANCE, message)
 
 
-def _make_test(entry, defines):
+def _make_test(entry, defines, section):
     """Build a bound-method-shaped closure for a single reference entry."""
     def test(self):
-        self._check_process(entry, defines)
+        self._check_process(entry, defines, section)
     test.__doc__ = '%s: %s (ref %.6g pb)' % (
         entry['id'], entry['process'], entry['cross'])
     return test
@@ -203,7 +278,7 @@ for _section, _entries in _REF['sections'].items():
     for _entry in _entries:
         _name = 'test_%s_%s_mg7' % (_section, _entry['id'])
         setattr(CheckXsecProcessesMG7Test, _name,
-                _make_test(_entry, _REF['defines']))
+                _make_test(_entry, _REF['defines'], _section))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- generate a table with the results from all the MG7 cross-section checks, including relative deviations and pulls
- provide error messages extracted from the log file below the table
- new verbosity mode `auto` in MG7 to automatically switch between `log` and `pretty` depending on whether a terminal is attached to stdout

See example output here: https://github.com/MadGraphTeam/MadGraph7/actions/runs/29644502579