### PR TITLE
Build all SubProcesses in parallel from a single make jobserver

### DIFF
--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -1532,9 +1532,9 @@ This will take effect only in a NEW terminal
             raise self.InvalidCmd('%s : Not a valid directory' % path)
         if os.path.isfile(pjoin(bin_path,'madevent')):
             return 'madevent'
-        elif os.path.isfile(pjoin(subproc_path, 'madmatrix.mk')):
-            # standalone_mg7 writes SubProcesses/madmatrix.mk explicitly
-            # (the regular mg7 export does not).
+        elif os.path.isfile(pjoin(subproc_path, 'madmatrix_standalone.mk')):
+            # standalone_mg7 writes SubProcesses/madmatrix_standalone.mk
+            # (the regular mg7 export only writes madmatrix.mk).
             return 'standalone_mg7'
         elif os.path.isfile(pjoin(card_path, 'run_card.toml')):
             return 'mg7'

--- a/madgraph/iolibs/template_files/madmatrix/madmatrix.mk
+++ b/madgraph/iolibs/template_files/madmatrix/madmatrix.mk
@@ -765,8 +765,17 @@ endif
 # Target (and build rules): common (src) library
 commonlib : $(LIBDIR)/lib$(MADMATRIX_COMMONLIB).so
 
+# The common library is shared by every P* directory. When several of them are
+# built concurrently (SubProcesses/makefile fanning out under 'make -j N'), they
+# must not all recurse into src/ and race on the same objects: the dispatcher
+# builds the common library once, up front, and sets MADMATRIX_COMMONLIB_EXTERNAL=1
+# to say so. Building a P* directory on its own (the default) is unaffected.
+ifeq ($(MADMATRIX_COMMONLIB_EXTERNAL),1)
+$(LIBDIR)/lib$(MADMATRIX_COMMONLIB).so: ;
+else
 $(LIBDIR)/lib$(MADMATRIX_COMMONLIB).so: $(SRC)/*.h $(SRC)/*.cc $(BUILDDIR)/.build.$(TAG)
 	$(MAKE) -C $(SRC) BACKEND=$(BACKEND) LIBDIR=$(LIBDIR)
+endif
 
 #-------------------------------------------------------------------------------
 
@@ -815,32 +824,43 @@ bld512z:
 	@echo
 	$(MAKE) $(_BLDFLAGS) BACKEND=cpp512z
 
+# The C++/SIMD backends that are worth building on this machine...
 ifeq ($(UNAME_P),ppc64le)
-bldavxs: bldnone bldsse4
+  BLDAVXS = cppnone cppsse4
 else ifneq (,$(filter $(UNAME_M),arm64 aarch64))
-bldavxs: bldnone bldsse4
+  BLDAVXS = cppnone cppsse4
 else
-bldavxs: bldnone bldsse4 bldavx2 bld512y bld512z
+  BLDAVXS = cppnone cppsse4 cppavx2 cpp512y cpp512z
 endif
 
+# ...plus the GPU backends whose compiler was found. This is the single place
+# where the list of 'bldall' backends is defined: SubProcesses/makefile drives
+# multi-backend builds through the bldall/bldcommonlib targets below.
+BLDBACKENDS = $(BLDAVXS)
+ifneq ($(CUDA_HOME),)
+  BLDBACKENDS := cuda $(BLDBACKENDS)
+endif
 ifneq ($(HIP_HOME),)
-ifneq ($(CUDA_HOME),)
-bldall: bldhip bldcuda bldavxs
-else
-bldall: bldhip bldavxs
+  BLDBACKENDS := hip $(BLDBACKENDS)
 endif
-else
-ifneq ($(CUDA_HOME),)
-bldall: bldcuda bldavxs
-else
-bldall: bldavxs
-endif
-endif
+
+# 'bldcppsse4' etc. are named 'bldsse4' etc. (the 'cpp' prefix is dropped)
+bldavxs: $(addprefix bld,$(subst cpp,,$(BLDAVXS)))
+bldall: $(addprefix bld,$(subst cpp,,$(BLDBACKENDS)))
+
+# Target: the common (src) library in all BACKEND modes. Used by the
+# SubProcesses dispatcher, which owns the common library during a 'bldall'
+# (see MADMATRIX_COMMONLIB_EXTERNAL above).
+.PHONY: bldcommonlib $(addprefix commonlib.,$(BLDBACKENDS))
+bldcommonlib: $(addprefix commonlib.,$(BLDBACKENDS))
+
+$(addprefix commonlib.,$(BLDBACKENDS)): commonlib.%%:
+	+$(MAKE) $(_BLDFLAGS) BACKEND=$* commonlib
 
 #-------------------------------------------------------------------------------
 
 # Target: clean the builds
-.PHONY: clean cleanall
+.PHONY: clean cleanall cleancommon cleanallcommon
 
 # clean: remove objects and libraries for the selected BACKEND only.
 clean:
@@ -850,14 +870,27 @@ else
 	rm -f $(BUILDDIR)/.build.* $(BUILDDIR)/*.o
 	rm -f $(LIBDIR)/lib$(MADMATRIX_LIB).so
 	rm -f $(BACKEND_LOG)
+ifneq ($(MADMATRIX_COMMONLIB_EXTERNAL),1)
 	$(MAKE) -C $(SRC) clean BACKEND=$(BACKEND) LIBDIR=$(LIBDIR)
 endif
- 
+endif
+
 # cleanall: remove objects and libraries for ALL backends.
 cleanall:
 	rm -rf build.*
 	rm -f ./.build.* ./*.o
 	rm -f $(LIBDIR)/libmadmatrix_$(processid_short)_*.so
+ifneq ($(MADMATRIX_COMMONLIB_EXTERNAL),1)
+	$(MAKE) -C $(SRC) cleanall LIBDIR=$(LIBDIR)
+endif
+
+# Clean only the common (src) part. These are the counterparts of 'commonlib'
+# for the SubProcesses dispatcher, which owns the common library while the P*
+# directories are cleaned in parallel with MADMATRIX_COMMONLIB_EXTERNAL=1.
+cleancommon:
+	$(MAKE) -C $(SRC) clean BACKEND=$(BACKEND) LIBDIR=$(LIBDIR)
+
+cleanallcommon:
 	$(MAKE) -C $(SRC) cleanall LIBDIR=$(LIBDIR)
 
 #-------------------------------------------------------------------------------

--- a/madgraph/iolibs/template_files/madmatrix/madmatrix_subprocesses.mk
+++ b/madgraph/iolibs/template_files/madmatrix/madmatrix_subprocesses.mk
@@ -1,0 +1,124 @@
+# Copyright (C) 2020-2026 CERN and UCLouvain.
+# Licensed under the GNU Lesser General Public License (version 3 or later).
+# Integrated with the MadGraph7 project in Feb 2026.
+#
+# SubProcesses/makefile: dispatcher over the P* subprocess directories.
+#
+# This file contains no build rule of its own: the rules live in madmatrix.mk,
+# which every P* directory links as its own 'makefile'. All this one does is fan
+# out over the subprocess directories with a plain recursive make, so that GNU
+# make's jobserver is shared by all the sub-makes. Running
+#
+#     make -j 18
+#
+# here therefore spreads 18 concurrent compilations over ALL the subprocess
+# directories at once: no directory is built at a time with 18 jobs, and no
+# directory is limited to 18/N jobs either. Whenever one directory runs out of
+# work its slots are immediately picked up by the others.
+#
+# Every variable understood by madmatrix.mk (BACKEND, FPTYPE, USEBUILDDIR,
+# HELINL, HRDCOD, LIBDIR, DEBUG, PROFILE, ...) can be given on the command line
+# as usual; make forwards command-line variables to the sub-makes by itself.
+
+SHELL := /bin/bash
+
+# Group the output of each sub-make instead of interleaving it line by line
+# (GNU make >= 4.0; silently skipped on older versions, e.g. the 3.81 shipped
+# with macOS, where .FEATURES is undefined).
+ifneq ($(filter output-sync,$(.FEATURES)),)
+  MAKEFLAGS += --output-sync=target
+endif
+
+#-------------------------------------------------------------------------------
+
+#=== The generated subprocess directories
+
+# (the trailing '/.' in the glob restricts the match to directories)
+SUBDIRS := $(sort $(patsubst %%/,%%,$(dir $(wildcard P[0-9]*_*/.))))
+
+ifeq ($(SUBDIRS),)
+  $(error No subprocess directory (P*) found in $(CURDIR))
+endif
+
+# The common library (built from ../src) is shared by every subprocess, so it is
+# built once here, before the fan-out. MADMATRIX_COMMONLIB_EXTERNAL=1 then tells
+# each P* makefile that this makefile owns the common library, and that it must
+# not recurse into ../src on its own -- which is what N sub-makes running in
+# parallel would otherwise all do at the same time, racing on the same objects.
+#
+# The common library is built *through* one representative subprocess directory
+# rather than directly: madmatrix.mk already resolves BACKEND (including the
+# 'cppauto' detection), FPTYPE, the compiler flags and the paths of src/ and
+# lib/, and none of that has to be duplicated here.
+COMMONDIR := $(firstword $(SUBDIRS))
+
+SUBMAKE = $(MAKE) --no-print-directory MADMATRIX_COMMONLIB_EXTERNAL=1
+
+#-------------------------------------------------------------------------------
+
+#=== Makefile TARGETS
+#
+# Each action gets one phony target per subprocess directory ('<action>@<dir>').
+# Depending on those targets, rather than looping over the directories inside a
+# single recipe, is what lets make schedule the directories concurrently.
+
+build_targets    := $(addprefix build@,$(SUBDIRS))
+bldall_targets   := $(addprefix bldall@,$(SUBDIRS))
+clean_targets    := $(addprefix clean@,$(SUBDIRS))
+cleanall_targets := $(addprefix cleanall@,$(SUBDIRS))
+
+.PHONY: all bldall clean cleanall commonlib bldcommonlib cleancommon cleanallcommon
+.PHONY: $(SUBDIRS) $(build_targets) $(bldall_targets) $(clean_targets) $(cleanall_targets)
+
+.DEFAULT_GOAL := all
+
+#-------------------------------------------------------------------------------
+
+# Target: build the library of every subprocess (this is the default goal)
+all: $(build_targets)
+
+# The common library must exist before any subprocess links against it: making
+# it a prerequisite of every 'build@<dir>' target has make build it exactly once
+# and wait for it before starting the fan-out.
+$(build_targets): build@%%: commonlib
+	+$(SUBMAKE) -C $*
+
+# Target: build a single subprocess ("make P1_gg_ttx")
+$(SUBDIRS): %%: build@%%
+
+# Target: the library shared by all subprocesses (built from ../src)
+commonlib:
+	+$(MAKE) --no-print-directory -C $(COMMONDIR) commonlib
+
+#-------------------------------------------------------------------------------
+
+# Target: build every subprocess in all BACKEND modes (each in its own build
+# directory). The list of backends worth building on this machine is decided by
+# madmatrix.mk, so that the platform logic lives in one place only.
+bldall: $(bldall_targets)
+
+$(bldall_targets): bldall@%%: bldcommonlib
+	+$(SUBMAKE) -C $* bldall
+
+# Target: the common library, in all BACKEND modes
+bldcommonlib:
+	+$(MAKE) --no-print-directory -C $(COMMONDIR) bldcommonlib
+
+#-------------------------------------------------------------------------------
+
+# Target: clean the builds of the selected BACKEND, in all subprocesses.
+# The common library is cleaned last, once the subprocesses are done with it.
+clean: $(clean_targets)
+	+$(MAKE) --no-print-directory -C $(COMMONDIR) cleancommon
+
+$(clean_targets): clean@%%:
+	+$(SUBMAKE) -C $* clean
+
+# Target: clean the builds of ALL backends, in all subprocesses
+cleanall: $(cleanall_targets)
+	+$(MAKE) --no-print-directory -C $(COMMONDIR) cleanallcommon
+
+$(cleanall_targets): cleanall@%%:
+	+$(SUBMAKE) -C $* cleanall
+
+#-------------------------------------------------------------------------------

--- a/madgraph/iolibs/template_files/mg7/madevent.py
+++ b/madgraph/iolibs/template_files/mg7/madevent.py
@@ -115,6 +115,51 @@ def resolve_verbosity(verbosity: str) -> str:
     return verbosity
 
 
+def resolve_cppauto_backend(build_path: str) -> str:
+    """Ask the matrix-element Makefile to resolve ``cppauto``.
+
+    Given the produced shared library will have its name taken from the resolved
+    backend name, we need to make sure the detection is taking place correctly
+    and catch any possible error.
+    """
+    command = ["make", "-n", "BACKEND=cppauto", "detect-backend"]
+    try:
+        result = subprocess.run(
+            command,
+            cwd=build_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not run make to resolve cppauto in '{build_path}': {exc}"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        output = "\n".join(
+            part.strip() for part in (exc.stdout, exc.stderr) if part.strip()
+        )
+        detail = f"\nmake output:\n{output}" if output else ""
+        raise RuntimeError(
+            f"Could not resolve cppauto in '{build_path}': "
+            f"Exit status {exc.returncode}.{detail}"
+        ) from exc
+
+    match = re.search(
+        r"^BACKEND=(\S+) \(was cppauto\)$", result.stdout, re.MULTILINE
+    )
+    if match is None or match.group(1) == "cppauto":
+        output = "\n".join(
+            part.strip() for part in (result.stdout, result.stderr) if part.strip()
+        )
+        detail = f"\nmake output:\n{output}" if output else ""
+        raise RuntimeError(
+            f"Could not resolve cppauto in '{build_path}': "
+            f"make failed to report a backend.{detail}"
+        )
+    return match.group(1)
+
+
 @dataclass
 class Channel:
     phasespace_mapping: ms.PhaseSpaceMapping
@@ -424,18 +469,14 @@ class MadgraphProcess:
 
         # Resolve 'cppauto' once (the build rules pick the best SIMD backend
         # available here), so that all subprocesses agree on the library names.
-        resolved = []
-        for backend in backends:
-            if backend == "cppauto":
-                out = subprocess.run(
-                    ["make", "-n", "BACKEND=cppauto", "detect-backend"],
-                    cwd=first_proc_path, capture_output=True, text=True,
-                ).stdout
-                match = re.search(r"BACKEND=(\S+) \(was cppauto\)", out)
-                if match:
-                    backend = match.group(1)
-                    logger.info(f"Device 'cppauto' resolved as '{backend}'")
-            resolved.append(backend)
+        cppauto_backend = None
+        if "cppauto" in backends:
+            cppauto_backend = resolve_cppauto_backend(first_proc_path)
+            logger.info("Device 'cppauto' resolved as '%s'", cppauto_backend)
+        resolved = [
+            cppauto_backend if backend == "cppauto" else backend
+            for backend in backends
+        ]
 
         nb_core = self.run_card["run"]["cpu_thread_pool_size"]
         if not nb_core or nb_core < 0:

--- a/madgraph/iolibs/template_files/mg7/madevent.py
+++ b/madgraph/iolibs/template_files/mg7/madevent.py
@@ -398,9 +398,65 @@ class MadgraphProcess:
         self.event_generator = None
 
     def init_subprocesses(self) -> None:
+        self.backends = self.compile_matrix_elements()
         self.subprocesses = []
         for subproc_id, meta in enumerate(self.subprocess_data):
             self.subprocesses.append(MadgraphSubprocess(self, meta, subproc_id))
+
+    def compile_matrix_elements(self) -> list[str]:
+        """Build the matrix-element library of every subprocess, and return the
+        list of requested devices with 'cppauto' replaced by the backend it
+        resolves to on this machine.
+
+        SubProcesses/makefile is a dispatcher over the P* directories, so a
+        single 'make -j N' there builds all the subprocesses at once with one
+        shared pool of N jobs: no subprocess is built with N jobs while the
+        others wait, and none is limited to N/#subprocesses jobs either.
+        """
+        backends = self.run_card["run"]["devices"]
+        if not isinstance(backends, list):
+            backends = [backends]
+        if not self.subprocess_data:
+            return backends
+
+        first_proc_path = self.subprocess_data[0]["path"]
+        subproc_path = os.path.dirname(first_proc_path)
+
+        # Resolve 'cppauto' once (the build rules pick the best SIMD backend
+        # available here), so that all subprocesses agree on the library names.
+        resolved = []
+        for backend in backends:
+            if backend == "cppauto":
+                out = subprocess.run(
+                    ["make", "-n", "BACKEND=cppauto", "detect-backend"],
+                    cwd=first_proc_path, capture_output=True, text=True,
+                ).stdout
+                match = re.search(r"BACKEND=(\S+) \(was cppauto\)", out)
+                if match:
+                    backend = match.group(1)
+                    logger.info(f"Device 'cppauto' resolved as '{backend}'")
+            resolved.append(backend)
+
+        nb_core = self.run_card["run"]["cpu_thread_pool_size"]
+        if not nb_core or nb_core < 0:
+            nb_core = os.cpu_count() or 1
+
+        for backend in resolved:
+            missing = [
+                meta for meta in self.subprocess_data
+                if not os.path.isfile(meta["me_path"].format(device=backend))
+            ]
+            if not missing:
+                continue
+            logger.info(
+                f"Compiling {len(missing)} subprocess(es) for device "
+                f"'{backend}' with {nb_core} parallel job(s)"
+            )
+            misc.compile(
+                arg=[f"BACKEND={backend}", "USEBUILDDIR=1"],
+                cwd=subproc_path, mode="cpp", nb_core=nb_core,
+            )
+        return resolved
 
     def build_event_generator(self, phasespaces: list[PhaseSpace]) -> ms.EventGenerator:
         channel_generators = []
@@ -959,29 +1015,11 @@ class MadgraphSubprocess:
         self.subproc_id = subproc_id
         self.multi_channel_data = None
 
-        api_path_format = self.meta["me_path"]
-        subproc_path = self.meta["path"]
-        devices = self.process.run_card["run"]["devices"]
-        api_paths = []
-        if not isinstance(devices, list):
-            devices = [devices]
-        for device in devices:
-            subproc_dir = os.path.dirname(subproc_path)
-            # 'cppauto' resolve quick fix
-            resolved = device
-            if device == "cppauto":
-                out = subprocess.run(
-                    ["make", "-n", "BACKEND=cppauto", "detect-backend"],
-                    cwd=subproc_path, capture_output=True, text=True,
-                ).stdout
-                match = re.search(r"BACKEND=(\S+) \(was cppauto\)", out)
-                if match:
-                    resolved = match.group(1)
-            api_path = api_path_format.format(device=resolved)
-            if not os.path.isfile(api_path):
-                logger.info(f"Compiling subprocess {subproc_dir}, for device '{device}'")
-                misc.compile(arg = [f"BACKEND={device}", "USEBUILDDIR=1"], cwd = subproc_path)
-            api_paths.append(api_path)
+        # The libraries were all built up front by MadgraphProcess.compile_matrix_elements
+        api_paths = [
+            self.meta["me_path"].format(device=backend)
+            for backend in self.process.backends
+        ]
 
         self.incoming_masses = [
             self.process.get_mass(pid) for pid in clean_pids(self.meta["incoming"])

--- a/madgraph/iolibs/template_files/mg7/madevent.py
+++ b/madgraph/iolibs/template_files/mg7/madevent.py
@@ -482,6 +482,7 @@ class MadgraphProcess:
         if not nb_core or nb_core < 0:
             nb_core = os.cpu_count() or 1
 
+        log_path = os.path.join(self.run_path, "compile_subprocesses.log")
         for backend in resolved:
             missing = [
                 meta for meta in self.subprocess_data
@@ -490,14 +491,38 @@ class MadgraphProcess:
             if not missing:
                 continue
             logger.info(
-                f"Compiling {len(missing)} subprocess(es) for device "
-                f"'{backend}' with {nb_core} parallel job(s)"
+                f"Start compilation of SubProcesses for device '{backend}' "
+                f"({len(missing)} subprocess(es), {nb_core} parallel job(s)), "
+                f"see log detail in {log_path}"
             )
-            misc.compile(
-                arg=[f"BACKEND={backend}", "USEBUILDDIR=1"],
-                cwd=subproc_path, mode="cpp", nb_core=nb_core,
+            start_time = time.time()
+            self.make_subprocesses(
+                subproc_path, [f"BACKEND={backend}", "USEBUILDDIR=1"],
+                nb_core, log_path,
+            )
+            logger.info(
+                f"Compilation of SubProcesses done in {time.time() - start_time:.1f} s"
             )
         return resolved
+
+    @staticmethod
+    def make_subprocesses(
+        subproc_path: str, args: list[str], nb_core: int, log_path: str
+    ) -> None:
+        """Run 'make -j nb_core' in SubProcesses/, appending the full build
+        output to log_path (one run per device, so the file is appended to)."""
+        command = ["make", f"-j{nb_core}"] + args
+        with open(log_path, "a") as log:
+            log.write(f"\n$ cd {subproc_path} && {' '.join(command)}\n")
+            log.flush()
+            returncode = subprocess.call(
+                command, cwd=subproc_path, stdout=log, stderr=subprocess.STDOUT
+            )
+        if returncode != 0:
+            raise RuntimeError(
+                f"Compilation of the SubProcesses failed with exit status "
+                f"{returncode}; see {log_path} for details"
+            )
 
     def build_event_generator(self, phasespaces: list[PhaseSpace]) -> ms.EventGenerator:
         channel_generators = []

--- a/madmatrix/model_handling.py
+++ b/madmatrix/model_handling.py
@@ -1487,6 +1487,9 @@ class OneProcessExporterMadMatrix(export_mg7.OneProcessExporterMG7):
     multichannel_var = ',fptype& multi_chanel_num, fptype& multi_chanel_denom'
     imaginary_unit = "cxtype(0,1)"
 
+    # Build rules (in SubProcesses/) that this P* directory links as its 'makefile'
+    p_makefile = 'madmatrix.mk'
+
     # AV - overload export_cpp.OneProcessExporterCPP constructor (rename gCPPProcess to CPPProcess)
     def __init__(self, *args, **kwargs):
         ###misc.sprint('Entering OneProcessExporterMadMatrix.__init__')
@@ -1952,9 +1955,11 @@ class OneProcessExporterMadMatrix(export_mg7.OneProcessExporterMG7):
         self.edit_memorybuffers() # AV new file (NB this is generic in Subprocesses and then linked in Sigma-specific)
         self.edit_memoryaccesscouplings() # AV new file (NB this is generic in Subprocesses and then linked in Sigma-specific)
         super().generate_process_files()
-        # NB: symlink of cudacpp.mk to makefile is overwritten by madevent makefile if this exists (#480)
+        # The build rules live in SubProcesses/<p_makefile>; SubProcesses/makefile
+        # itself is the dispatcher that fans out over all the P* directories.
+        # NB: this symlink is overwritten by the madevent makefile if this exists (#480)
         # NB: this relies on the assumption that cudacpp code is generated before madevent code
-        files.ln(pjoin(self.path, "..", "makefile"), self.path, "makefile")
+        files.ln(pjoin(self.path, "..", self.p_makefile), self.path, "makefile")
 
     # AV - replace the export_cpp.OneProcessExporterCPP method (add debug printouts and multichannel handling #473) 
     def edit_mgonGPU(self):
@@ -2226,6 +2231,13 @@ class OneProcessExporterMadMatrix(export_mg7.OneProcessExporterMG7):
         """Get lines to reset jamps"""
         ret_lines = ""
         return ret_lines
+
+
+# Standalone mode: P*/makefile points at the wrapper that also builds check_sa.exe
+# (see ProcessExporterMadMatrixStandalone in output.py)
+class OneProcessExporterMadMatrixStandalone(OneProcessExporterMadMatrix):
+
+    p_makefile = 'madmatrix_standalone.mk'
 
 #------------------------------------------------------------------------------------
 

--- a/madmatrix/output.py
+++ b/madmatrix/output.py
@@ -129,7 +129,15 @@ class ProcessExporterMadMatrix(export_cpp.ProcessExporterMG7):
                     'umami.h', 'umami.cc', 'rambo.h']
 
     template_src_make = pjoin(madmatrix_templates, 'madmatrix_src.mk')
-    template_Sub_make = pjoin(madmatrix_templates, 'madmatrix.mk')
+    # SubProcesses/makefile is only a dispatcher over the P* directories: it is
+    # what makes 'make -j N' in SubProcesses build all the subprocesses with a
+    # single, shared pool of N jobs.
+    template_Sub_make = pjoin(madmatrix_templates, 'madmatrix_subprocesses.mk')
+
+    # The actual build rules, rendered into SubProcesses/. Each P* directory
+    # links one of them (p_makefile, see OneProcessExporterMadMatrix) as its own
+    # 'makefile'.
+    p_makefiles = ['madmatrix.mk']
 
     dirs_to_create = ['bin', 'src', 'lib', 'Cards', 'SubProcesses']
 
@@ -168,6 +176,18 @@ class ProcessExporterMadMatrix(export_cpp.ProcessExporterMG7):
             shutil.move(os.path.join(self.dir_path, "src", "Makefile"), os.path.join(self.dir_path, "src", "makefile"))
         if self.template_Sub_make:
             shutil.move(os.path.join(self.dir_path, "SubProcesses", "Makefile"), os.path.join(self.dir_path, "SubProcesses", "makefile"))
+        self.write_p_makefiles(model)
+
+    def write_p_makefiles(self, model):
+        """Render the build rules shared by all the P* directories into
+        SubProcesses/ (they are linked from there as each P*/makefile)."""
+        replace_dict = {
+            'model': self.get_model_name(model.get('name')),
+            'cpp_compiler': self.opt['cpp_compiler'] if self.opt['cpp_compiler'] else 'g++',
+        }
+        for name in self.p_makefiles:
+            rendered = self.read_template_file(pjoin(self.madmatrix_templates, name)) % replace_dict
+            open(pjoin(self.dir_path, 'SubProcesses', name), 'w').write(rendered)
 
     # AV - add debug printouts (in addition to the default one from OM's tutorial)
     def generate_subprocess_directory(self, matrix_element, cpp_helas_call_writer, proc_number=None):
@@ -202,12 +222,13 @@ class ProcessExporterMadMatrix(export_cpp.ProcessExporterMG7):
 
 
 # Standalone mode: in addition to the normal madmatrix exports, this writes
-# an additional wrapper Makefile (with the template file being madmatrix_standalone.mk) on top of madmatrix.mk,
+# an additional wrapper makefile (madmatrix_standalone.mk) on top of madmatrix.mk,
 # so that when running `make` in a P* folder, it builds check_sa.exe as well as the process library (predicatable behaviour)
 class ProcessExporterMadMatrixStandalone(ProcessExporterMadMatrix):
 
-    # This wrapper replaces madmatrix.mk
-    template_Sub_make = pjoin(ProcessExporterMadMatrix.madmatrix_templates, 'madmatrix_standalone.mk')
+    # Each P* directory links madmatrix_standalone.mk (which itself includes
+    # madmatrix.mk) as its 'makefile'; both have to be rendered in SubProcesses/
+    p_makefiles = ProcessExporterMadMatrix.p_makefiles + ['madmatrix_standalone.mk']
 
     # Standalone-only template files needed to build check_sa.exe
     _standalone_extra_files = ['check_sa.cc',
@@ -224,17 +245,16 @@ class ProcessExporterMadMatrixStandalone(ProcessExporterMadMatrix):
     # We don't need the run_card.toml
     from_template['Cards'] = []
 
-    # Symlink the madmatrix.mk file to each P* folder
+    # Symlink the madmatrix.mk file to each P* folder (madmatrix_standalone.mk,
+    # linked there as 'makefile', includes it by name)
     to_link_in_P = ProcessExporterMadMatrix.to_link_in_P + _standalone_extra_files + ['madmatrix.mk']
+
+    # P*/makefile points at the standalone wrapper, so that a plain 'make' in a
+    # P* directory (or from the SubProcesses dispatcher) also builds check_sa.exe
+    oneprocessclass = model_handling.OneProcessExporterMadMatrixStandalone
 
     def copy_template(self, model):
         super().copy_template(model)
-        madmatrix_mk = pjoin(self.madmatrix_templates, 'madmatrix.mk')
-        rendered = self.read_template_file(madmatrix_mk) % {
-            'model': self.get_model_name(model.get('name')),
-            'cpp_compiler': self.opt['cpp_compiler'] if self.opt['cpp_compiler'] else 'g++',
-        }
-        open(pjoin(self.dir_path, 'SubProcesses', 'madmatrix.mk'), 'w').write(rendered)
 
         # Write another custom bin/generate_events to orchestrate the standalone mode
         gen_events = pjoin(self.dir_path, 'bin', 'generate_events')


### PR DESCRIPTION
Running `make -j 18` in `SubProcesses/` now spreads 18 concurrent compilations over **all** the `P*` directories at once — instead of building one directory at a time with 18 jobs, or giving each directory `18/N`.

This is the make-level counterpart of #61, which did the same thing with a `ThreadPoolExecutor` in `mg7/madevent.py`.

## Mechanism

The parallelism comes from GNU make's **jobserver**. `SubProcesses/makefile` becomes a plain recursive dispatcher that fans out with `+$(MAKE) -C <dir>`, so its `-j` slots are shared with every sub-make: a directory that runs out of work immediately hands its slots to the others.

## File layout

`SubProcesses/makefile` used to *be* the per-process build rules (symlinked into each `P*`). That name is now the dispatcher, so the files are rearranged:

| file | role |
|---|---|
| `SubProcesses/makefile` | the dispatcher (new template `madmatrix_subprocesses.mk`) |
| `SubProcesses/madmatrix.mk` | the build rules, linked as each `P*/makefile` |
| `SubProcesses/madmatrix_standalone.mk` | ditto for `standalone_mg7` (it `include`s `madmatrix.mk`) |

The dispatcher owns no build logic of its own. It even builds the common library *through* a representative `P*` directory, so the `BACKEND`/`cppauto` resolution, the compiler flags and the `src/`, `lib/` paths stay defined in `madmatrix.mk` only.

## The race that had to be fixed first

Every `P*` makefile recursed into `src/` to build the shared common library. With N directories running at once they would all have done that simultaneously, on the same objects. The dispatcher builds it once, up front, and passes `MADMATRIX_COMMONLIB_EXTERNAL=1` to say it owns that step; a `P*` directory built on its own is unaffected.

The `bldall` backend list is collapsed into a single `BLDBACKENDS` variable, so multi-backend builds can be driven from the dispatcher without duplicating the platform logic.

## Python side

`mg7` compiled one subprocess per `MadgraphSubprocess`. It now resolves `cppauto` once and makes a single `make -jN` call on `SubProcesses/` (`N` = `cpu_thread_pool_size`, `-1` meaning the CPU count). One `make` invocation replaces the per-subprocess loop.

## Incidental

`find_output_type` told `standalone_mg7` apart by the presence of `SubProcesses/madmatrix.mk`, which the regular `mg7` export now also has; the discriminator moves to `madmatrix_standalone.mk`.

## Testing

`p p > e+ e-` + `p p > e+ e- j` (4 subprocesses), both `mg7` and `standalone_mg7`:

- scaling on an 18-core machine: `-j1` 12.3s → `-j4` 4.0s → `-j18` 2.1s; the common library is compiled exactly once
- `clean`, `cleanall`, `bldall` (2 backends, one common lib each), `make P2_gQ_epemQ`, `BACKEND=… USEBUILDDIR=1`, plain `make`, incremental no-op, and a plain `make` inside a single `P*` directory
- a deliberate compile error reports `make: *** [build@P2_gQ_epemQ] Error 2`, so the failing directory is still named
- `check_sa.exe` runs; full `bin/generate_events` completes in 5.2s including the build
- acceptance tests `test_standalone_mg7_goodhel_filter`, `test_standalone_mg7_vs_cpp`, `test_output_mg7_directory` pass (`test_group_subprocess_mg7` skips)

Note: the `systematics computation failed` message at the end of `generate_events` is pre-existing — reproduced on a stashed baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
