### PR TITLE
tests: define aloha TMP temporaries in an explicit eval namespace (fix 9 errors on python 3.13+)

### DIFF
--- a/tests/parallel_tests/test_aloha.py
+++ b/tests/parallel_tests/test_aloha.py
@@ -38,6 +38,27 @@ set_global = misc.set_global
 
 pjoin = os.path.join
 
+def eval_scope(local_vars):
+    """Return a namespace in which the string form of an aloha expression can
+    be exec'ed/eval'ed.
+
+    Those strings refer to the TMP.../FCT... temporaries that aloha introduces
+    for the common subexpressions (KERNEL.reduced_expr2, exposed per routine as
+    AbstractRoutine.contracted/fct), so a test has to define them first, exactly
+    like the writers emit their definition ahead of the expression itself.
+
+    Defining them with a bare exec() used to work by accident: the assignment
+    landed in the dict returned by locals(), and that dict was cached per frame,
+    so a later eval() -- which also reads locals() -- still saw it. Since PEP 667
+    (python 3.13) locals() hands out an independent snapshot of the function
+    scope, so the assignment is thrown away and the eval() raises NameError.
+    Passing an explicit namespace to both exec() and eval() is version
+    independent.
+    """
+    scope = dict(globals())
+    scope.update(local_vars)
+    return scope
+
 class TestVariable(unittest.TestCase):
 
     def setUp(self):
@@ -1082,19 +1103,20 @@ class testLorentzObject(unittest.TestCase):
     
         analytical2 = (P(-1, t)* P(-1,t)-1) * (Metric(alpha, beta))
         analytical2= analytical2.expand()
+        scope = eval_scope(locals())
         for name, cexpr in aloha_lib.KERNEL.reduced_expr2.items():
             try:
-                exec('%s = %s' % (name, cexpr))   
+                exec('%s = %s' % (name, cexpr), scope)
             except:
                 pass
-        
+
         for ind in analytical.listindices():
             data1 = analytical.get_rep(ind)
             data2 = analytical2.get_rep(ind)
-            self.assertAlmostEqual(eval(str( data1 )),eval(str(data2)))
-        
-        
-        
+            self.assertAlmostEqual(eval(str( data1 ), scope),eval(str(data2), scope))
+
+
+
     def testTraceofObject(self):
         """Check that we can output the trace of an object"""
         
@@ -1212,14 +1234,15 @@ class testLorentzObject(unittest.TestCase):
         P1_0, P1_1, P1_2, P1_3 = 20,3,4,5
         OM1 = 1/(P1_0 **2 - P1_1 **2 -P1_2 **2 -P1_3 **2)
         M1 = math.sqrt(P1_0 **2 - P1_1 **2 -P1_2 **2 -P1_3 **2)
+        scope = eval_scope(locals())
         for name, cexpr in aloha_lib.KERNEL.reduced_expr2.items():
             try:
-                exec('%s = %s' % (name, cexpr))   
+                exec('%s = %s' % (name, cexpr), scope)
             except:
                 pass
         for ind in zero.listindices():
             data = zero.get_rep(ind)
-            self.assertEqual(eval(str(data)),0)
+            self.assertEqual(eval(str(data), scope),0)
 
 
     
@@ -1335,16 +1358,17 @@ class testLorentzObject(unittest.TestCase):
 
         P1_0, P1_1, P1_2, P1_3 = 7,2,3,5
         OM1 = 1.0/48#(P1_0 **2 - P1_1 **2 -P1_2 **2 -P1_3 **2)
+        scope = eval_scope(locals())
         for name, cexpr in aloha_lib.KERNEL.reduced_expr2.items():
             try:
-                exec('%s = %s' % (name, cexpr))   
+                exec('%s = %s' % (name, cexpr), scope)
             except:
                 pass
-        
+
         for ind in analytical.listindices():
             data1 = aloha.get_rep(ind)
             data2 = analytical.get_rep(ind)
-            self.assertAlmostEqual(eval(str( data1 )),eval(str(data2)))
+            self.assertAlmostEqual(eval(str( data1 ), scope),eval(str(data2), scope))
             
     def test_short_spin2propagator5(self):
         """test the spin2 propagator is correctly contracted --part by part --"""
@@ -2853,11 +2877,12 @@ class test_aloha_creation(IOTests.IOTestManager):
         P1_0,P1_1,P1_2,P1_3 = 10, 11, 12, 19
         P2_0,P2_1,P2_2,P2_3 = 101, 111, 121, 134
         P3_0,P3_1,P3_2,P3_3 = 1001, 1106, 1240, 1320
+        scope = eval_scope(locals())
         for name, cexpr in abstract_ZP.contracted.items():
-            exec('%s = %s' % (name, cexpr))
+            exec('%s = %s' % (name, cexpr), scope)
 
         for ind in expr.listindices():
-            self.assertEqual(eval(str(expr.get_rep(ind))), 178727040j)
+            self.assertEqual(eval(str(expr.get_rep(ind)), scope), 178727040j)
 
     def test_short_regular_expression_propa(self):
 
@@ -2919,15 +2944,14 @@ class test_aloha_creation(IOTests.IOTestManager):
         OM1,OM2,OM3 = 0 , 0, 1.0 / 500**2
         M3 = 500
         
-        #for name, cexpr in one_exp.contracted.items():
-        #    exec('%s = %s' % (name, cexpr))
+        scope = eval_scope(locals())
         for name, cexpr in aloha_lib.KERNEL.reduced_expr2.items():
             try:
-                exec('%s = %s' % (name, cexpr))            
+                exec('%s = %s' % (name, cexpr), scope)
             except:
                 pass
         for ind in one_exp.listindices():
-            self.assertAlmostEqual(eval(str(one_exp.get_rep(ind))), eval(str(two_exp.get_rep(ind))))
+            self.assertAlmostEqual(eval(str(one_exp.get_rep(ind)), scope), eval(str(two_exp.get_rep(ind)), scope))
 
 
     @set_global()
@@ -3016,12 +3040,13 @@ class test_aloha_creation(IOTests.IOTestManager):
         OM1,OM2,OM3 = 0 , 0, 1.0 / 500**2
         M3 = 500
         
+        scope = eval_scope(locals())
         for name, cexpr in aloha_lib.KERNEL.reduced_expr2.items():
-            exec('%s = %s' % (name, cexpr)) 
-        
+            exec('%s = %s' % (name, cexpr), scope)
+
         for ind in zero.listindices():
-            self.assertAlmostEqual(eval(str(zero.get_rep(ind))),0)
-             
+            self.assertAlmostEqual(eval(str(zero.get_rep(ind)), scope),0)
+
     def test_short_aloha_get_rank(self):
         """ test the FFV creation of vertex """
         
@@ -3081,18 +3106,19 @@ class test_aloha_creation(IOTests.IOTestManager):
         j = complex(0,1)
         P3_0,P3_1,P3_2,P3_3 = 10, 11, 12, 13
         
+        scope = eval_scope(locals())
         for name, cexpr in aloha_lib.KERNEL.reduced_expr2.items():
-            exec('%s = %s' % (name, cexpr)) 
-        
-        for ind in abstract.expr.listindices():                        
-            self.assertAlmostEqual(eval(str(abstract.expr.get_rep(ind))) -
-                             eval(str(abstract_M.expr.get_rep(ind))) -
-                             eval(str(abstract_P.expr.get_rep(ind)))
+            exec('%s = %s' % (name, cexpr), scope)
+
+        for ind in abstract.expr.listindices():
+            self.assertAlmostEqual(eval(str(abstract.expr.get_rep(ind)), scope) -
+                             eval(str(abstract_M.expr.get_rep(ind)), scope) -
+                             eval(str(abstract_P.expr.get_rep(ind)), scope)
                              ,0)
         zero = abstract_M.expr + abstract_P.expr - abstract.expr
         zero.simplify()
         for ind in abstract.expr.listindices():
-            self.assertEqual(eval(str(zero.get_rep(ind))),0,'fail')
+            self.assertEqual(eval(str(zero.get_rep(ind)), scope),0,'fail')
 
     def test_short_aloha_FFVP1N(self):
         """ Check that the special routine for P1N propagator --no propagator--
@@ -3114,21 +3140,22 @@ class test_aloha_creation(IOTests.IOTestManager):
         j = complex(0,1)
         P3_0,P3_1,P3_2,P3_3 = 20, 21, 22, 23
         
-        #evaluate all contraction 
+        #evaluate all contraction
+        scope = eval_scope(locals())
         for name, cexpr in aloha_lib.KERNEL.reduced_expr2.items():
-            exec('%s = %s' % (name, cexpr))
-            
+            exec('%s = %s' % (name, cexpr), scope)
+
         # evaluate FFV_0
-        val_V = eval(str(V.expr.get_rep((0,))))
+        val_V = eval(str(V.expr.get_rep((0,))), scope)
 
         # evaluate the FFVP1N_ output -> vector
         vN1 = []
         vN2 = []
         vN3 = []
         for i in range(4):
-            vN1.append(eval(str(N1.expr.get_rep((i,)))))
-            vN2.append(eval(str(N2.expr.get_rep((i,)))))
-            vN3.append(eval(str(N3.expr.get_rep((i,)))))
+            vN1.append(eval(str(N1.expr.get_rep((i,))), scope))
+            vN2.append(eval(str(N2.expr.get_rep((i,))), scope))
+            vN3.append(eval(str(N3.expr.get_rep((i,))), scope))
         
         # contract them to get the value which should be the same as the _0
         val_N1 = F1_1 * vN1[0] + F1_2 * vN1[1] + F1_3 * vN1[2] + F1_4 * vN1[3] 
@@ -3173,13 +3200,14 @@ class test_aloha_creation(IOTests.IOTestManager):
         s3 = -j*((OM3*(P3_2*((F2_1*((F1_3*(-P3_0-P3_3))+(F1_4*(-P3_1-1*j*P3_2))))+(F2_2*((F1_3*(-P3_1+1*j*P3_2))+(F1_4*(-P3_0+P3_3)))))))+(-1*j*(F1_4*F2_1)+1*j*(F1_3*F2_2)))
         s4 = -j*((OM3*(P3_3*((F2_1*((F1_3*(-P3_0-P3_3))+(F1_4*(-P3_1-1*j*P3_2))))+(F2_2*((F1_3*(-P3_1+1*j*P3_2))+(F1_4*(-P3_0+P3_3)))))))+(-(F1_3*F2_1)+(F1_4*F2_2)))
 
+        scope = eval_scope(locals())
         for name, cexpr in aloha_lib.KERNEL.reduced_expr2.items():
-            exec('%s = %s' % (name, cexpr)) 
+            exec('%s = %s' % (name, cexpr), scope)
 
-        self.assertEqual(s1, eval(str(abstract_M.expr.get_rep([0]))))
-        self.assertEqual(s2, eval(str(abstract_M.expr.get_rep([1]))))    
-        self.assertEqual(s3, eval(str(abstract_M.expr.get_rep([2]))))    
-        self.assertEqual(s4, eval(str(abstract_M.expr.get_rep([3]))))                                   
+        self.assertEqual(s1, eval(str(abstract_M.expr.get_rep([0])), scope))
+        self.assertEqual(s2, eval(str(abstract_M.expr.get_rep([1])), scope))
+        self.assertEqual(s3, eval(str(abstract_M.expr.get_rep([2])), scope))
+        self.assertEqual(s4, eval(str(abstract_M.expr.get_rep([3])), scope))
 
         FFV_6 = self.Lorentz(name = 'FFV_6',
                 spins = [ 2, 2, 3 ],
@@ -3192,11 +3220,12 @@ class test_aloha_creation(IOTests.IOTestManager):
          
         zero = abstract_6.expr - abstract_M.expr - \
                                                     2* abstract_P.expr   
+        scope = eval_scope(locals())
         for name, cexpr in aloha_lib.KERNEL.reduced_expr2.items():
-            exec('%s = %s' % (name, cexpr)) 
+            exec('%s = %s' % (name, cexpr), scope)
         for ind in zero.listindices():
-            self.assertEqual(eval(str(zero.get_rep(ind))),0)
-        
+            self.assertEqual(eval(str(zero.get_rep(ind)), scope),0)
+
     def test_short_aloha_symmetries_and_get_info(self):
         """ test that the symmetries of particles works """
     


### PR DESCRIPTION
## Symptom

Nine tests in `tests/parallel_tests/test_aloha.py` error out locally with `NameError: name 'TMP0' is not defined` (or `TMP2`, ...):

```
./tests/test_manager.py -p P -l WARNING 'test_aloha.*'
Ran 124 tests ... FAILED (errors=9)
```

- `testLorentzObject`: `test_short_expand_veto`, `test_short_part_spin32propagator`, `test_short_spin2propagator4`
- `test_aloha_creation`: `test_short_aloha_FFT2`, `test_short_aloha_FFV`, `test_short_aloha_FFVP1N`, `test_short_aloha_FFV_MG4`, `test_short_aloha_ZPZZ`, `test_short_use_of_library_spin2`

## Root cause

Not an aloha bug. Aloha's stringification is correct, and the writers already materialise the temporaries properly (`AbstractRoutine.contracted` / `.fct`, built in `create_aloha.define_simple_output` from `KERNEL.reduced_expr2`).

The tests stringify an aloha expression and `eval()` the result. Those strings refer to the `TMP...`/`FCT...` temporaries aloha introduces for common subexpressions (`aloha_lib.Computation.add_expression_contraction`), so each test first defines them with a bare

```python
for name, cexpr in aloha_lib.KERNEL.reduced_expr2.items():
    exec('%s = %s' % (name, cexpr))
```

That only ever worked by accident. Inside a function, `exec()` with no explicit namespace writes into the dict returned by `locals()`. Before **PEP 667**, CPython cached that dict on the frame and refreshed it from the fast locals without deleting extra keys — so the `TMP0` written by `exec()` survived, and the later `eval()`, which reads the same cached dict, still saw it.

PEP 667 (**python 3.13**) makes `locals()` return an *independent snapshot* of the function scope. The `exec()` write goes into a throwaway dict, the next `eval()` gets a fresh snapshot without `TMP0`, and it raises `NameError`.

Minimal reproducer, independent of this repo:

```python
def f():
    exec('TMP0 = 3 + 4')
    return eval('TMP0')
```

`python3.9` gives `7`. `python3.14` gives `NameError: name 'TMP0' is not defined`.

So these tests were always fragile — they leaned on a CPython implementation detail — and only now trip. It is worth a real fix rather than writing it off as an environment artefact, because every interpreter from 3.13 onwards hits it.

## Why CI is green

`.github/workflows/aloha.yml` has no `setup-python` step, so `./tests/test_manager.py` (shebang `#!/usr/bin/env python3`) runs on the `ubuntu-24.04` runner's default `python3`, which is **3.12** — one release before PEP 667. The test *selection* is identical to the local one; only the interpreter differs.

## The fix

Build the namespace explicitly and pass it to both `exec()` and `eval()`, which behaves the same on every version. A small module-level helper seeds it from the module globals plus the test's own locals:

```python
def eval_scope(local_vars):
    scope = dict(globals())
    scope.update(local_vars)
    return scope
```

and each affected site becomes `scope = eval_scope(locals())`, then `exec(..., scope)` and `eval(..., scope)`. This is the idiom the generated `write_param_card.py` files in this repo already use (`exec(..., {"cmath": cmath}, local_vars)`).

Only the nine failing tests are touched, and the surrounding `try/except` structure of each site is preserved exactly, so the pre-3.13 behaviour is reproduced rather than changed.

**No assertion was loosened.** The tests still compare against the same hardcoded MG4 reference values and the same cross-checks between routines.

## Verification

`./tests/test_manager.py -p P -l WARNING 'test_aloha.*'` (124 tests), run on both interpreters available locally:

|          | python 3.9.6 (pre-PEP-667, proxy for CI's 3.12) | python 3.14.6 (PEP 667) |
|----------|------------------------------------------------|-------------------------|
| before   | OK                                             | **FAILED (errors=9)**   |
| after    | OK                                             | OK                      |

That 2x2 is the evidence for the diagnosis: the interpreter is the only variable, and the fix is version independent.

Liveness checks, so the green is not vacuous:

- The temporaries really are generated and really are consumed — `test_short_aloha_ZPZZ` builds `TMP0`..`TMP7`, `test_short_aloha_FFV_MG4` builds `TMP0`/`TMP1`.
- Negative control: perturbing the `test_short_aloha_ZPZZ` reference by one unit makes it fail with `AssertionError: 178727040j != 178727041j` — i.e. the `eval()` is genuinely producing the right value through the temporaries.

Full unit suite (`-p U`): **892 tests**, only the two known pre-existing failures (`testIO_UnitProcOutputIOTests`, order-dependent; `test_DensityMatrixObservables22`, missing scipy). No regression.

## Note on a nearby, separate issue

`.github/workflows/aloha.yml:51` is missing a space before `-e`, so the `test_short_mssm_subset_creation` exclusion is inert. That is **not** touched here — a fix already exists on `claude/fix-dead-ci-test-names` (63466ec45), which has not yet landed on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
