### PR TITLE
Make a test name matching nothing an error, and drop the dead CI jobs

### DIFF
--- a/.github/workflows/IOtest.yml
+++ b/.github/workflows/IOtest.yml
@@ -75,17 +75,6 @@ jobs:
             ./tests/test_manager.py testIO_FDgauge_standalone_fortran testIO_FDgauge_madmatrix -pA -t0
 
 
-  # C++ exporter IOTests (from unittest_20)
-  IOtest_cpp_write:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v5
-      - name: test C++ write IO tests
-        run: |
-            cd $GITHUB_WORKSPACE
-            ./tests/test_manager.py testIO_write_cpp_go_process_cc_file testIO_write_dec_multiprocess_files -t0
-
-
   # Export v4 and Python matrix element IOTests (from unittest_21, unittest_22, unittest_23)
   IOtest_export:
     runs-on: ubuntu-24.04

--- a/.github/workflows/acceptancetest.yml
+++ b/.github/workflows/acceptancetest.yml
@@ -225,26 +225,6 @@ jobs:
 
 
 
-  acceptancetest_28:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/checkout_mg5
-      - uses: ./.github/actions/restore-pip-cache
-
-      # Runs a set of commands using the runners shell
-      - name: test one of the test test_read_madgraph4_proc_card
-        run: |
-            cd $GITHUB_WORKSPACE
-            ./tests/test_manager.py test_read_madgraph4_proc_card -pA -t0 -l INFO
-
-
-
   acceptancetest_29:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
@@ -391,24 +371,6 @@ jobs:
 
 
 
-  acceptancetest_36:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/checkout_mg5
-      - uses: ./.github/actions/restore-pip-cache
-
-      # Runs a set of commands using the runners shell
-      - name: test one of the test test_v4_heft
-        run: |
-            cd $GITHUB_WORKSPACE
-            ./tests/test_manager.py test_v4_heft -pA -t0 -l INFO
-
 #
 #  installpy8:
 #    # The type of runner that the job will run on
@@ -430,68 +392,6 @@ jobs:
 #            ./bin/mg5_aMC cmd
 #
 #      # Runs a set of commands using the runners shell
-
-  acceptancetest_48:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/checkout_mg5
-
-      # Runs a set of commands using the runners shell
-      - name: test one of the test test_eft_running
-        run: |
-            cd $GITHUB_WORKSPACE
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
-            echo "install RunningCoupling" > cmd
-            ./bin/mg5_aMC cmd
-            ./tests/test_manager.py test_eft_running_nlo -pA -t0 -l INFO
-
-
-
-  acceptancetest_65:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/checkout_mg5
-      - uses: ./.github/actions/restore-pip-cache
-
-      # Runs a set of commands using the runners shell
-      - name: test one of the test test_tt_semi
-        run: |
-            cd $GITHUB_WORKSPACE
-            ./tests/test_manager.py test_tt_semi -pA -t0 -l INFO
-
-
-
-  acceptancetest_66:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/checkout_mg5
-      - uses: ./.github/actions/restore-pip-cache
-
-      # Runs a set of commands using the runners shell
-      - name: test one of the test test_zh
-        run: |
-            cd $GITHUB_WORKSPACE
-            ./tests/test_manager.py test_zh -pA -t0 -l INFO
-
-
 
   acceptancetest_67:
     # The type of runner that the job will run on

--- a/.github/workflows/aloha.yml
+++ b/.github/workflows/aloha.yml
@@ -48,7 +48,7 @@ jobs:
             cd $GITHUB_WORKSPACE
             echo "import model MSSM_SLHA2" > cmd
             ./bin/mg5_aMC cmd
-            ./tests/test_manager.py -pP -t0 test_aloha.*  testIO_aloha.*-e test_short_mssm_subset_creation
+            ./tests/test_manager.py -pP -t0 test_aloha.* -e test_short_mssm_subset_creation
 
   test_excluded:
     # excluded due to side effect

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -185,7 +185,65 @@ def find_test_in_file(path):
                     continue
                 all.append(arg)
     return all
-            
+
+# an expression made only of those characters designates a single test by name,
+# anything else is a regular expression which is allowed to select nothing.
+re_syntax = re.compile(r'[*+?\[\]{}()|\\^$]')
+
+def find_test_definition(name):
+    """ Look for the file(s) where a test called 'name' would be defined, either
+    as a function or as a module. This does not import anything: it is only used
+    to tell where a test has gone when it is not found in the requested package.
+    """
+
+    out = []
+    definition = re.compile(r'^\s*def\s+%s\s*\(' % re.escape(name), re.M)
+    for directory, dirnames, filenames in os.walk(pjoin(root_path, 'tests')):
+        dirnames[:] = [d for d in dirnames
+                            if d not in ('input_files', '__pycache__')]
+        for filename in filenames:
+            if not filename.endswith('.py'):
+                continue
+            filepath = pjoin(directory, filename)
+            if filename[:-3] != name:
+                try:
+                    text = open(filepath).read()
+                except (IOError, UnicodeDecodeError):
+                    continue
+                if not definition.search(text):
+                    continue
+            out.append(os.path.relpath(filepath, root_path))
+    return out
+
+def report_unmatched(unmatched, package):
+    """ Warn about the requested expressions which selected no test at all and
+    return those of them which are plain names. A plain name selecting nothing
+    is a typo or a test which has been renamed/moved/removed, and must not be
+    reported as a successful run.
+    """
+
+    fatal = [expr for expr in unmatched if not re_syntax.search(expr)]
+    loose = [expr for expr in unmatched if re_syntax.search(expr)]
+
+    if loose:
+        print(colored % (34, "WARNING: no test selected by: %s" %
+                                                             ' '.join(loose)))
+    if fatal:
+        print(colored % (31, "ERROR: the following requested test(s) do not "
+                             "exist in '%s':" % package))
+        for expr in fatal:
+            elsewhere = find_test_definition(expr)
+            if elsewhere:
+                print(colored % (31, "   %s (still defined in %s: wrong -p "
+                            "option?)" % (expr, ', '.join(elsewhere))))
+            else:
+                print(colored % (31, "   %s" % expr))
+        print(colored % (31, "Such a name selected no test at all: it is a "
+                    "typo, or the test has been renamed, moved or removed."))
+
+    return fatal
+
+
 #===============================================================================
 # run
 #===============================================================================
@@ -217,17 +275,23 @@ def run(expression='', re_opt=0, package='./tests/unit_tests', verbosity=1,
         exclude = []
 
 
-    for test_fct in TestFinder(package=package, expression=expression, \
-                                   re_opt=re_opt, excluded=exclude):
-        data = collect.loadTestsFromName(test_fct)        
-        assert(isinstance(data,unittest.TestSuite))        
+    finder = TestFinder(package=package, expression=expression, \
+                                   re_opt=re_opt, excluded=exclude)
+    for test_fct in finder:
+        data = collect.loadTestsFromName(test_fct)
+        assert(isinstance(data,unittest.TestSuite))
         data.__class__ = TestSuiteModified
 
         testsuite.addTest(data)
-        
+
     output =  MyTextTestRunner(verbosity=verbosity).run(testsuite)
-    
-    
+
+    # a name explicitly asked for which selects nothing has to be an error,
+    # otherwise a test removed/renamed silently keeps on being "OK" forever.
+    output.unmatched_names = report_unmatched(finder.unmatched_expressions(),
+                                              package)
+
+
     
     
     if TestSuiteModified.time_limit < 0:
@@ -649,7 +713,8 @@ class TestFinder(list):
 
         self.package = package
         self.rule = []
-        if self.package[-1] != '/': 
+        self.collected = False
+        if self.package[-1] != '/':
             self.package += '/'
         self.restrict_to(expression, re_opt)
         self.launch_pos = ''
@@ -659,11 +724,12 @@ class TestFinder(list):
             self.excluded = excluded
 
     def _check_if_obj_build(self):
-        """ Check if a collect is already done 
+        """ Check if a collect is already done
             Uses to have smart __iter__ and __contain__ functions
         """
-        if len(self) == 0:
+        if len(self) == 0 and not self.collected:
             start = time.time()
+            self.collected = True
             self.collect_dir(self.package, checking=True)
             print('loading test takes %ss'  % (time.time()-start))
     def __iter__(self):
@@ -763,15 +829,20 @@ class TestFinder(list):
         """
 
         if isinstance(expression, list):
-            pass
+            requested = list(expression)
         elif isinstance(expression, str):
             if expression in '':
                 expression = ['.*'] #made an re authorizing all regular name
+                requested = [] # nothing asked for: everything is selected
             else:
                 expression = [expression]
+                requested = list(expression)
         else:
             raise self.TestFinderError('obj should be list or string')
 
+        # what the caller explicitly asked for, aligned with self.rule, so that
+        # we can tell afterwards which of those selected no test at all.
+        self.requested = requested
         self.rule = []
         for expr in expression:
             #fix the beginning/end of the regular expression
@@ -889,6 +960,52 @@ class TestFinder(list):
         add_to_possibility(out, new_pos)
 
         return out
+
+    def collected_possibility(self, name):
+        """ return the different names under which a collected test, given in
+        the 'module.path.TestClass.test_function' format, could have been asked
+        for: the function, the class, the file or any of its parent directories.
+        """
+
+        pieces = name.split('.')
+        if len(pieces) < 2:
+            return [name]
+
+        out = [name, pieces[-1], pieces[-2], '.'.join(pieces[-2:])]
+        directories = pieces[:-2]
+        # the module itself (with the .py extension) and each directory above it
+        for i in range(len(directories), 0, -1):
+            pos = '/'.join(directories[:i])
+            if i == len(directories):
+                pos += '.py'
+            for possibility in self.format_possibility(pos):
+                if possibility not in out:
+                    out.append(possibility)
+
+        return out
+
+    def unmatched_expressions(self):
+        """ return the explicitly requested expressions which do not select any
+        of the collected tests, i.e. those pointing to a test which does not
+        exist (anymore) in this package.
+        """
+
+        if not self.requested:
+            return []
+
+        self._check_if_obj_build()
+        aliases = set()
+        for name in self:
+            aliases.update(self.collected_possibility(name))
+
+        unmatched = []
+        for expr, rule in zip(self.requested, self.rule):
+            if not expr:
+                continue
+            if not any(rule.search(alias) for alias in aliases):
+                unmatched.append(expr)
+
+        return unmatched
 
     def go_to_root(self):
         """ 
@@ -1171,6 +1288,8 @@ https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/DevelopmentPage/CodeTesting
         output = runIOTests(args,update=options.IOTests=='U',force=force,
                                                 synchronize=options.synchronize)
 
+    # keep it aside: output is replaced by a string by the notification below
+    unmatched_names = getattr(output, 'unmatched_names', [])
 
     if 0 < float(options.notification) < time.time()-start_time:
         if isinstance(output, unittest.runner.TextTestResult):
@@ -1189,6 +1308,9 @@ https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/DevelopmentPage/CodeTesting
                                (output.failures, output.errors, output.skipped)))
         if failed or errored or skipped:
             sys.exit(1)
+
+    if unmatched_names:
+        sys.exit(1)
 #some example
 #    run('iolibs')
 #    run('test_test_manager.py')

--- a/tests/unit_tests/various/test_test_finder.py
+++ b/tests/unit_tests/various/test_test_finder.py
@@ -16,8 +16,73 @@
 """Unit test library for the Misc routine library in the I/O package"""
 
 from __future__ import absolute_import
+import contextlib
+import io
 import tests.unit_tests as unittest
 import tests.test_manager as test_manager
+
+#===============================================================================
+# TestUnmatchedExpression
+#===============================================================================
+class TestUnmatchedExpression(unittest.TestCase):
+    """Check that a test name asked for on the command line but selecting no
+    test at all is reported, so that a renamed/removed test can not keep on
+    being silently 'OK' in the CI."""
+
+    test_path = 'tests/unit_tests/various'
+
+    def finder(self, expression):
+        return test_manager.TestFinder(package=self.test_path,
+                                       expression=expression)
+
+    def test_unmatched_on_unknown_name(self):
+        """a name which matches nothing is reported"""
+
+        finder = self.finder(['test_no_such_test_anywhere'])
+        self.assertEqual(finder.unmatched_expressions(),
+                         ['test_no_such_test_anywhere'])
+
+    def test_unmatched_keeps_the_valid_names(self):
+        """only the names selecting nothing are reported"""
+
+        finder = self.finder(['test_unmatched_on_unknown_name',
+                              'test_no_such_test_anywhere'])
+        self.assertEqual(finder.unmatched_expressions(),
+                         ['test_no_such_test_anywhere'])
+
+    def test_unmatched_on_class_module_and_regexp(self):
+        """a class, a module or a regular expression can select a test as well"""
+
+        for expression in ['TestUnmatchedExpression', 'test_test_finder',
+                           'test_test_finder.py',
+                           'tests/unit_tests/various/test_test_finder.py',
+                           'test_unmatched_on_class.*']:
+            finder = self.finder([expression])
+            self.assertEqual(finder.unmatched_expressions(), [],
+                             'wrongly reported as unknown: %s' % expression)
+
+    def test_unmatched_on_directory(self):
+        """a directory below the searched package selects all its tests"""
+
+        finder = test_manager.TestFinder(package='tests/unit_tests',
+                                         expression=['various'])
+        self.assertEqual(finder.unmatched_expressions(), [])
+
+    def test_unmatched_empty_when_nothing_requested(self):
+        """the bulk modes (no name given) never report anything"""
+
+        self.assertEqual(self.finder('').unmatched_expressions(), [])
+        self.assertEqual(self.finder([]).unmatched_expressions(), [])
+
+    def test_only_a_plain_name_is_fatal(self):
+        """a regular expression is allowed to select nothing, a name is not"""
+
+        report = io.StringIO()
+        with contextlib.redirect_stdout(report):
+            fatal = test_manager.report_unmatched(['test_gone', 'test_gone_.*'],
+                                                  self.test_path)
+        self.assertEqual(fatal, ['test_gone'])
+        self.assertIn('test_gone_.*', report.getvalue())
 
 #===============================================================================
 # TestTestFinder


### PR DESCRIPTION
`tests/test_manager.py` reported `OK` when a requested name selected zero tests, so a CI job kept being green long after its test had been renamed or deleted.

## test_manager.py

`TestFinder` now remembers what was explicitly asked for (`restrict_to`) and can tell which of those expressions selected none of the collected tests (`unmatched_expressions`, using `collected_possibility` to recognise a selection made by function, class, module or directory name). `run()` reports them and the script exits 1.

- A plain name selecting nothing is an **error**.
- A regular expression is only a **warning**, since it is allowed to select nothing.
- The bulk modes (no name given, `-p U` / `-p A`) are untouched.
- When the name still exists elsewhere under `tests/`, the error says where, since that is usually a wrong `-p` option.

## Dead CI jobs removed

| job | test | gone since |
| --- | --- | --- |
| `acceptancetest_28` | `test_read_madgraph4_proc_card` | deleted in 977292129 |
| `acceptancetest_36` | `test_v4_heft` | disabled (`notest_`) in 360366ab1, v4 not supported anymore |
| `acceptancetest_48` | `test_eft_running_nlo` | disabled (`notest_`) in 6dc8390b9 -- the surviving LO `test_eft_running` is already run by `acceptancetest_madevent.yml` |
| `acceptancetest_65` / `acceptancetest_66` | `test_tt_semi` / `test_zh` | deleted with madweight in 9d3c959d2, which did remove those two jobs; a later merge brought them back |
| `IOtest_cpp_write` | `testIO_write_cpp_go_process_cc_file`, `testIO_write_dec_multiprocess_files` | deleted with the pythia8 export tests in c83282d40, which cleaned `unittest.yml` but not `IOtest.yml` |

## aloha.yml

`testIO_aloha.*-e` was a missing space, so no `testIO_aloha` test was ever selected (none exists) and the `-e` exclusion was inert, running `test_short_mssm_subset_creation` in the very batch it is meant to be kept out of.

## Validation

Rebased from `claude/fix-dead-ci-test-names` (one conflict, in `IOtest.yml`, where main added the `IOtest_fd_gauge` job next to the removed `IOtest_cpp_write` one -- both kept/removed as intended). The change content is otherwise identical to the original commit.

On this branch:
- All seven removed test names still have zero definitions under `tests/`.
- Every `test_manager.py` invocation in `.github/workflows/*.yml` was replayed against the new `unmatched_expressions` check (including the `madspin_parallel.yml` matrix expansion): **no surviving job trips the new error**. The only skipped invocation is the regex in `check_xsec_processes_mg7.yml`, which is warn-only by design.
- `./tests/test_manager.py test_test_finder -t0` -> 6 tests, OK, exit 0.
- `./tests/test_manager.py test_read_madgraph4_proc_card -pA -t0` -> error reported, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
