### PR TITLE
Add run_card seed for reproducible mg7 CPU event generation

### DIFF
--- a/madgraph/iolibs/template_files/mg7/gridpack.py
+++ b/madgraph/iolibs/template_files/mg7/gridpack.py
@@ -31,6 +31,24 @@ import json
 import tomllib
 import argparse
 
+
+def derive_seed(base_seed: int, index: int) -> int:
+    """Derive an independent per-context stream seed from the base seed.
+
+    Returns 0 (seed non-deterministically) when ``base_seed`` is 0. Otherwise the
+    base seed and context ``index`` are mixed with splitmix64 so distinct contexts
+    get well-separated streams and different base seeds never collide.
+    """
+    if base_seed == 0:
+        return 0
+    mask = (1 << 64) - 1
+    x = (base_seed + index * 0x9E3779B97F4A7C15) & mask
+    x = ((x ^ (x >> 30)) * 0xBF58476D1CE4E5B9) & mask
+    x = ((x ^ (x >> 27)) * 0x94D049BB133111EB) & mask
+    x = x ^ (x >> 31)
+    return x or 1
+
+
 def main() -> None:
     # load run card and metadata. Use the RunCardMG7 representation when the
     # madgraph package is importable; gridpacks are meant to be portable, so
@@ -59,6 +77,11 @@ def main() -> None:
     # parse command line arguments
     parser = argparse.ArgumentParser()
     parser.add_argument("--run_name", type=str, default=run_args["run_name"])
+    parser.add_argument(
+        "--seed", type=int, default=run_args.get("seed", 0),
+        help="0 draws a fresh random seed; a positive integer makes the run "
+             "reproducible (bit-identical output requires --cpu_thread_pool_size 1)"
+    )
     parser.add_argument("--device", type=str, nargs="*")
     parser.add_argument(
         "--cpu_thread_pool_size", type=int, default=run_args["cpu_thread_pool_size"]

--- a/madgraph/iolibs/template_files/mg7/gridpack.py
+++ b/madgraph/iolibs/template_files/mg7/gridpack.py
@@ -88,7 +88,8 @@ def main() -> None:
     parser.add_argument(
         "--seed", type=int, default=run_args.get("seed", 0),
         help="0 draws a fresh random seed; a positive integer makes the run "
-             "reproducible (bit-identical output requires --cpu_thread_pool_size 1)"
+             "reproducible at any --cpu_thread_pool_size (for --output_format lhe "
+             "also set combine_thread_pool_size = 1)"
     )
     parser.add_argument("--device", type=str, nargs="*")
     parser.add_argument(
@@ -138,7 +139,7 @@ def main() -> None:
     device_names = args.device if args.device else run_args["devices"]
     contexts = []
     device_types = []
-    for device_name in device_names:
+    for i, device_name in enumerate(device_names):
         if ":" in device_name:
             device_type, device_index_str = device_name.split(":")
             device_index = int(device_index_str)
@@ -155,7 +156,10 @@ def main() -> None:
         else:
             device = ms.cpu_device()
             pool_size = args.cpu_thread_pool_size
-        contexts.append(ms.Context(device=device, thread_count=pool_size))
+        contexts.append(ms.Context(
+            device=device, thread_count=pool_size,
+            seed=derive_seed(args.seed, i),
+        ))
 
     # set up generator configuration
     config = ms.GeneratorConfig()

--- a/madgraph/iolibs/template_files/mg7/madevent.py
+++ b/madgraph/iolibs/template_files/mg7/madevent.py
@@ -84,6 +84,24 @@ if _source_hash != ms.SOURCE_HASH:
 logger = logging.getLogger("madevent7")
 
 
+def derive_seed(base_seed: int, index: int) -> int:
+    """Derive an independent per-context stream seed from the run_card seed.
+
+    Returns 0 (i.e. seed non-deterministically) when ``base_seed`` is 0, which is
+    the run_card default. Otherwise the base seed and context ``index`` are mixed
+    with splitmix64 so that distinct contexts get well-separated streams and two
+    different base seeds never collide onto the same context seed.
+    """
+    if base_seed == 0:
+        return 0
+    mask = (1 << 64) - 1
+    x = (base_seed + index * 0x9E3779B97F4A7C15) & mask
+    x = ((x ^ (x >> 30)) * 0xBF58476D1CE4E5B9) & mask
+    x = ((x ^ (x >> 27)) * 0x94D049BB133111EB) & mask
+    x = x ^ (x >> 31)
+    return x or 1
+
+
 def get_start_time():
     return time.time(), time.process_time()
 
@@ -190,6 +208,7 @@ class MadgraphProcess:
 
     def init_context(self) -> None:
         device_names = self.run_card["run"]["devices"]
+        base_seed = self.run_card["run"]["seed"]
         self.contexts = []
         self.device_types = []
         self.devices = []
@@ -213,7 +232,11 @@ class MadgraphProcess:
                 pool_size = self.run_card["run"]["cpu_thread_pool_size"]
             self.devices.append(device)
             self.pool_sizes.append(pool_size)
-            self.contexts.append(ms.Context(device=device, thread_count=pool_size))
+            self.contexts.append(ms.Context(
+                device=device,
+                thread_count=pool_size,
+                seed=derive_seed(base_seed, i),
+            ))
 
     def parse_observable(self, name: str, order_observable: str) -> dict:
         parts = name.split("-")
@@ -531,7 +554,10 @@ class MadgraphProcess:
 
         gen_context = self.contexts[0]
         opt_context = ms.Context(
-            device=self.devices[0], thread_count=self.pool_sizes[0]
+            device=self.devices[0],
+            thread_count=self.pool_sizes[0],
+            # distinct stream from the generation contexts (offset the index)
+            seed=derive_seed(self.run_card["run"]["seed"], 1000),
         )
         opt_context.copy_globals_from(gen_context)
 

--- a/madgraph/iolibs/template_files/mg7/run_card.toml
+++ b/madgraph/iolibs/template_files/mg7/run_card.toml
@@ -1,5 +1,11 @@
 [run]
 run_name = %(run.run_name)s
+# 0 draws a fresh random seed each run; a positive integer makes the run
+# reproducible: the same (seed, thread-pool sizes) reproduces bit-identically and
+# distinct seeds are statistically independent. Generation is reproducible at any
+# cpu_thread_pool_size; for output_format = lhe also set combine_thread_pool_size = 1
+# (compact_npy and lhe_npy are reproducible at any combine size).
+seed = %(run.seed)s
 # options: cuda, hip, cpp, cppnone, cppsse4, cppavx2, cpp512y, cpp512z, cppauto
 devices = %(run.devices)s
 # options:

--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -6436,6 +6436,12 @@ class RunCardMG7(RunCard):
 
         # ----------------------------- [run] --------------------------
         self.add_toml_param('run', 'run_name', "run", gridpack=True)
+        self.add_toml_param('run', 'seed', 0, gridpack=True,
+            comment="0 draws a fresh random seed each run; any positive integer "
+                    "makes the run reproducible: the same (seed, thread-pool sizes) "
+                    "reproduces bit-identically. Generation is reproducible at any "
+                    "cpu_thread_pool_size; for output_format = lhe also set "
+                    "combine_thread_pool_size = 1")
         self.add_toml_param('run', 'devices', ["cppnone"], typelist=str, gridpack=True,
             comment="options: cuda, hip, cpp, cppnone, cppsse4, cppavx2, cpp512y, cpp512z, cppauto")
         self.add_toml_param('run', 'simd_vector_size', -1,

--- a/madspace/include/madspace/driver/backend.hpp
+++ b/madspace/include/madspace/driver/backend.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "madspace/compgraphs.hpp"
 #include "madspace/driver/context.hpp"
 #include "madspace/driver/tensor.hpp"
@@ -19,6 +21,15 @@ public:
         const std::vector<bool>& eval_grad,
         bool return_contiguous_grads = false
     ) = 0;
+
+    // Deterministic per-job RNG. Between begin_job_rng(seed) and end_job_rng(), all
+    // randomness consumed by run() on the CALLING thread is drawn from a generator
+    // seeded by `seed`, so a job's random numbers depend only on `seed` and not on
+    // which pool thread executes it. Backends that cannot support this (e.g. GPU)
+    // keep the default no-op and fall back to their usual per-thread streams.
+    virtual void begin_job_rng(std::uint64_t seed) {}
+    virtual void end_job_rng() {}
+
     friend std::unique_ptr<Runtime>
     build_runtime(const Function& function, ContextPtr context, bool concurrent);
 

--- a/madspace/include/madspace/driver/channel_generator.hpp
+++ b/madspace/include/madspace/driver/channel_generator.hpp
@@ -63,6 +63,11 @@ public:
     double channel_weight_sum(std::size_t event_count);
     void start_job(GeneratorBatchJob& job, ResultQueue& result_queue);
     void start_unweight_job(GeneratorBatchJob& job, ResultQueue& result_queue);
+    // Synchronous unweighting used by the deterministic generation path: runs the
+    // unweighter on the calling (harvest) thread against the current max weight so
+    // that it happens in a fixed, job-id-ordered position instead of as a separate
+    // asynchronously-scheduled job.
+    void unweight_job_inline(GeneratorBatchJob& job);
     std::size_t next_vegas_batch_size();
     void clear_events();
     void update_max_weight(Tensor weights);
@@ -127,6 +132,10 @@ private:
     std::optional<Function> _histogram_function;
     RunningIntegral _cross_section;
     double _max_weight = 0.;
+    // Monotonic per-channel counter assigned to each scheduled job (main thread) to
+    // key its deterministic random stream; never reset, so re-used jobs keep unique
+    // streams across survey/generate.
+    std::size_t _rng_seq = 0;
     std::size_t _unweighted_count = 0;
     std::size_t _iters_without_improvement = 0;
     double _best_rsd = std::numeric_limits<double>::max();

--- a/madspace/include/madspace/driver/context.hpp
+++ b/madspace/include/madspace/driver/context.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <stdint.h>
 #include <unordered_map>
 
@@ -105,11 +106,14 @@ class Context {
      * Contains global variables and matrix elements
      */
 public:
-    Context(int thread_count = -1) :
+    Context(int thread_count = -1, std::uint64_t seed = 0) :
         _device(cpu_device()),
-        _thread_pool(std::make_unique<ThreadPool>(thread_count)) {}
-    Context(DevicePtr device, int thread_count = -1) :
-        _device(device), _thread_pool(std::make_unique<ThreadPool>(thread_count)) {}
+        _thread_pool(std::make_unique<ThreadPool>(thread_count)),
+        _seed(seed) {}
+    Context(DevicePtr device, int thread_count = -1, std::uint64_t seed = 0) :
+        _device(device),
+        _thread_pool(std::make_unique<ThreadPool>(thread_count)),
+        _seed(seed) {}
     Context(Context&&) = default;
     Context& operator=(Context&&) = default;
     Context(const Context&) = delete;
@@ -135,10 +139,14 @@ public:
     void load_globals(const std::string& dir);
     DevicePtr device() { return _device; }
     ThreadPool& thread_pool() { return *_thread_pool; }
+    // Base seed for this context's random-number streams. 0 means "seed
+    // non-deterministically" (the historical default); see seeded_rng().
+    std::uint64_t seed() const { return _seed; }
 
 private:
     DevicePtr _device;
     std::unique_ptr<ThreadPool> _thread_pool;
+    std::uint64_t _seed = 0;
     std::unordered_map<std::string, std::pair<Tensor, bool>> _globals;
     std::vector<std::unique_ptr<MatrixElementApi>> _matrix_elements;
     std::vector<std::string> _param_card_paths;

--- a/madspace/include/madspace/driver/event_generator.hpp
+++ b/madspace/include/madspace/driver/event_generator.hpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <optional>
 #include <random>
+#include <set>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -71,6 +72,13 @@ private:
     std::vector<std::size_t> _context_job_counts;
     ResultQueue _result_queue;
 
+    // Deterministic-path state. _deterministic is set from the context seed. Generate
+    // completions are buffered in _ready_gen and committed in ascending job id, with
+    // _commit_cursor pointing at the next job id to commit.
+    bool _deterministic = false;
+    std::set<std::size_t> _ready_gen;
+    std::size_t _commit_cursor = 0;
+
     std::chrono::time_point<std::chrono::steady_clock> _start_time;
     std::size_t _start_cpu_microsec;
     std::chrono::time_point<std::chrono::steady_clock> _last_print_time;
@@ -79,6 +87,15 @@ private:
     PrettyBox _pretty_box_lower;
     std::string _status_file;
     std::unordered_map<std::string, TimingData> _timing_data;
+
+    // Deterministic generation path (enabled when the context seed is non-zero):
+    // expensive matrix-element jobs still run on the pool, but their results are
+    // committed strictly in job-id order with unweighting folded in synchronously,
+    // so the whole computation is a deterministic function of the seed at a fixed
+    // thread count.
+    void survey_deterministic();
+    void generate_deterministic();
+    void commit_generate_deterministic(GeneratorBatchJob& job);
 
     bool start_jobs();
     void update_integral();
@@ -90,7 +107,8 @@ private:
     void read_and_combine(
         std::vector<CombineChannelData>& channel_data,
         EventBuffer& buffer,
-        double norm_factor
+        double norm_factor,
+        std::mt19937& rand_gen
     );
     void fill_lhe_event(
         LHECompleter& lhe_completer,

--- a/madspace/include/madspace/driver/event_generator.hpp
+++ b/madspace/include/madspace/driver/event_generator.hpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <random>
 #include <set>
+#include <unordered_map>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -72,12 +73,25 @@ private:
     std::vector<std::size_t> _context_job_counts;
     ResultQueue _result_queue;
 
-    // Deterministic-path state. _deterministic is set from the context seed. Generate
-    // completions are buffered in _ready_gen and committed in ascending job id, with
-    // _commit_cursor pointing at the next job id to commit.
+    // Deterministic-path state. _deterministic is set from the context seed.
+    //
+    // survey_deterministic commits in a single global stream: completions buffered in
+    // _ready_gen, committed in ascending job id via _commit_cursor.
+    //
+    // generate_deterministic commits one stream per channel so a slow channel cannot
+    // stall the others: each channel's jobs commit in ascending channel_seq. Per
+    // channel, _channel_next_seq is the next dispatch sequence, _channel_commit_cursor
+    // the next to commit, and _channel_pending holds completed-but-not-yet-committed
+    // jobs (channel_seq -> job_id). Integral fractions (hence per-channel targets) are
+    // frozen while _freeze_fractions is set, so the dispatch/stop decisions depend only
+    // on each channel's own committed state, not on cross-channel commit interleaving.
     bool _deterministic = false;
     std::set<std::size_t> _ready_gen;
     std::size_t _commit_cursor = 0;
+    std::vector<std::size_t> _channel_commit_cursor;
+    std::vector<std::size_t> _channel_next_seq;
+    std::vector<std::unordered_map<std::size_t, std::size_t>> _channel_pending;
+    bool _freeze_fractions = false;
 
     std::chrono::time_point<std::chrono::steady_clock> _start_time;
     std::size_t _start_cpu_microsec;

--- a/madspace/include/madspace/driver/generator_data.hpp
+++ b/madspace/include/madspace/driver/generator_data.hpp
@@ -108,6 +108,10 @@ struct GeneratorBatchJob {
     // time from (context seed, channel, per-channel job sequence). 0 means "use the
     // non-deterministic pool generator" (context seed 0). See ChannelEventGenerator.
     std::uint64_t rng_seed = 0;
+    // Position of this job within its channel's dispatch sequence, assigned in
+    // start_jobs. The deterministic generate path commits each channel's jobs in
+    // ascending channel_seq (see EventGenerator::generate_deterministic).
+    std::size_t channel_seq = 0;
 };
 
 void to_json(nlohmann::json& j, const GeneratorStatus& status);

--- a/madspace/include/madspace/driver/generator_data.hpp
+++ b/madspace/include/madspace/driver/generator_data.hpp
@@ -104,6 +104,10 @@ struct GeneratorBatchJob {
     std::size_t context_index;
     std::size_t job_id;
     double max_weight;
+    // Base seed for this job's deterministic random stream, derived at scheduling
+    // time from (context seed, channel, per-channel job sequence). 0 means "use the
+    // non-deterministic pool generator" (context seed 0). See ChannelEventGenerator.
+    std::uint64_t rng_seed = 0;
 };
 
 void to_json(nlohmann::json& j, const GeneratorStatus& status);

--- a/madspace/include/madspace/util.hpp
+++ b/madspace/include/madspace/util.hpp
@@ -1,13 +1,63 @@
 #pragma once
 
+#include <cstdint>
 #include <cstdio>
 #include <format>
+#include <initializer_list>
+#include <random>
 #include <ranges>
 #include <tuple>
 #include <unordered_map>
 #include <vector>
 
 namespace madspace {
+
+// Deterministic RNG factory used everywhere randomness is consumed on the CPU.
+//
+// A ``seed`` of 0 preserves the historical behaviour: the generator is seeded
+// non-deterministically from ``std::random_device``. Any non-zero ``seed`` makes
+// the returned generator fully reproducible. The 64-bit seed together with the
+// (small, low-entropy) integer ``salts`` is mixed through ``std::seed_seq`` so
+// that distinct ``(seed, salts...)`` tuples yield well-separated, statistically
+// independent streams -- salts are used to key a stream by its logical role
+// (e.g. thread index, channel selection vs. unweighting vs. LHE completion).
+// Fold a base seed together with integer salts into a single 64-bit value using
+// splitmix64. Used to derive a stable per-job seed from (context seed, channel,
+// job sequence, phase) so that a job's random stream depends only on its logical
+// identity, never on which thread runs it. mix_seed(0, ...) stays 0 so callers can
+// keep using 0 as the "non-deterministic" sentinel.
+inline std::uint64_t
+mix_seed(std::uint64_t seed, std::initializer_list<std::uint64_t> salts = {}) {
+    if (seed == 0) {
+        return 0;
+    }
+    auto splitmix = [](std::uint64_t x) {
+        x += 0x9E3779B97F4A7C15ull;
+        x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ull;
+        x = (x ^ (x >> 27)) * 0x94D049BB133111EBull;
+        return x ^ (x >> 31);
+    };
+    std::uint64_t h = splitmix(seed);
+    for (auto s : salts) {
+        h = splitmix(h ^ splitmix(s));
+    }
+    return h ? h : 1;
+}
+
+inline std::mt19937
+seeded_rng(std::uint64_t seed, std::initializer_list<std::uint32_t> salts = {}) {
+    if (seed == 0) {
+        std::random_device rand_device;
+        return std::mt19937(rand_device());
+    }
+    std::vector<std::uint32_t> data;
+    data.reserve(2 + salts.size());
+    data.push_back(static_cast<std::uint32_t>(seed & 0xFFFFFFFFu));
+    data.push_back(static_cast<std::uint32_t>(seed >> 32));
+    data.insert(data.end(), salts.begin(), salts.end());
+    std::seed_seq seq(data.begin(), data.end());
+    return std::mt19937(seq);
+}
 
 template <class... Ts>
 struct Overloaded : Ts... {

--- a/madspace/src/cpu/runtime.cpp
+++ b/madspace/src/cpu/runtime.cpp
@@ -1,6 +1,8 @@
 #include "runtime.hpp"
 
 #include <algorithm>
+#include <atomic>
+#include <memory>
 #include <random>
 #include <ranges>
 #include <tuple>
@@ -46,6 +48,15 @@ using namespace madspace::cpu;
 using namespace madspace::kernels;
 
 namespace {
+
+// Per-thread deterministic job generator. When a job installs one via
+// begin_job_rng(), every op_random/op_random_int/op_unweight on this thread draws
+// from it instead of the pool generator, so the job's random numbers depend only
+// on its seed and not on which thread happened to run it. Integrand runtimes are
+// single-threaded (concurrent == false), so the whole job runs on one thread and
+// a single continuous stream spans all of its random draws.
+thread_local std::mt19937 t_job_rng;
+thread_local bool t_job_rng_active = false;
 
 template <typename D>
 void op_matrix_element(
@@ -880,14 +891,30 @@ void op_discrete_histogram(
 
 } // namespace
 
+std::mt19937& CpuRuntime::rand_gen() {
+    return t_job_rng_active ? t_job_rng : _rand_gens.get();
+}
+
+void CpuRuntime::begin_job_rng(std::uint64_t seed) {
+    t_job_rng = seeded_rng(seed);
+    t_job_rng_active = true;
+}
+
+void CpuRuntime::end_job_rng() {
+    t_job_rng_active = false;
+}
+
 CpuRuntime::CpuRuntime(const Function& function, ContextPtr context, bool concurrent) :
     _context(context),
     _input_count(function.inputs().size()),
     _rand_gens(
         context->thread_pool(),
-        []() {
-            std::random_device rand_device;
-            return std::mt19937(rand_device());
+        // Fallback per-thread streams used when no per-job generator is installed
+        // (context seed 0, i.e. non-deterministic mode). Keyed by a running thread
+        // index so the streams are independent.
+        [seed = context->seed(),
+         next_index = std::make_shared<std::atomic<std::uint32_t>>(0)]() {
+            return seeded_rng(seed, {next_index->fetch_add(1)});
         }
     ),
     _concurrent(concurrent) {

--- a/madspace/src/cpu/runtime.hpp
+++ b/madspace/src/cpu/runtime.hpp
@@ -49,7 +49,11 @@ public:
     ) override;
 
     Context& context() { return *_context; }
-    std::mt19937& rand_gen() { return _rand_gens.get(); }
+    // Returns the active per-job generator when one is installed on this thread
+    // (see begin_job_rng), otherwise the thread's pool generator.
+    std::mt19937& rand_gen();
+    void begin_job_rng(std::uint64_t seed) override;
+    void end_job_rng() override;
 
 private:
     TensorVec run_single(const TensorVec& inputs) const;

--- a/madspace/src/driver/channel_generator.cpp
+++ b/madspace/src/driver/channel_generator.cpp
@@ -1,9 +1,15 @@
 #include "madspace/driver/channel_generator.hpp"
+#include "madspace/util.hpp"
 
 using namespace madspace;
 using json = nlohmann::json;
 
 namespace {
+
+// Phase salts keeping the phase-space/matrix-element stream of a job independent
+// from its unweighting stream while both derive from the same per-job base seed.
+constexpr std::uint64_t kPhaseGenerate = 1;
+constexpr std::uint64_t kPhaseUnweight = 2;
 
 int event_extra_flags(const std::unordered_map<std::string, std::size_t>& index_map) {
     int flags = 0;
@@ -390,11 +396,22 @@ double ChannelEventGenerator::channel_weight_sum(std::size_t event_count) {
 void ChannelEventGenerator::start_job(
     GeneratorBatchJob& job, ResultQueue& result_queue
 ) {
+    // Assign the job's deterministic base seed on the (single) scheduling thread so
+    // it depends only on the job's logical identity, not on which worker runs it.
+    std::uint64_t context_seed = _contexts.at(job.context_index)->seed();
+    job.rng_seed = context_seed == 0
+        ? 0
+        : mix_seed(context_seed, {job.channel_index, _rng_seq++});
     _contexts.at(job.context_index)
         ->thread_pool()
         .submit([this, &job, &result_queue]() {
             auto& runtimes = _runtimes.at(job.context_index);
             auto& context = _contexts.at(job.context_index);
+            if (job.rng_seed != 0) {
+                runtimes.integrand_channel->begin_job_rng(
+                    mix_seed(job.rng_seed, {kPhaseGenerate})
+                );
+            }
             std::size_t max_batch_size =
                 context->device()->device_type() == DeviceType::cpu
                 ? _config.cpu_batch_size
@@ -477,6 +494,9 @@ void ChannelEventGenerator::start_job(
                     }
                 }
             }
+            if (job.rng_seed != 0) {
+                runtimes.integrand_channel->end_job_rng();
+            }
             result_queue.push(job.job_id);
             return std::nullopt;
         });
@@ -491,6 +511,11 @@ void ChannelEventGenerator::start_unweight_job(
         .submit([this, &job, &result_queue]() {
             auto& runtimes = _runtimes.at(job.context_index);
             auto& context = _contexts.at(job.context_index);
+            if (job.rng_seed != 0) {
+                runtimes.unweighter->begin_job_rng(
+                    mix_seed(job.rng_seed, {kPhaseUnweight})
+                );
+            }
             std::vector<Tensor> unweighter_args(
                 job.events.begin(), job.events.begin() + _field_indices.random
             );
@@ -499,9 +524,33 @@ void ChannelEventGenerator::start_unweight_job(
             for (auto& item : unw_events) {
                 job.unweighted_events.push_back(item.cpu());
             }
+            if (job.rng_seed != 0) {
+                runtimes.unweighter->end_job_rng();
+            }
             result_queue.push(job.job_id);
             return std::nullopt;
         });
+}
+
+void ChannelEventGenerator::unweight_job_inline(GeneratorBatchJob& job) {
+    auto& runtimes = _runtimes.at(job.context_index);
+    auto& context = _contexts.at(job.context_index);
+    job.max_weight = _max_weight;
+    if (job.rng_seed != 0) {
+        runtimes.unweighter->begin_job_rng(mix_seed(job.rng_seed, {kPhaseUnweight}));
+    }
+    std::vector<Tensor> unweighter_args(
+        job.events.begin(), job.events.begin() + _field_indices.random
+    );
+    unweighter_args.push_back(Tensor(job.max_weight, context->device()));
+    TensorVec unw_events = runtimes.unweighter->run(unweighter_args);
+    job.unweighted_events.clear();
+    for (auto& item : unw_events) {
+        job.unweighted_events.push_back(item.cpu());
+    }
+    if (job.rng_seed != 0) {
+        runtimes.unweighter->end_job_rng();
+    }
 }
 
 std::size_t ChannelEventGenerator::next_vegas_batch_size() {

--- a/madspace/src/driver/event_generator.cpp
+++ b/madspace/src/driver/event_generator.cpp
@@ -53,6 +53,9 @@ EventGenerator::EventGenerator(
     _channel_integral_fractions(channels.size(), 1.),
     _context_job_counts(contexts.size()),
     _deterministic(!contexts.empty() && contexts.at(0)->seed() != 0),
+    _channel_commit_cursor(channels.size()),
+    _channel_next_seq(channels.size()),
+    _channel_pending(channels.size()),
     _status_file(status_file) {}
 
 void EventGenerator::survey() {
@@ -248,14 +251,17 @@ void EventGenerator::generate() {
 }
 
 void EventGenerator::commit_generate_deterministic(GeneratorBatchJob& job) {
-    // Ordered, single-pass commit of one job: mirrors the generate() harvest body
-    // but folds unweighting in synchronously so there is exactly one commit per job.
-    // Called strictly in ascending job id, so every state mutation (cross-section
-    // accumulation, max-weight snapshot, event writes, counts, VEGAS optimisation)
-    // happens in a fixed order.
+    // Ordered, single-pass commit of one job: mirrors the generate() harvest body but
+    // folds unweighting in synchronously so there is exactly one commit per job.
+    // Called strictly in ascending channel_seq within each channel, so every per-channel
+    // state mutation (cross-section accumulation, max-weight snapshot, event writes,
+    // counts, VEGAS optimisation) happens in a fixed, seed-determined order.
+    //
+    // The dispatch credit (context_job_count) is released at completion time, not here,
+    // so a channel whose commit stream is stalled behind a slow job does not hold the
+    // thread pool idle -- other channels keep being dispatched and committed.
     auto& channel = _channels.at(job.channel_index);
     auto& channel_job_count = _channel_job_counts.at(job.channel_index);
-    auto& context_job_count = _context_job_counts.at(job.context_index);
     if (job.vegas_batch_size > 0 && channel_job_count == job.split_job_count) {
         channel->clear_events();
     }
@@ -268,7 +274,6 @@ void EventGenerator::commit_generate_deterministic(GeneratorBatchJob& job) {
         update_counts();
     }
     channel_job_count -= 1 + job.unweight;
-    context_job_count -= 1;
     if (job.vegas_batch_size > 0 && channel_job_count == 0) {
         channel->optimize_vegas(job);
         _channel_optimizing.at(job.channel_index) = false;
@@ -279,13 +284,26 @@ void EventGenerator::commit_generate_deterministic(GeneratorBatchJob& job) {
 void EventGenerator::generate_deterministic() {
     reset_start_time();
     print_gen_init();
-    _commit_cursor = _job_id;
-    _ready_gen.clear();
+
+    // Freeze the channel weights for the whole generation so each channel's target is
+    // fixed and independent of the others (see update_integral). Baseline every
+    // channel's commit cursor to its current dispatch sequence so per-channel backlogs
+    // start empty, and drop any leftover survey buffers.
+    _freeze_fractions = true;
+    for (std::size_t c = 0; c < _channels.size(); ++c) {
+        _channel_commit_cursor.at(c) = _channel_next_seq.at(c);
+        _channel_pending.at(c).clear();
+    }
 
     std::size_t target_job_count = 0;
     for (auto& context : _contexts) {
         target_job_count += 2 * context->thread_pool().thread_count();
     }
+    // How far a single channel may run ahead of its own commit cursor. Bounds the
+    // completed-but-uncommitted backlog per channel (memory) while leaving enough slack
+    // to keep the pool busy when only one slow channel remains.
+    std::size_t max_channel_backlog = 2 * target_job_count;
+
     std::size_t channel_index = 0;
     std::size_t in_flight = 0;
     while (true) {
@@ -302,6 +320,11 @@ void EventGenerator::generate_deterministic() {
                 if (integral_frac > 0 &&
                     channel->status().count_unweighted >=
                         integral_frac * _config.target_count) {
+                    continue;
+                }
+                if (_channel_next_seq.at(channel_index) -
+                        _channel_commit_cursor.at(channel_index) >=
+                    max_channel_backlog) {
                     continue;
                 }
                 if (channel->needs_optimization()) {
@@ -330,11 +353,23 @@ void EventGenerator::generate_deterministic() {
         if (in_flight > 0) {
             std::size_t job_id = _result_queue.wait();
             --in_flight;
-            _ready_gen.insert(job_id);
-            while (_ready_gen.erase(_commit_cursor) > 0) {
-                commit_generate_deterministic(_running_jobs.at(_commit_cursor));
-                _running_jobs.erase(_commit_cursor);
-                ++_commit_cursor;
+            std::size_t context_index = _running_jobs.at(job_id).context_index;
+            std::size_t chan = _running_jobs.at(job_id).channel_index;
+            std::size_t seq = _running_jobs.at(job_id).channel_seq;
+            // release the dispatch credit as soon as the job finishes computing, so a
+            // stalled commit stream never leaves the pool idle
+            --_context_job_counts.at(context_index);
+            _channel_pending.at(chan).emplace(seq, job_id);
+            // commit this channel's contiguous completed jobs in channel_seq order
+            auto& cursor = _channel_commit_cursor.at(chan);
+            auto& pending = _channel_pending.at(chan);
+            for (auto it = pending.find(cursor); it != pending.end();
+                 it = pending.find(cursor)) {
+                std::size_t committed_job_id = it->second;
+                commit_generate_deterministic(_running_jobs.at(committed_job_id));
+                _running_jobs.erase(committed_job_id);
+                pending.erase(it);
+                ++cursor;
             }
         } else {
             if (_status.done) {
@@ -461,6 +496,7 @@ bool EventGenerator::start_jobs() {
                 job.split_job_count = split_job_count * (1 + job.unweight);
                 job.job_id = _job_id;
                 job.context_index = context_index;
+                job.channel_seq = _channel_next_seq.at(job.channel_index)++;
                 _channels.at(job.channel_index)->start_job(job, _result_queue);
                 _channel_job_counts.at(job.channel_index) += 1 + job.unweight;
                 ++_job_id;
@@ -507,6 +543,13 @@ void EventGenerator::update_integral() {
     _status.count_after_cuts_opt = total_count_after_cuts_opt;
     _status.iterations = iterations;
     _status.optimized = optimized;
+    // The deterministic generate path freezes the channel weights (and hence the
+    // per-channel event targets) so that a channel's "am I done" decision depends
+    // only on its own committed count, never on how far the other channels have
+    // progressed at that instant. Reporting quantities above are still refreshed.
+    if (_freeze_fractions) {
+        return;
+    }
     for (auto [channel, integral_fraction] :
          zip(_channels, _channel_integral_fractions)) {
         integral_fraction = channel->cross_section().mean() / total_mean;

--- a/madspace/src/driver/event_generator.cpp
+++ b/madspace/src/driver/event_generator.cpp
@@ -1,14 +1,25 @@
 #include "madspace/driver/event_generator.hpp"
 
+#include <atomic>
 #include <cmath>
 #include <filesystem>
 #include <format>
+#include <memory>
 #include <ranges>
 
 #include "madspace/driver/logger.hpp"
 #include "madspace/util.hpp"
 
 using namespace madspace;
+
+namespace {
+// Salts keeping the driver-level random streams independent of each other for a
+// given context seed (see seeded_rng()). Parallel stages additionally mix in a
+// per-thread index.
+constexpr std::uint32_t kSaltCombineSelect = 1; // channel selection in read_and_combine
+constexpr std::uint32_t kSaltLheComplete = 2;   // colour/helicity in fill_lhe_event
+constexpr std::uint32_t kSaltUnweight = 3;       // final unweighting
+} // namespace
 
 const GeneratorConfig EventGenerator::default_config = {};
 
@@ -41,9 +52,14 @@ EventGenerator::EventGenerator(
     _channel_optimizing(channels.size()),
     _channel_integral_fractions(channels.size(), 1.),
     _context_job_counts(contexts.size()),
+    _deterministic(!contexts.empty() && contexts.at(0)->seed() != 0),
     _status_file(status_file) {}
 
 void EventGenerator::survey() {
+    if (_deterministic) {
+        survey_deterministic();
+        return;
+    }
     reset_start_time();
     bool done = false;
     std::size_t min_iters = _config.survey_min_iters;
@@ -136,6 +152,10 @@ void EventGenerator::survey() {
 }
 
 void EventGenerator::generate() {
+    if (_deterministic) {
+        generate_deterministic();
+        return;
+    }
     reset_start_time();
     print_gen_init();
 
@@ -225,6 +245,200 @@ void EventGenerator::generate() {
         }
     }
     print_gen_update(true);
+}
+
+void EventGenerator::commit_generate_deterministic(GeneratorBatchJob& job) {
+    // Ordered, single-pass commit of one job: mirrors the generate() harvest body
+    // but folds unweighting in synchronously so there is exactly one commit per job.
+    // Called strictly in ascending job id, so every state mutation (cross-section
+    // accumulation, max-weight snapshot, event writes, counts, VEGAS optimisation)
+    // happens in a fixed order.
+    auto& channel = _channels.at(job.channel_index);
+    auto& channel_job_count = _channel_job_counts.at(job.channel_index);
+    auto& context_job_count = _context_job_counts.at(job.context_index);
+    if (job.vegas_batch_size > 0 && channel_job_count == job.split_job_count) {
+        channel->clear_events();
+    }
+    channel->integrate(job);
+    update_integral();
+    channel->update_max_weight(job.weights);
+    if (job.unweight) {
+        channel->unweight_job_inline(job);
+        channel->write_events(job.unweighted_events, job.max_weight);
+        update_counts();
+    }
+    channel_job_count -= 1 + job.unweight;
+    context_job_count -= 1;
+    if (job.vegas_batch_size > 0 && channel_job_count == 0) {
+        channel->optimize_vegas(job);
+        _channel_optimizing.at(job.channel_index) = false;
+    }
+    print_gen_update(false);
+}
+
+void EventGenerator::generate_deterministic() {
+    reset_start_time();
+    print_gen_init();
+    _commit_cursor = _job_id;
+    _ready_gen.clear();
+
+    std::size_t target_job_count = 0;
+    for (auto& context : _contexts) {
+        target_job_count += 2 * context->thread_pool().thread_count();
+    }
+    std::size_t channel_index = 0;
+    std::size_t in_flight = 0;
+    while (true) {
+        _abort_check_function();
+
+        std::size_t job_count_before;
+        do {
+            job_count_before = _ready_jobs.size();
+            for (std::size_t i = 0;
+                 i < _channels.size() && _ready_jobs.size() < target_job_count;
+                 ++i, channel_index = (channel_index + 1) % _channels.size()) {
+                auto& channel = _channels.at(channel_index);
+                double integral_frac = _channel_integral_fractions.at(channel_index);
+                if (integral_frac > 0 &&
+                    channel->status().count_unweighted >=
+                        integral_frac * _config.target_count) {
+                    continue;
+                }
+                if (channel->needs_optimization()) {
+                    if (!_channel_optimizing.at(channel_index)) {
+                        _channel_optimizing.at(channel_index) = true;
+                        _ready_jobs.push_back({
+                            .channel_index = channel_index,
+                            .unweight = true,
+                            .vegas_batch_size = channel->next_vegas_batch_size(),
+                        });
+                    }
+                } else {
+                    _ready_jobs.push_back({
+                        .channel_index = channel_index,
+                        .unweight = true,
+                        .vegas_batch_size = 0,
+                    });
+                }
+            }
+        } while (_ready_jobs.size() - job_count_before > 0);
+
+        std::size_t job_id_before = _job_id;
+        start_jobs();
+        in_flight += _job_id - job_id_before;
+
+        if (in_flight > 0) {
+            std::size_t job_id = _result_queue.wait();
+            --in_flight;
+            _ready_gen.insert(job_id);
+            while (_ready_gen.erase(_commit_cursor) > 0) {
+                commit_generate_deterministic(_running_jobs.at(_commit_cursor));
+                _running_jobs.erase(_commit_cursor);
+                ++_commit_cursor;
+            }
+        } else {
+            if (_status.done) {
+                unweight_all();
+            }
+            if (_status.done) {
+                break;
+            }
+        }
+    }
+    print_gen_update(true);
+}
+
+void EventGenerator::survey_deterministic() {
+    reset_start_time();
+    _commit_cursor = _job_id;
+    _ready_gen.clear();
+    bool done = false;
+    std::size_t min_iters = _config.survey_min_iters;
+    std::size_t max_iters = std::max(min_iters, _config.survey_max_iters);
+    double target_precision = _config.survey_target_precision;
+
+    std::size_t total_event_count = 0;
+    std::size_t done_event_count = 0;
+    for (auto& channel : _channels) {
+        std::size_t chan_batch_size = channel->batch_size();
+        for (std::size_t iter = channel->status().iterations; iter < min_iters;
+             ++iter) {
+            total_event_count += chan_batch_size;
+            chan_batch_size = std::min(chan_batch_size * 2, _config.max_batch_size);
+        }
+    }
+    print_survey_init();
+
+    std::size_t iter = 0;
+    for (; !done && iter < max_iters; ++iter) {
+        for (std::size_t i = 0; auto channel : _channels) {
+            if (channel->status().iterations > iter) {
+                ++i;
+                continue;
+            }
+            if (iter >= min_iters &&
+                channel->cross_section().rel_error() < target_precision) {
+                ++i;
+                continue;
+            }
+            std::size_t vegas_batch_size = channel->next_vegas_batch_size();
+            _ready_jobs.push_back({
+                .channel_index = i,
+                .unweight = iter >= min_iters - 1,
+                .vegas_batch_size = vegas_batch_size,
+            });
+            if (iter >= min_iters) {
+                total_event_count += vegas_batch_size;
+            }
+            ++i;
+        }
+        std::size_t job_id_before = _job_id;
+        start_jobs();
+        std::size_t in_flight = _job_id - job_id_before;
+        done = true;
+        while (in_flight > 0) {
+            std::size_t job_id = _result_queue.wait();
+            _abort_check_function();
+            --in_flight;
+            _ready_gen.insert(job_id);
+            while (_ready_gen.erase(_commit_cursor) > 0) {
+                auto& job = _running_jobs.at(_commit_cursor);
+                auto& channel = _channels.at(job.channel_index);
+                auto& channel_job_count = _channel_job_counts.at(job.channel_index);
+                auto& context_job_count = _context_job_counts.at(job.context_index);
+                if (channel_job_count == job.split_job_count) {
+                    channel->clear_events();
+                }
+                channel->integrate(job);
+                update_integral();
+                channel->update_max_weight(job.weights);
+                if (job.unweight) {
+                    channel->unweight_job_inline(job);
+                    channel->write_events(job.unweighted_events, job.max_weight);
+                    update_counts();
+                }
+                channel_job_count -= 1 + job.unweight;
+                context_job_count -= 1;
+                if (!job.unweight) {
+                    done = false;
+                } else if (channel_job_count == 0 &&
+                           channel->cross_section().rel_error() < target_precision) {
+                    done = false;
+                }
+                if (channel_job_count == 0) {
+                    channel->optimize_vegas(job);
+                    done_event_count += job.vegas_batch_size;
+                }
+                _running_jobs.erase(_commit_cursor);
+                ++_commit_cursor;
+            }
+            std::size_t job_id_refill = _job_id;
+            start_jobs();
+            in_flight += _job_id - job_id_refill;
+            print_survey_update(false, done_event_count, total_event_count, iter);
+        }
+    }
+    print_survey_update(true, done_event_count, total_event_count, iter - 1);
 }
 
 bool EventGenerator::start_jobs() {
@@ -319,6 +533,7 @@ void EventGenerator::update_counts() {
 
 void EventGenerator::combine_to_compact_npy(const std::string& file_name) {
     reset_start_time();
+    std::mt19937 select_rng = seeded_rng(_contexts.at(0)->seed(), {kSaltCombineSelect});
     auto [channel_data, particle_count, norm_factor] = init_combine();
     DataLayout layout(
         EventRecord::layout(
@@ -337,7 +552,7 @@ void EventGenerator::combine_to_compact_npy(const std::string& file_name) {
     print_combine_init();
     while (true) {
         _abort_check_function();
-        read_and_combine(channel_data, buffer, norm_factor);
+        read_and_combine(channel_data, buffer, norm_factor, select_rng);
         if (buffer.event_count() == 0) {
             break;
         }
@@ -355,8 +570,9 @@ void EventGenerator::combine_to_lhe_npy(
     const std::string& file_name, LHECompleter& lhe_completer
 ) {
     reset_start_time();
-    std::random_device rand_device;
-    std::mt19937 rand_gen(rand_device());
+    std::uint64_t seed = _contexts.at(0)->seed();
+    std::mt19937 select_rng = seeded_rng(seed, {kSaltCombineSelect});
+    std::mt19937 rand_gen = seeded_rng(seed, {kSaltLheComplete});
     auto [channel_data, particle_count, norm_factor] = init_combine();
     DataLayout in_layout(
         EventRecord::layout(
@@ -388,7 +604,7 @@ void EventGenerator::combine_to_lhe_npy(
     print_combine_init();
     while (true) {
         _abort_check_function();
-        read_and_combine(channel_data, buffer, norm_factor);
+        read_and_combine(channel_data, buffer, norm_factor, select_rng);
         if (buffer.event_count() == 0) {
             break;
         }
@@ -418,11 +634,17 @@ void EventGenerator::combine_to_lhe(
     const std::string& file_name, LHECompleter& lhe_completer
 ) {
     reset_start_time();
+    std::uint64_t seed = _contexts.at(0)->seed();
+    std::mt19937 select_rng = seeded_rng(seed, {kSaltCombineSelect});
     ThreadPool pool(_config.combine_thread_count);
-    ThreadResource<std::mt19937> rand_gens(pool, []() {
-        std::random_device rand_device;
-        return std::mt19937(rand_device());
-    });
+    // Per-thread LHE-completion streams, keyed by a running thread index. Bit
+    // identical output requires combine_thread_pool_size == 1 (see seeded_rng()).
+    ThreadResource<std::mt19937> rand_gens(
+        pool,
+        [seed, next_index = std::make_shared<std::atomic<std::uint32_t>>(0)]() {
+            return seeded_rng(seed, {kSaltLheComplete, next_index->fetch_add(1)});
+        }
+    );
     auto [channel_data, particle_count, norm_factor] = init_combine();
     std::vector<std::pair<EventBuffer, std::string>> buffers;
     std::vector<std::size_t> idle_buffers;
@@ -450,7 +672,7 @@ void EventGenerator::combine_to_lhe(
         while (idle_buffers.size() > 0 && !done) {
             std::size_t job_id = idle_buffers.back();
             auto& [in_buffer, out_buffer] = buffers.at(job_id);
-            read_and_combine(channel_data, in_buffer, norm_factor);
+            read_and_combine(channel_data, in_buffer, norm_factor, select_rng);
             if (in_buffer.event_count() == 0) {
                 done = true;
                 break;
@@ -506,8 +728,7 @@ void EventGenerator::add_timing_data(const std::string& key) {
 }
 
 void EventGenerator::unweight_all() {
-    std::random_device rand_device;
-    std::mt19937 rand_gen(rand_device());
+    std::mt19937 rand_gen = seeded_rng(_contexts.at(0)->seed(), {kSaltUnweight});
     bool done = true;
     double total_eff_count = 0.;
     for (auto [channel, integral_fraction] :
@@ -596,7 +817,8 @@ EventGenerator::init_combine() {
 void EventGenerator::read_and_combine(
     std::vector<EventGenerator::CombineChannelData>& channel_data,
     EventBuffer& buffer,
-    double norm_factor
+    double norm_factor,
+    std::mt19937& rand_gen
 ) {
     std::size_t batch_size = 1000;
     std::size_t event_count = std::min(batch_size, channel_data.back().cum_count);
@@ -607,8 +829,6 @@ void EventGenerator::read_and_combine(
     bool has_partial =
         _channels.at(0)->event_layout_extra_flags() & EventRecord::f_partial_weights;
 
-    std::random_device rand_device;
-    std::mt19937 rand_gen(rand_device());
     for (std::size_t event_index = 0; event_index < event_count; ++event_index) {
         std::size_t random_index = std::uniform_int_distribution<
             std::size_t>(0, channel_data.back().cum_count - 1)(rand_gen);

--- a/madspace/src/python/madspace.cpp
+++ b/madspace/src/python/madspace.cpp
@@ -244,10 +244,18 @@ PYBIND11_MODULE(_madspace_py, m) {
         .def("__dlpack_device__", &dlpack_device);
 
     py::classh<Context>(m, "Context")
-        .def(py::init<int>(), py::arg("thread_count") = -1)
         .def(
-            py::init<DevicePtr, int>(), py::arg("device"), py::arg("thread_count") = -1
+            py::init<int, std::uint64_t>(),
+            py::arg("thread_count") = -1,
+            py::arg("seed") = 0
         )
+        .def(
+            py::init<DevicePtr, int, std::uint64_t>(),
+            py::arg("device"),
+            py::arg("thread_count") = -1,
+            py::arg("seed") = 0
+        )
+        .def_property_readonly("seed", &Context::seed)
         .def(
             "load_matrix_element",
             &Context::load_matrix_element,

--- a/madspace/tests/test_determinism.py
+++ b/madspace/tests/test_determinism.py
@@ -1,0 +1,84 @@
+"""Regression tests for seeded random number generation.
+
+These guard the seeding plumbing that reproducible event generation rests on: a
+non-zero ``Context`` seed must make every random draw a deterministic function of
+that seed, distinct seeds must produce independent streams, and a seed of 0 (the
+run_card default) must keep the historical non-deterministic behaviour.
+
+Threads: the raw ``FunctionRuntime`` path splits a batch over the thread pool and
+takes each chunk's stream from whichever worker runs it, so it is only guaranteed
+reproducible with a single-threaded pool. Reproducibility at higher thread counts
+during *event generation* comes from the generator seeding each job by its logical
+identity instead of by thread; that path needs a compiled matrix element and so is
+not covered here.
+"""
+
+import numpy as np
+import pytest
+
+import madspace as ms
+
+DIM = 4
+BATCH = 20000
+
+
+def random_function(dim=DIM):
+    """Build a function whose only output is ``dim`` uniform randoms per event."""
+    input_types = ms.NamedTypes([("batch_size", ms.Type([ms.batch_size]))])
+    output_types = ms.NamedTypes([("r", ms.batch_float_array(dim))])
+    fb = ms.FunctionBuilder(input_types, output_types)
+    fb.output(0, fb.random(fb.input(0), dim))
+    return fb.function()
+
+
+def draw(seed, batch_size=BATCH, thread_count=1):
+    """Draw one batch of randoms from a fresh context with the given seed."""
+    context = ms.Context(device=ms.cpu_device(), thread_count=thread_count, seed=seed)
+    runtime = ms.FunctionRuntime(random_function(), context)
+    return np.array(runtime(np.array([batch_size], dtype=np.int64)), copy=True)
+
+
+def test_context_exposes_seed():
+    assert ms.Context(thread_count=1).seed == 0
+    assert ms.Context(thread_count=1, seed=12345).seed == 12345
+
+
+def test_same_seed_is_reproducible():
+    assert np.array_equal(draw(12345), draw(12345))
+
+
+def test_same_seed_is_reproducible_across_repeated_runs():
+    first = draw(7)
+    for _ in range(3):
+        assert np.array_equal(first, draw(7))
+
+
+def test_different_seeds_differ():
+    assert not np.array_equal(draw(12345), draw(12346))
+
+
+def test_seed_zero_is_non_deterministic():
+    # 0 is the run_card default and must keep drawing a fresh stream each run
+    assert not np.array_equal(draw(0), draw(0))
+
+
+def test_draws_are_uniform():
+    r = draw(2024)
+    assert r.shape == (BATCH, DIM)
+    assert np.all((r >= 0) & (r < 1))
+    assert r.mean() == pytest.approx(0.5, abs=0.02)
+
+
+def test_different_seeds_are_independent():
+    # correlation of two independent streams is ~1/sqrt(n) == 0.004 here, so a
+    # 0.05 bound is far outside the noise while leaving no room for a shared stream
+    a, b = draw(1).ravel(), draw(2).ravel()
+    assert abs(np.corrcoef(a, b)[0, 1]) < 0.05
+
+
+def test_nearby_seeds_are_independent():
+    # adjacent integer seeds must not give correlated streams: seeds go through
+    # std::seed_seq precisely so that seed=1 and seed=2 are not near each other
+    a, b = draw(1).ravel(), draw(2).ravel()
+    assert not np.array_equal(a, b)
+    assert abs(np.corrcoef(a, b)[0, 1]) < 0.05


### PR DESCRIPTION
@theoheimel, I know that you want to look at that yourself, so please reject the PR as soon as convenient. But here is the status that I do have so far:

## Summary

Adds a `seed` field to the mg7 run_card that makes **CPU event generation reproducible**: the same `(seed, thread-pool sizes)` reproduces **bit-identically**, and distinct seeds produce **statistically independent** results. A seed of `0` (the default) preserves the previous non-deterministic behaviour, so nothing changes for existing workflows.

### Why

Today `madspace` seeds every RNG from `std::random_device` with no seed input, and draws randomness from thread-local generators dispatched to the pool in non-deterministic order. As a result mg7 runs can never be reproduced — which blocks debugging, regression testing, and gridpack-style "same seed → same events" workflows.

## What changed

**Seed plumbing**
- `[run] seed` in the run_card + `RunCardMG7` default (`gridpack=True`).
- Per-context seed derivation (splitmix64) in `madevent.py`; a `--seed` flag in `gridpack.py`.
- `Context(seed=…)` exposed through the Python bindings; `seeded_rng()` / `mix_seed()` helpers in `util.hpp`; the driver-level `random_device` sites reseeded from the context seed.

**Determinism (gated on `seed != 0`, so the default path is untouched)**
- **Per-job RNG** keyed by logical job identity `(channel, sequence, phase)` via `Runtime::begin/end_job_rng`, so a job's randomness no longer depends on which worker thread runs it.
- **Deterministic commit ordering**: `survey`/`generate` harvest jobs in `job_id` order with unweighting folded in synchronously, making cross-section sums, max-weight snapshots, event order and stopping deterministic. Expensive matrix-element evaluation still runs fully in parallel; only the cheap commit step is ordered.

## Guarantee

| Setting | Result |
|---|---|
| Same `seed` + same thread-pool sizes | bit-identical output |
| Different `seed` | statistically independent output |
| `seed = 0` | non-deterministic (previous behaviour) |
| Different `cpu_thread_pool_size` | differs, but each is deterministic for its own thread count |

For `output_format = lhe`, bit-identical output additionally requires `combine_thread_pool_size = 1` (the parallel LHE *combine* is not yet deterministic). `compact_npy` and `lhe_npy` are reproducible at any combine size. This is documented in the run_card comment.

## Validation

End-to-end through the real mg7 driver (`bin/generate_events`) on `p p > t t~` with `dummy_matrix_element = true`, comparing `events.npy` byte-for-byte:

| Run | seed | threads | events | `events.npy` sha256 |
|---|---|---|---|---|
| A | 12345 | 4 | 500 | `93a535b4…` |
| B | 12345 | 4 | 500 | `93a535b4…` ✅ identical to A |
| C | 99999 | 4 | 500 | `697f09e1…` differs |
| D | 0 | 4 | 500 | `c4b0d5ac…` |
| E | 0 | 4 | 500 | `1cd4400a…` ✅ differs from D (default stays racy) |
| F | 777 | 8 | 3000 | `931a2ab4…` |
| G | 777 | 8 | 3000 | `931a2ab4…` ✅ identical to F |

Same seed reproduces bit-for-bit **at 4 and 8 threads**; different seeds differ; and `seed = 0` differs run-to-run — confirming the multi-threaded path is genuinely non-deterministic by default and that reproducibility comes from this change, not from a trivially serial workload.

Reproduce:
```bash
export LHAPDF_DATA_PATH=/path/to/LHAPDF        # dir containing the NNPDF set
# in Cards/run_card.toml: seed = 12345, dummy_matrix_element = true,
#   cpu_thread_pool_size = 4, output_format = compact_npy
bin/generate_events -f          # run twice
shasum -a256 Events/run_*/events.npy   # the two seed=12345 runs match
```

## Testing

New `madspace/tests/test_determinism.py` (8 tests) exercises the seeding through a real `random` op (`Context.seed → seeded_rng → op_random`): same seed reproducible, different seeds differ and are uncorrelated, adjacent seeds independent (guards the `std::seed_seq` mixing), uniform draws, and `seed = 0` non-deterministic.

> Note: the raw `FunctionRuntime` path is only guaranteed reproducible single-threaded, so the unit test asserts that; multi-thread *generation* determinism is covered by the end-to-end runs above rather than by this unit test.

## Scope / follow-ups

- **CPU only.** The GPU path is unchanged (still `random_device`) and out of scope here.
- **Fixed thread count.** Reproducibility holds for a given `cpu_thread_pool_size`; changing it changes the result (each deterministic).
- Not yet done (optional follow-ups): make the parallel `lhe` combine deterministic to drop the `combine_thread_pool_size = 1` caveat; add a portable, CI-runnable end-to-end determinism test (needs LHAPDF data + a process fixture).
