### PR TITLE
MadSpace stream handling for external users

### DIFF
--- a/madspace/include/madspace/driver/backend.hpp
+++ b/madspace/include/madspace/driver/backend.hpp
@@ -19,6 +19,9 @@ public:
         const std::vector<bool>& eval_grad,
         bool return_contiguous_grads = false
     ) = 0;
+    // inputs of a call that returned before the work reading them was done are held
+    // until it is. every call releases what is done, this does it without calling
+    virtual void release_inputs() {}
     friend std::unique_ptr<Runtime>
     build_runtime(const Function& function, ContextPtr context, bool concurrent);
 

--- a/madspace/include/madspace/driver/backend.hpp
+++ b/madspace/include/madspace/driver/backend.hpp
@@ -19,8 +19,6 @@ public:
         const std::vector<bool>& eval_grad,
         bool return_contiguous_grads = false
     ) = 0;
-    // inputs of a call that returned before the work reading them was done are held
-    // until it is. every call releases what is done, this does it without calling
     virtual void release_inputs() {}
     friend std::unique_ptr<Runtime>
     build_runtime(const Function& function, ContextPtr context, bool concurrent);

--- a/madspace/include/madspace/driver/context.hpp
+++ b/madspace/include/madspace/driver/context.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
+#include <optional>
 #include <unordered_map>
 
 #include "madspace/compgraphs.hpp"
@@ -199,6 +200,13 @@ ContextPtr default_context();
 ContextPtr default_cuda_context(std::size_t index = 0);
 ContextPtr default_hip_context(std::size_t index = 0);
 ContextPtr default_device_context(DevicePtr device);
+
+// stream the caller expects madspace to use. an empty optional means that madspace
+// uses its own streams and synchronizes before returning, 0 is the legacy default
+// stream and a valid choice. thread-local, so it has to be set on every thread that
+// calls into madspace, torch autograd workers included
+std::optional<std::uintptr_t> caller_stream();
+void set_caller_stream(std::optional<std::uintptr_t> stream);
 
 inline std::string prefixed_name(const std::string& prefix, const std::string& name) {
     return prefix == "" ? name : std::format("{}.{}", prefix, name);

--- a/madspace/include/madspace/driver/context.hpp
+++ b/madspace/include/madspace/driver/context.hpp
@@ -178,7 +178,7 @@ public:
     void load_globals(const std::string& dir);
     DevicePtr device() { return _device; }
     ThreadPool& thread_pool() { return *_thread_pool; }
-    Tensor cached_tensor(std::size_t size, std::uintptr_t stream);
+    Tensor cached_tensor(std::size_t size);
     void reset_cache() {
         _tensor_cache = ThreadResource<TensorVec>(
             thread_pool(), []() { return TensorVec{}; }
@@ -201,14 +201,10 @@ ContextPtr default_cuda_context(std::size_t index = 0);
 ContextPtr default_hip_context(std::size_t index = 0);
 ContextPtr default_device_context(DevicePtr device);
 
-// stream the caller expects madspace to use. an empty optional means that madspace
-// uses its own streams and synchronizes before returning, 0 is the legacy default
-// stream and keeps them too, because putting the main stream on the legacy stream
-// would serialize the lanes. thread-local, so it has to be set on every thread that
-// calls into madspace, torch autograd workers included. only run() returns without
-// synchronizing, since torch's end-of-backward sync does not cover the param.grad
-// assignment in torch.py; its results are then ordered on the caller's stream alone,
-// so consume them there or copy them out before the next call reuses the pool
+// stream that madspace should run on. an empty optional means it uses its own streams
+// and synchronizes before returning, 0 keeps them too because running the main stream
+// on the legacy stream would serialize the lanes. thread-local, so every thread that
+// calls into madspace has to set it. only run() returns without synchronizing
 std::optional<std::uintptr_t> caller_stream();
 std::optional<std::uintptr_t> caller_input_stream();
 void set_caller_stream(std::optional<std::uintptr_t> stream, bool order_inputs = true);

--- a/madspace/include/madspace/driver/context.hpp
+++ b/madspace/include/madspace/driver/context.hpp
@@ -178,7 +178,7 @@ public:
     void load_globals(const std::string& dir);
     DevicePtr device() { return _device; }
     ThreadPool& thread_pool() { return *_thread_pool; }
-    Tensor cached_tensor(std::size_t size);
+    Tensor cached_tensor(std::size_t size, std::uintptr_t stream);
     void reset_cache() {
         _tensor_cache = ThreadResource<TensorVec>(
             thread_pool(), []() { return TensorVec{}; }
@@ -203,10 +203,15 @@ ContextPtr default_device_context(DevicePtr device);
 
 // stream the caller expects madspace to use. an empty optional means that madspace
 // uses its own streams and synchronizes before returning, 0 is the legacy default
-// stream and a valid choice. thread-local, so it has to be set on every thread that
-// calls into madspace, torch autograd workers included
+// stream and keeps them too, because putting the main stream on the legacy stream
+// would serialize the lanes. thread-local, so it has to be set on every thread that
+// calls into madspace, torch autograd workers included. only run() returns without
+// synchronizing, since torch's end-of-backward sync does not cover the param.grad
+// assignment in torch.py; its results are then ordered on the caller's stream alone,
+// so consume them there or copy them out before the next call reuses the pool
 std::optional<std::uintptr_t> caller_stream();
-void set_caller_stream(std::optional<std::uintptr_t> stream);
+std::optional<std::uintptr_t> caller_input_stream();
+void set_caller_stream(std::optional<std::uintptr_t> stream, bool order_inputs = true);
 
 inline std::string prefixed_name(const std::string& prefix, const std::string& name) {
     return prefix == "" ? name : std::format("{}.{}", prefix, name);

--- a/madspace/include/madspace/driver/context.hpp
+++ b/madspace/include/madspace/driver/context.hpp
@@ -204,10 +204,11 @@ ContextPtr default_device_context(DevicePtr device);
 // stream that madspace should run on. an empty optional means it uses its own streams
 // and synchronizes before returning, 0 keeps them too because running the main stream
 // on the legacy stream would serialize the lanes. thread-local, so every thread that
-// calls into madspace has to set it. only run() returns without synchronizing
+// calls into madspace has to set it. only run() returns without synchronizing. inputs
+// are ordered against it through the dlpack protocol either way, with the legacy stream
+// standing in for it when it is empty
 std::optional<std::uintptr_t> caller_stream();
-std::optional<std::uintptr_t> caller_input_stream();
-void set_caller_stream(std::optional<std::uintptr_t> stream, bool order_inputs = true);
+void set_caller_stream(std::optional<std::uintptr_t> stream);
 
 inline std::string prefixed_name(const std::string& prefix, const std::string& name) {
     return prefix == "" ? name : std::format("{}.{}", prefix, name);

--- a/madspace/include/madspace/driver/context.hpp
+++ b/madspace/include/madspace/driver/context.hpp
@@ -201,8 +201,7 @@ ContextPtr default_cuda_context(std::size_t index = 0);
 ContextPtr default_hip_context(std::size_t index = 0);
 ContextPtr default_device_context(DevicePtr device);
 
-// thread-local stream to run on, empty to use our own and synchronize. 0 also keeps
-// ours, running the main stream on the legacy stream would serialize the lanes
+// thread-local stream to run on, empty to use our own and synchronize. 0 keeps ours
 std::optional<std::uintptr_t> caller_stream();
 void set_caller_stream(std::optional<std::uintptr_t> stream);
 

--- a/madspace/include/madspace/driver/context.hpp
+++ b/madspace/include/madspace/driver/context.hpp
@@ -201,12 +201,8 @@ ContextPtr default_cuda_context(std::size_t index = 0);
 ContextPtr default_hip_context(std::size_t index = 0);
 ContextPtr default_device_context(DevicePtr device);
 
-// stream that madspace should run on. an empty optional means it uses its own streams
-// and synchronizes before returning, 0 keeps them too because running the main stream
-// on the legacy stream would serialize the lanes. thread-local, so every thread that
-// calls into madspace has to set it. only run() returns without synchronizing. inputs
-// are ordered against it through the dlpack protocol either way, with the legacy stream
-// standing in for it when it is empty
+// thread-local stream to run on, empty to use our own and synchronize. 0 also keeps
+// ours, running the main stream on the legacy stream would serialize the lanes
 std::optional<std::uintptr_t> caller_stream();
 void set_caller_stream(std::optional<std::uintptr_t> stream);
 

--- a/madspace/include/madspace/driver/tensor.hpp
+++ b/madspace/include/madspace/driver/tensor.hpp
@@ -214,6 +214,7 @@ public:
     virtual const Device* device_ptr() const = 0;
     virtual void sync_barrier() const {}
     virtual DeviceType device_type() const = 0;
+    virtual int device_index() const { return 0; }
     virtual void activate() const = 0;
     virtual void adam_step(
         const Tensor& gradient,
@@ -389,6 +390,7 @@ public:
         );
     }
 
+    // the free fails once the cuda runtime has shut down, and this cannot throw
     ~Tensor() {
         try {
             reset();
@@ -485,8 +487,6 @@ public:
         check_impl();
         return impl->device;
     }
-    // stream to order against before touching the storage, empty when there is
-    // nothing left to wait for
     std::optional<std::uintptr_t> stream() const {
         return impl == nullptr ? std::nullopt : storage()->stream;
     }
@@ -531,7 +531,6 @@ public:
         if (impl == nullptr) {
             return;
         }
-        // the free can throw, and it has taken the reference either way
         std::exchange(impl, nullptr)->reset(device);
     }
 

--- a/madspace/include/madspace/driver/tensor.hpp
+++ b/madspace/include/madspace/driver/tensor.hpp
@@ -204,6 +204,7 @@ public:
     allocate(std::size_t size, AllocHint hint) const = 0;
     virtual void free(void* ptr) const = 0;
     virtual void free_on_stream(void* ptr, std::uintptr_t stream) const { free(ptr); }
+    virtual void order_streams(std::uintptr_t from, std::uintptr_t to) const {}
     virtual void memcpy(void* to, void* from, std::size_t size) const = 0;
     virtual void tensor_copy(const Tensor& source, Tensor& target) const = 0;
     virtual void tensor_zero(Tensor& tensor) const = 0;
@@ -475,6 +476,16 @@ public:
         check_impl();
         return impl->device;
     }
+    // stream to order against before touching the storage, empty when there is
+    // nothing left to wait for
+    std::optional<std::uintptr_t> stream() const {
+        return impl == nullptr ? std::nullopt : impl->stream;
+    }
+    void set_stream(std::optional<std::uintptr_t> stream) {
+        if (impl != nullptr) {
+            impl->stream = stream;
+        }
+    }
     std::size_t index_value() const {
         check_impl();
         if (impl->batch_sizes.size() > 0) {
@@ -500,7 +511,7 @@ public:
 
     std::size_t byte_size() const { return dtype_size() * shape().product(); }
 
-    void reset() { reset_on_stream(0); }
+    void reset() { reset_on_stream(stream().value_or(0)); }
 
     template <typename D>
     void reset(const D& device) {
@@ -638,6 +649,7 @@ private:
         std::size_t contiguous_dims;
         SizeVec batch_sizes;
         bool stream_ordered = false;
+        std::optional<std::uintptr_t> stream;
 
         template <typename D>
         void reset(const D& device) {

--- a/madspace/include/madspace/driver/tensor.hpp
+++ b/madspace/include/madspace/driver/tensor.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <functional>
 #include <initializer_list>
+#include <utility>
 #include <vector>
 
 namespace madspace {
@@ -405,7 +406,10 @@ public:
     }
 
     Tensor& operator=(Tensor&& other) noexcept {
-        reset();
+        try {
+            reset();
+        } catch (...) {
+        }
         impl = other.impl;
         other.impl = nullptr;
         return *this;
@@ -527,16 +531,15 @@ public:
         if (impl == nullptr) {
             return;
         }
-        impl->reset(device);
-        impl = nullptr;
+        // the free can throw, and it has taken the reference either way
+        std::exchange(impl, nullptr)->reset(device);
     }
 
     void reset_on_stream(std::uintptr_t stream) {
         if (impl == nullptr) {
             return;
         }
-        impl->reset_on_stream(stream);
-        impl = nullptr;
+        std::exchange(impl, nullptr)->reset_on_stream(stream);
     }
 
     Tensor select(std::size_t axis, std::size_t index) const;
@@ -731,6 +734,7 @@ private:
             ++tensor_count;
             if constexpr (requires { D::stream_ordered_alloc; }) {
                 impl->stream_ordered = D::stream_ordered_alloc;
+                impl->stream = reinterpret_cast<std::uintptr_t>(device.stream());
             }
         }
     }

--- a/madspace/include/madspace/driver/tensor.hpp
+++ b/madspace/include/madspace/driver/tensor.hpp
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <functional>
 #include <initializer_list>
-#include <utility>
+#include <optional>
 #include <vector>
 
 namespace madspace {
@@ -200,12 +200,14 @@ inline bool needs_zero_init(AllocHint hint) {
 
 class Device {
 public:
+    static constexpr bool stream_ordered_alloc = false;
+
     virtual ~Device() = default;
     virtual std::pair<void*, Tensor>
     allocate(std::size_t size, AllocHint hint) const = 0;
     virtual void free(void* ptr) const = 0;
-    virtual void free_on_stream(void* ptr, std::uintptr_t stream) const { free(ptr); }
-    virtual void order_streams(std::uintptr_t from, std::uintptr_t to) const {}
+    virtual void free_on_stream(void* ptr, void* stream) const { free(ptr); }
+    virtual void order_streams(void* from, void* to) const {}
     virtual void memcpy(void* to, void* from, std::size_t size) const = 0;
     virtual void tensor_copy(const Tensor& source, Tensor& target) const = 0;
     virtual void tensor_zero(Tensor& tensor) const = 0;
@@ -214,7 +216,6 @@ public:
     virtual const Device* device_ptr() const = 0;
     virtual void sync_barrier() const {}
     virtual DeviceType device_type() const = 0;
-    virtual int device_index() const { return 0; }
     virtual void activate() const = 0;
     virtual void adam_step(
         const Tensor& gradient,
@@ -390,7 +391,6 @@ public:
         );
     }
 
-    // the free fails once the cuda runtime has shut down, and this cannot throw
     ~Tensor() {
         try {
             reset();
@@ -531,14 +531,19 @@ public:
         if (impl == nullptr) {
             return;
         }
-        std::exchange(impl, nullptr)->reset(device);
+        // released before the free, which can throw
+        TensorImpl* owner = impl;
+        impl = nullptr;
+        owner->reset(device);
     }
 
     void reset_on_stream(std::uintptr_t stream) {
         if (impl == nullptr) {
             return;
         }
-        std::exchange(impl, nullptr)->reset_on_stream(stream);
+        TensorImpl* owner = impl;
+        impl = nullptr;
+        owner->reset_on_stream(stream);
     }
 
     Tensor select(std::size_t axis, std::size_t index) const;
@@ -684,7 +689,7 @@ private:
             }
             if (owns_data && data != nullptr) {
                 if (stream_ordered) {
-                    device->free_on_stream(data, stream);
+                    device->free_on_stream(data, reinterpret_cast<void*>(stream));
                 } else {
                     device->free(data);
                 }
@@ -731,8 +736,8 @@ private:
             impl->data_owner = parent.impl;
         } else if (data != nullptr) {
             ++tensor_count;
-            if constexpr (requires { D::stream_ordered_alloc; }) {
-                impl->stream_ordered = D::stream_ordered_alloc;
+            if constexpr (D::stream_ordered_alloc) {
+                impl->stream_ordered = true;
                 impl->stream = reinterpret_cast<std::uintptr_t>(device.stream());
             }
         }

--- a/madspace/include/madspace/driver/tensor.hpp
+++ b/madspace/include/madspace/driver/tensor.hpp
@@ -203,6 +203,7 @@ public:
     virtual std::pair<void*, Tensor>
     allocate(std::size_t size, AllocHint hint) const = 0;
     virtual void free(void* ptr) const = 0;
+    virtual void free_on_stream(void* ptr, std::uintptr_t stream) const { free(ptr); }
     virtual void memcpy(void* to, void* from, std::size_t size) const = 0;
     virtual void tensor_copy(const Tensor& source, Tensor& target) const = 0;
     virtual void tensor_zero(Tensor& tensor) const = 0;
@@ -499,13 +500,7 @@ public:
 
     std::size_t byte_size() const { return dtype_size() * shape().product(); }
 
-    void reset() {
-        if (impl == nullptr) {
-            return;
-        }
-        impl->reset(*impl->device);
-        impl = nullptr;
-    }
+    void reset() { reset_on_stream(0); }
 
     template <typename D>
     void reset(const D& device) {
@@ -513,6 +508,14 @@ public:
             return;
         }
         impl->reset(device);
+        impl = nullptr;
+    }
+
+    void reset_on_stream(std::uintptr_t stream) {
+        if (impl == nullptr) {
+            return;
+        }
+        impl->reset_on_stream(stream);
         impl = nullptr;
     }
 
@@ -634,6 +637,7 @@ private:
         Sizes stride;
         std::size_t contiguous_dims;
         SizeVec batch_sizes;
+        bool stream_ordered = false;
 
         template <typename D>
         void reset(const D& device) {
@@ -645,6 +649,25 @@ private:
                 --Tensor::tensor_count;
             } else if (data_owner != nullptr) {
                 data_owner->reset(device);
+            } else if (external_reset) {
+                (*external_reset)();
+            }
+            delete this;
+        }
+
+        void reset_on_stream(std::uintptr_t stream) {
+            if (ref_count.fetch_sub(1, std::memory_order_acq_rel) != 1) {
+                return;
+            }
+            if (owns_data && data != nullptr) {
+                if (stream_ordered) {
+                    device->free_on_stream(data, stream);
+                } else {
+                    device->free(data);
+                }
+                --Tensor::tensor_count;
+            } else if (data_owner != nullptr) {
+                data_owner->reset_on_stream(stream);
             } else if (external_reset) {
                 (*external_reset)();
             }
@@ -677,6 +700,9 @@ private:
             impl->data_owner = parent.impl;
         } else if (data != nullptr) {
             ++tensor_count;
+            if constexpr (requires { D::stream_ordered_alloc; }) {
+                impl->stream_ordered = D::stream_ordered_alloc;
+            }
         }
     }
 

--- a/madspace/include/madspace/driver/tensor.hpp
+++ b/madspace/include/madspace/driver/tensor.hpp
@@ -388,7 +388,12 @@ public:
         );
     }
 
-    ~Tensor() { reset(); }
+    ~Tensor() {
+        try {
+            reset();
+        } catch (...) {
+        }
+    }
 
     Tensor& operator=(const Tensor& other) {
         reset();
@@ -479,11 +484,15 @@ public:
     // stream to order against before touching the storage, empty when there is
     // nothing left to wait for
     std::optional<std::uintptr_t> stream() const {
-        return impl == nullptr ? std::nullopt : impl->stream;
+        return impl == nullptr ? std::nullopt : storage()->stream;
     }
     void set_stream(std::optional<std::uintptr_t> stream) {
-        if (impl != nullptr) {
-            impl->stream = stream;
+        if (impl == nullptr) {
+            return;
+        }
+        TensorImpl* owner = storage();
+        if (owner->stream_ordered) {
+            owner->stream = stream;
         }
     }
     std::size_t index_value() const {
@@ -688,6 +697,14 @@ private:
 
         void incref() { ref_count.fetch_add(1, std::memory_order_relaxed); }
     };
+
+    TensorImpl* storage() const {
+        TensorImpl* item = impl;
+        while (item->data_owner != nullptr) {
+            item = item->data_owner;
+        }
+        return item;
+    }
 
     Tensor(TensorImpl* _impl) : impl(_impl) {
         if (impl->data_owner != nullptr) {

--- a/madspace/include/madspace/driver/thread_pool.hpp
+++ b/madspace/include/madspace/driver/thread_pool.hpp
@@ -72,15 +72,17 @@ public:
         std::optional<std::function<void(T&)>> destructor = std::nullopt
     ) :
         _pool(&pool),
+        _constructor(std::move(constructor)),
         _destructor(destructor),
-        _listener_id(pool.add_listener([this, constructor](std::size_t thread_count) {
+        _listener_id(pool.add_listener([this](std::size_t thread_count) {
             while (_resources.size() < thread_count) {
-                _resources.push_back(constructor());
+                _resources.emplace_back();
             }
         })) {
         for (std::size_t i = 0; i == 0 || i < pool.thread_count(); ++i) {
-            _resources.push_back(constructor());
+            _resources.emplace_back();
         }
+        get();
     }
     ~ThreadResource() {
         reset();
@@ -88,6 +90,7 @@ public:
     ThreadResource(ThreadResource&& other) noexcept :
         _pool(std::move(other._pool)),
         _resources(std::move(other._resources)),
+        _constructor(std::move(other._constructor)),
         _listener_id(std::move(other._listener_id)),
         _destructor(std::move(other._destructor)) {
         other._pool = nullptr;
@@ -97,6 +100,7 @@ public:
         reset();
         _pool = std::move(other._pool);
         _resources = std::move(other._resources);
+        _constructor = std::move(other._constructor);
         _listener_id = std::move(other._listener_id);
         _destructor = std::move(other._destructor);
         other._pool = nullptr;
@@ -104,13 +108,21 @@ public:
     }
     ThreadResource(const ThreadResource&) = delete;
     ThreadResource& operator=(const ThreadResource&) = delete;
-    T& get() { return _resources.at(ThreadPool::thread_index()); }
-    const T& get() const { return _resources.at(ThreadPool::thread_index()); }
+    T& get() const {
+        auto& [flag, item] = _resources.at(ThreadPool::thread_index());
+        std::call_once(flag, [&] {
+            std::unique_lock<std::mutex> lock(construction_mutex());
+            item.emplace(_constructor());
+        });
+        return *item;
+    }
     void reset() {
         if (_pool) {
             if (_destructor) {
-                for (auto& item : _resources) {
-                    _destructor.value()(item);
+                for (auto& [flag, item] : _resources) {
+                    if (item) {
+                        _destructor.value()(*item);
+                    }
                 }
             }
             _pool->remove_listener(_listener_id);
@@ -118,8 +130,14 @@ public:
     }
 
 private:
+    static std::mutex& construction_mutex() {
+        static std::mutex mutex;
+        return mutex;
+    }
+
     ThreadPool* _pool = nullptr;
-    std::vector<T> _resources;
+    mutable std::deque<std::pair<std::once_flag, std::optional<T>>> _resources;
+    std::function<T()> _constructor;
     std::size_t _listener_id;
     std::optional<std::function<void(T&)>> _destructor;
 };

--- a/madspace/madspace/_madspace_py_loader.py
+++ b/madspace/madspace/_madspace_py_loader.py
@@ -21,12 +21,8 @@ from ._madspace_py import *
 @contextlib.contextmanager
 def stream(handle):
     """
-    Run the calls on the given cuda stream instead of madspace's own, handle being an
-    integer such as torch.cuda.current_stream().cuda_stream, or None to go back. They
-    then return without synchronizing, so consume the results on this stream and keep it
-    alive until everything madspace handed out has been dropped, as the frees are
-    ordered on it. Inputs from another framework are held until the work reading them is
-    done, which the next call releases, as does release_inputs. Thread-local.
+    Run the calls on the given cuda stream instead of madspace's own, without
+    synchronizing. Keep it alive until everything madspace handed out has been dropped.
     """
     previous = get_stream()
     set_stream(handle)

--- a/madspace/madspace/_madspace_py_loader.py
+++ b/madspace/madspace/_madspace_py_loader.py
@@ -21,11 +21,11 @@ from ._madspace_py import *
 @contextlib.contextmanager
 def stream(handle, order_inputs=True):
     """
-    Run madspace on the given cuda stream instead of its own. Calls without gradients
-    then return without synchronizing, so consume their results on this stream or copy
-    them out before the next call reuses the memory pool, and drop them before the
-    stream is destroyed. Inputs are ordered against it through the dlpack protocol
-    unless order_inputs is false.
+    Run the mapping and function calls on the given cuda stream instead of madspace's
+    own. Calls without gradients then return without synchronizing, so keep the inputs
+    alive, consume the results on this stream and drop everything before the stream is
+    destroyed. Inputs are ordered against it through the dlpack protocol unless
+    order_inputs is false.
     """
     previous, previous_inputs = get_stream(), get_input_stream()
     set_stream(handle, order_inputs)
@@ -33,36 +33,6 @@ def stream(handle, order_inputs=True):
         yield
     finally:
         set_stream(previous, previous_inputs is not None)
-
-
-@contextlib.contextmanager
-def _torch_stream(args):
-    """
-    Run on torch's current stream when every argument is torch's and one is on the gpu.
-    They are already ordered against it, so the producers are not asked for a handshake;
-    a foreign producer gets one, because we cannot know which stream it is on.
-    """
-    on_gpu = False
-    for arg in args:
-        if type(arg).__module__.partition(".")[0] == "torch":
-            on_gpu = on_gpu or getattr(arg, "is_cuda", False)
-        elif hasattr(arg, "__dlpack__"):
-            yield
-            return
-    if not on_gpu or get_stream() is not None:
-        yield
-        return
-    import torch
-
-    handle = torch.cuda.current_stream().cuda_stream
-    if handle == 2:  # per-thread default, which set_stream rejects
-        yield
-        return
-    set_stream(handle, False)
-    try:
-        yield
-    finally:
-        set_stream(None)
 
 
 def _init():
@@ -76,8 +46,7 @@ def _init():
             tensorlib = "numpy"
         else:
             tensorlib = type(args[0]).__module__
-        with _torch_stream(args):
-            outputs = runtime.call(args)
+        outputs = runtime.call(args)
         # Convert outputs, lazy-loading torch or numpy
         if tensorlib == "torch":
             import torch

--- a/madspace/madspace/_madspace_py_loader.py
+++ b/madspace/madspace/_madspace_py_loader.py
@@ -1,3 +1,4 @@
+import contextlib
 import ctypes
 import logging
 import os
@@ -17,6 +18,53 @@ ctypes.CDLL(
 from ._madspace_py import *
 
 
+@contextlib.contextmanager
+def stream(handle, order_inputs=True):
+    """
+    Run madspace on the given cuda stream instead of its own. Calls without gradients
+    then return without synchronizing, so consume their results on this stream or copy
+    them out before the next call reuses the memory pool, and drop them before the
+    stream is destroyed. Inputs are ordered against it through the dlpack protocol
+    unless order_inputs is false.
+    """
+    previous, previous_inputs = get_stream(), get_input_stream()
+    set_stream(handle, order_inputs)
+    try:
+        yield
+    finally:
+        set_stream(previous, previous_inputs is not None)
+
+
+@contextlib.contextmanager
+def _torch_stream(args):
+    """
+    Run on torch's current stream when every argument is torch's and one is on the gpu.
+    They are already ordered against it, so the producers are not asked for a handshake;
+    a foreign producer gets one, because we cannot know which stream it is on.
+    """
+    on_gpu = False
+    for arg in args:
+        if type(arg).__module__.partition(".")[0] == "torch":
+            on_gpu = on_gpu or getattr(arg, "is_cuda", False)
+        elif hasattr(arg, "__dlpack__"):
+            yield
+            return
+    if not on_gpu or get_stream() is not None:
+        yield
+        return
+    import torch
+
+    handle = torch.cuda.current_stream().cuda_stream
+    if handle == 2:  # per-thread default, which set_stream rejects
+        yield
+        return
+    set_stream(handle, False)
+    try:
+        yield
+    finally:
+        set_stream(None)
+
+
 def _init():
     """
     Monkey-patch classes for a more pythonic experience.
@@ -28,7 +76,8 @@ def _init():
             tensorlib = "numpy"
         else:
             tensorlib = type(args[0]).__module__
-        outputs = runtime.call(args)
+        with _torch_stream(args):
+            outputs = runtime.call(args)
         # Convert outputs, lazy-loading torch or numpy
         if tensorlib == "torch":
             import torch

--- a/madspace/madspace/_madspace_py_loader.py
+++ b/madspace/madspace/_madspace_py_loader.py
@@ -19,20 +19,20 @@ from ._madspace_py import *
 
 
 @contextlib.contextmanager
-def stream(handle, order_inputs=True):
+def stream(handle):
     """
     Run the mapping and function calls on the given cuda stream instead of madspace's
-    own. Calls without gradients then return without synchronizing, so keep the inputs
-    alive, consume the results on this stream and drop everything before the stream is
-    destroyed. Inputs are ordered against it through the dlpack protocol unless
-    order_inputs is false.
+    own. Calls without gradients then return without synchronizing, so consume the
+    results on this stream and drop everything before the stream is destroyed. Inputs
+    are held until the work reading them is done, which every call takes care of, as
+    does release_inputs for the work that has finished by then.
     """
-    previous, previous_inputs = get_stream(), get_input_stream()
-    set_stream(handle, order_inputs)
+    previous = get_stream()
+    set_stream(handle)
     try:
         yield
     finally:
-        set_stream(previous, previous_inputs is not None)
+        set_stream(previous)
 
 
 def _init():
@@ -143,8 +143,16 @@ def _init():
     FunctionRuntime.__call__ = runtime_call
     Function.__call__ = function_call
     FunctionGenerator.__call__ = function_generator_call
+    def release_inputs(self):
+        for name in ("runtime", "forward_runtime", "inverse_runtime"):
+            if hasattr(self, name):
+                getattr(self, name).release_inputs()
+
     Mapping.map_forward = map_forward
     Mapping.map_inverse = map_inverse
+    Function.release_inputs = release_inputs
+    FunctionGenerator.release_inputs = release_inputs
+    Mapping.release_inputs = release_inputs
     Tensor.numpy = tensor_numpy
     Tensor.torch = tensor_torch
     # Logger.set_log_handler(log_handler)

--- a/madspace/madspace/_madspace_py_loader.py
+++ b/madspace/madspace/_madspace_py_loader.py
@@ -21,11 +21,12 @@ from ._madspace_py import *
 @contextlib.contextmanager
 def stream(handle):
     """
-    Run the mapping and function calls on the given cuda stream instead of madspace's
-    own. Calls without gradients then return without synchronizing, so consume the
-    results on this stream and drop everything before the stream is destroyed. Inputs
-    are held until the work reading them is done, which every call takes care of, as
-    does release_inputs for the work that has finished by then.
+    Run the calls on the given cuda stream instead of madspace's own, handle being an
+    integer such as torch.cuda.current_stream().cuda_stream, or None to go back. They
+    then return without synchronizing, so consume the results on this stream and keep it
+    alive until everything madspace handed out has been dropped, as the frees are
+    ordered on it. Inputs from another framework are held until the work reading them is
+    done, which the next call releases, as does release_inputs. Thread-local.
     """
     previous = get_stream()
     set_stream(handle)
@@ -45,7 +46,7 @@ def _init():
         if len(args) == 0:
             tensorlib = "numpy"
         else:
-            tensorlib = type(args[0]).__module__
+            tensorlib = type(args[0]).__module__.partition(".")[0]
         outputs = runtime.call(args)
         # Convert outputs, lazy-loading torch or numpy
         if tensorlib == "torch":
@@ -140,14 +141,14 @@ def _init():
             case Logger.level_error:
                 py_logger.error(message)
 
-    FunctionRuntime.__call__ = runtime_call
-    Function.__call__ = function_call
-    FunctionGenerator.__call__ = function_generator_call
     def release_inputs(self):
         for name in ("runtime", "forward_runtime", "inverse_runtime"):
             if hasattr(self, name):
                 getattr(self, name).release_inputs()
 
+    FunctionRuntime.__call__ = runtime_call
+    Function.__call__ = function_call
+    FunctionGenerator.__call__ = function_generator_call
     Mapping.map_forward = map_forward
     Mapping.map_inverse = map_inverse
     Function.release_inputs = release_inputs

--- a/madspace/madspace/torch.py
+++ b/madspace/madspace/torch.py
@@ -53,6 +53,9 @@ class AutogradWrapper(torch.autograd.Function):
         )
         ctx.module = module
         ctx.eval_grad = eval_grad
+        # backward runs on autograd's thread, which the thread-local does not reach,
+        # but on the stream of the forward call
+        ctx.stream = me.get_stream()
         ctx.save_for_backward(
             *(None if grad is None else torch.from_dlpack(grad) for grad in local_grads)
         )
@@ -64,9 +67,10 @@ class AutogradWrapper(torch.autograd.Function):
     @staticmethod
     @once_differentiable
     def backward(ctx: FunctionCtx, *output_grads: torch.Tensor):
-        input_grads, global_grads = ctx.module.runtime.call_backward(
-            output_grads, ctx.saved_tensors, ctx.eval_grad
-        )
+        with me.stream(ctx.stream):
+            input_grads, global_grads = ctx.module.runtime.call_backward(
+                output_grads, ctx.saved_tensors, ctx.eval_grad
+            )
         for name, grad in global_grads:
             if grad is None:
                 continue

--- a/madspace/madspace/torch.py
+++ b/madspace/madspace/torch.py
@@ -33,8 +33,7 @@ class FunctionModule(nn.Module):
         if torch.is_grad_enabled():
             return AutogradWrapper.apply(self, self.dummy, *args)
         else:
-            with me._torch_stream(args):
-                outputs = self.runtime.call(args)
+            outputs = self.runtime.call(args)
             if len(outputs) == 1:
                 return torch.from_dlpack(outputs[0])
             else:
@@ -49,10 +48,9 @@ class AutogradWrapper(torch.autograd.Function):
         dummy: torch.Tensor,
         *args: torch.Tensor,
     ) -> list[torch.Tensor]:
-        with me._torch_stream(args):
-            outputs, local_grads, eval_grad = module.runtime.call_with_grad(
-                [arg.detach() for arg in args], [arg.requires_grad for arg in args]
-            )
+        outputs, local_grads, eval_grad = module.runtime.call_with_grad(
+            [arg.detach() for arg in args], [arg.requires_grad for arg in args]
+        )
         ctx.module = module
         ctx.eval_grad = eval_grad
         ctx.save_for_backward(
@@ -66,10 +64,9 @@ class AutogradWrapper(torch.autograd.Function):
     @staticmethod
     @once_differentiable
     def backward(ctx: FunctionCtx, *output_grads: torch.Tensor):
-        with me._torch_stream(output_grads):
-            input_grads, global_grads = ctx.module.runtime.call_backward(
-                output_grads, ctx.saved_tensors, ctx.eval_grad
-            )
+        input_grads, global_grads = ctx.module.runtime.call_backward(
+            output_grads, ctx.saved_tensors, ctx.eval_grad
+        )
         for name, grad in global_grads:
             if grad is None:
                 continue

--- a/madspace/madspace/torch.py
+++ b/madspace/madspace/torch.py
@@ -56,9 +56,7 @@ class AutogradWrapper(torch.autograd.Function):
         )
         ctx.module = module
         ctx.eval_grad = eval_grad
-        # backward runs on autograd's thread, which the thread-local does not reach
         ctx.stream = me.get_stream()
-        # save_for_backward would hide our own memory from the runtime, which holds it
         ctx.stored_locals = local_grads
         if len(outputs) == 1:
             return torch.from_dlpack(outputs[0])

--- a/madspace/madspace/torch.py
+++ b/madspace/madspace/torch.py
@@ -33,7 +33,8 @@ class FunctionModule(nn.Module):
         if torch.is_grad_enabled():
             return AutogradWrapper.apply(self, self.dummy, *args)
         else:
-            outputs = self.runtime.call(args)
+            with me._torch_stream(args):
+                outputs = self.runtime.call(args)
             if len(outputs) == 1:
                 return torch.from_dlpack(outputs[0])
             else:
@@ -48,9 +49,10 @@ class AutogradWrapper(torch.autograd.Function):
         dummy: torch.Tensor,
         *args: torch.Tensor,
     ) -> list[torch.Tensor]:
-        outputs, local_grads, eval_grad = module.runtime.call_with_grad(
-            [arg.detach() for arg in args], [arg.requires_grad for arg in args]
-        )
+        with me._torch_stream(args):
+            outputs, local_grads, eval_grad = module.runtime.call_with_grad(
+                [arg.detach() for arg in args], [arg.requires_grad for arg in args]
+            )
         ctx.module = module
         ctx.eval_grad = eval_grad
         ctx.save_for_backward(
@@ -64,9 +66,10 @@ class AutogradWrapper(torch.autograd.Function):
     @staticmethod
     @once_differentiable
     def backward(ctx: FunctionCtx, *output_grads: torch.Tensor):
-        input_grads, global_grads = ctx.module.runtime.call_backward(
-            output_grads, ctx.saved_tensors, ctx.eval_grad
-        )
+        with me._torch_stream(output_grads):
+            input_grads, global_grads = ctx.module.runtime.call_backward(
+                output_grads, ctx.saved_tensors, ctx.eval_grad
+            )
         for name, grad in global_grads:
             if grad is None:
                 continue

--- a/madspace/madspace/torch.py
+++ b/madspace/madspace/torch.py
@@ -29,11 +29,14 @@ class FunctionModule(nn.Module):
             ),
         )
 
+    def release_inputs(self) -> None:
+        self.runtime.release_inputs()
+
     def forward(self, *args: torch.Tensor) -> list[torch.Tensor]:
         if torch.is_grad_enabled():
             return AutogradWrapper.apply(self, self.dummy, *args)
         else:
-            outputs = self.runtime.call(args)
+            outputs = self.runtime.call([arg.detach() for arg in args])
             if len(outputs) == 1:
                 return torch.from_dlpack(outputs[0])
             else:
@@ -53,12 +56,10 @@ class AutogradWrapper(torch.autograd.Function):
         )
         ctx.module = module
         ctx.eval_grad = eval_grad
-        # backward runs on autograd's thread, which the thread-local does not reach,
-        # but on the stream of the forward call
+        # backward runs on autograd's thread, which the thread-local does not reach
         ctx.stream = me.get_stream()
-        ctx.save_for_backward(
-            *(None if grad is None else torch.from_dlpack(grad) for grad in local_grads)
-        )
+        # save_for_backward would hide our own memory from the runtime, which holds it
+        ctx.stored_locals = local_grads
         if len(outputs) == 1:
             return torch.from_dlpack(outputs[0])
         else:
@@ -69,7 +70,7 @@ class AutogradWrapper(torch.autograd.Function):
     def backward(ctx: FunctionCtx, *output_grads: torch.Tensor):
         with me.stream(ctx.stream):
             input_grads, global_grads = ctx.module.runtime.call_backward(
-                output_grads, ctx.saved_tensors, ctx.eval_grad
+                output_grads, ctx.stored_locals, ctx.eval_grad
             )
         for name, grad in global_grads:
             if grad is None:

--- a/madspace/src/cpu/runtime.cpp
+++ b/madspace/src/cpu/runtime.cpp
@@ -1172,8 +1172,24 @@ CpuRuntime::CpuRuntime(const Function& function, ContextPtr context, bool concur
         );
     }
 
+    std::vector<bool> grad_accumulated(function.locals().size());
+    SizeVec output_counts(function.locals().size());
+    for (auto& instr : function.instructions()) {
+        for (auto& in : instr.inputs) {
+            grad_accumulated.at(in.local_index) = true;
+        }
+    }
+    for (auto& out : function.outputs()) {
+        ++output_counts.at(out.local_index);
+    }
     for (auto& out : function.outputs()) {
         _output_indices.push_back(out.local_index);
+        // an output that is read again or returned twice is accumulated into, and that
+        // must not happen in the caller's tensor
+        _copy_output_grads.push_back(
+            grad_accumulated.at(out.local_index) ||
+            output_counts.at(out.local_index) > 1
+        );
     }
 }
 
@@ -1294,8 +1310,19 @@ std::pair<TensorVec, TensorVec> CpuRuntime::run_backward_single(
     auto& device = CpuDevice::instance();
     TensorVec local_grads(stored_locals.size());
     TensorVec locals(stored_locals);
-    for (auto [index, grad] : zip(_output_indices, output_grads)) {
-        local_grads[index] = grad;
+    for (auto [index, grad, copy] :
+         zip(_output_indices, output_grads, _copy_output_grads)) {
+        auto& local_grad = local_grads[index];
+        if (!grad) {
+            continue;
+        }
+        if (local_grad) {
+            local_grad.add(grad);
+        } else if (copy) {
+            local_grad = grad.copy(AllocHint::local_grad);
+        } else {
+            local_grad = grad;
+        }
     }
 
     Tensor all_global_grads(
@@ -1304,6 +1331,10 @@ std::pair<TensorVec, TensorVec> CpuRuntime::run_backward_single(
     // all_global_grads.zero();
     TensorVec global_grads = all_global_grads.split_and_reshape(_grad_global_shapes);
     for (auto [index, grad] : zip(_grad_global_indices, global_grads)) {
+        // a global that is also an output was seeded above
+        if (local_grads[index]) {
+            grad.add(local_grads[index]);
+        }
         local_grads[index] = grad;
     }
 
@@ -1474,8 +1505,19 @@ std::pair<TensorVec, TensorVec> CpuRuntime::run_backward_concurrent(
     auto& thread_pool = _context->thread_pool();
     TensorVec local_grads(stored_locals.size());
     TensorVec locals(stored_locals);
-    for (auto [index, grad] : zip(_output_indices, output_grads)) {
-        local_grads[index] = grad;
+    for (auto [index, grad, copy] :
+         zip(_output_indices, output_grads, _copy_output_grads)) {
+        auto& local_grad = local_grads[index];
+        if (!grad) {
+            continue;
+        }
+        if (local_grad) {
+            local_grad.add(grad);
+        } else if (copy) {
+            local_grad = grad.copy(AllocHint::local_grad);
+        } else {
+            local_grad = grad;
+        }
     }
 
     Tensor all_global_grads(
@@ -1484,6 +1526,10 @@ std::pair<TensorVec, TensorVec> CpuRuntime::run_backward_concurrent(
     // all_global_grads.zero();
     TensorVec global_grads = all_global_grads.split_and_reshape(_grad_global_shapes);
     for (auto [index, grad] : zip(_grad_global_indices, global_grads)) {
+        // a global that is also an output was seeded above
+        if (local_grads[index]) {
+            grad.add(local_grads[index]);
+        }
         local_grads[index] = grad;
     }
 

--- a/madspace/src/cpu/runtime.cpp
+++ b/madspace/src/cpu/runtime.cpp
@@ -1184,8 +1184,6 @@ CpuRuntime::CpuRuntime(const Function& function, ContextPtr context, bool concur
     }
     for (auto& out : function.outputs()) {
         _output_indices.push_back(out.local_index);
-        // an output that is read again or returned twice is accumulated into, and that
-        // must not happen in the caller's tensor
         _copy_output_grads.push_back(
             grad_accumulated.at(out.local_index) ||
             output_counts.at(out.local_index) > 1
@@ -1331,7 +1329,6 @@ std::pair<TensorVec, TensorVec> CpuRuntime::run_backward_single(
     // all_global_grads.zero();
     TensorVec global_grads = all_global_grads.split_and_reshape(_grad_global_shapes);
     for (auto [index, grad] : zip(_grad_global_indices, global_grads)) {
-        // a global that is also an output was seeded above
         if (local_grads[index]) {
             grad.add(local_grads[index]);
         }
@@ -1526,7 +1523,6 @@ std::pair<TensorVec, TensorVec> CpuRuntime::run_backward_concurrent(
     // all_global_grads.zero();
     TensorVec global_grads = all_global_grads.split_and_reshape(_grad_global_shapes);
     for (auto [index, grad] : zip(_grad_global_indices, global_grads)) {
-        // a global that is also an output was seeded above
         if (local_grads[index]) {
             grad.add(local_grads[index]);
         }

--- a/madspace/src/cpu/runtime.hpp
+++ b/madspace/src/cpu/runtime.hpp
@@ -76,6 +76,7 @@ private:
 
     std::vector<Instruction> _instructions;
     SizeVec _output_indices;
+    std::vector<bool> _copy_output_grads;
     std::size_t _input_count;
     TensorVec _locals_init;
     std::vector<bool> _requires_grad_init;

--- a/madspace/src/driver/context.cpp
+++ b/madspace/src/driver/context.cpp
@@ -96,7 +96,7 @@ MatrixElementApi::MatrixElementApi(
         );
     }
 
-    _instances = ThreadResource<InstanceType>(thread_pool, [&, device] {
+    _instances = ThreadResource<InstanceType>(thread_pool, [this, device, param_card] {
         device->activate();
         void* instance;
         check_umami_status(_initialize(&instance, param_card.c_str()));

--- a/madspace/src/driver/context.cpp
+++ b/madspace/src/driver/context.cpp
@@ -310,9 +310,7 @@ void Context::load_globals(const std::string& dir) {
     }
 }
 
-// shared by every runtime on this context, so a block only comes back out on its
-// own stream
-Tensor Context::cached_tensor(std::size_t size, std::uintptr_t stream) {
+Tensor Context::cached_tensor(std::size_t size) {
     auto& tensors = _tensor_cache.get();
     int largest_unused = -1, size_pos = 0;
     for (int i = 0; auto& tensor : tensors) {
@@ -320,7 +318,7 @@ Tensor Context::cached_tensor(std::size_t size, std::uintptr_t stream) {
         if (size >= byte_size) {
             size_pos = i;
         }
-        if (tensor.is_only_reference() && tensor.stream() == stream) {
+        if (tensor.is_only_reference()) {
             if (byte_size >= size) {
                 return tensor;
             }
@@ -336,7 +334,6 @@ Tensor Context::cached_tensor(std::size_t size, std::uintptr_t stream) {
     }
     std::size_t word_count = (size + 7) / 8;
     Tensor new_tensor(DataType::dt_float, {word_count}, device());
-    new_tensor.set_stream(stream);
     tensors.insert(tensors.begin() + size_pos, new_tensor);
     return new_tensor;
 }
@@ -357,6 +354,8 @@ ContextPtr madspace::default_hip_context(std::size_t index) {
 }
 
 ContextPtr madspace::default_device_context(DevicePtr device) {
+    // leaked on purpose, the contexts hold gpu resources that must not be freed
+    // after the cuda runtime has shut down
     static auto& default_contexts = *new std::unordered_map<DevicePtr, ContextPtr>;
     if (auto search = default_contexts.find(device); search != default_contexts.end()) {
         return search->second;

--- a/madspace/src/driver/context.cpp
+++ b/madspace/src/driver/context.cpp
@@ -3,6 +3,7 @@
 #include <dlfcn.h>
 #include <filesystem>
 #include <nlohmann/json.hpp>
+#include <stdexcept>
 #include <unordered_map>
 
 #include "madspace/driver/io.hpp"
@@ -353,7 +354,6 @@ ContextPtr madspace::default_hip_context(std::size_t index) {
 }
 
 ContextPtr madspace::default_device_context(DevicePtr device) {
-    // leaked on purpose, the gpu resources must not be freed at interpreter exit
     static auto& default_contexts = *new std::unordered_map<DevicePtr, ContextPtr>;
     if (auto search = default_contexts.find(device); search != default_contexts.end()) {
         return search->second;
@@ -372,7 +372,7 @@ void madspace::set_caller_stream(std::optional<std::uintptr_t> stream) {
     if (stream && *stream == 2) {
         throw std::invalid_argument("the per-thread default stream is not supported");
     }
-    // dlpack spells the legacy stream 1 on cuda, we spell it 0 everywhere
+    // cuda spells the legacy stream 1 and the per-thread one 2, we spell ours 0
     current_caller_stream =
         stream && *stream == 1 ? std::optional<std::uintptr_t>(0) : stream;
 }

--- a/madspace/src/driver/context.cpp
+++ b/madspace/src/driver/context.cpp
@@ -12,6 +12,7 @@ using json = nlohmann::json;
 
 namespace {
 UmamiStatus umami_key_query_not_implemented(bool const**, int*) { return UMAMI_ERROR_NOT_IMPLEMENTED; }
+thread_local std::optional<std::uintptr_t> current_caller_stream;
 } // namespace
 
 MatrixElementApi::MatrixElementApi(
@@ -360,4 +361,12 @@ ContextPtr madspace::default_device_context(DevicePtr device) {
         default_contexts[device] = context;
         return context;
     }
+}
+
+std::optional<std::uintptr_t> madspace::caller_stream() {
+    return current_caller_stream;
+}
+
+void madspace::set_caller_stream(std::optional<std::uintptr_t> stream) {
+    current_caller_stream = stream;
 }

--- a/madspace/src/driver/context.cpp
+++ b/madspace/src/driver/context.cpp
@@ -13,7 +13,6 @@ using json = nlohmann::json;
 namespace {
 UmamiStatus umami_key_query_not_implemented(bool const**, int*) { return UMAMI_ERROR_NOT_IMPLEMENTED; }
 thread_local std::optional<std::uintptr_t> current_caller_stream;
-thread_local bool current_caller_orders_inputs = true;
 } // namespace
 
 MatrixElementApi::MatrixElementApi(
@@ -370,18 +369,11 @@ std::optional<std::uintptr_t> madspace::caller_stream() {
     return current_caller_stream;
 }
 
-std::optional<std::uintptr_t> madspace::caller_input_stream() {
-    return current_caller_orders_inputs ? current_caller_stream : std::nullopt;
-}
-
-void madspace::set_caller_stream(
-    std::optional<std::uintptr_t> stream, bool order_inputs
-) {
+void madspace::set_caller_stream(std::optional<std::uintptr_t> stream) {
     if (stream && *stream == 2) {
         throw std::invalid_argument("the per-thread default stream is not supported");
     }
     // dlpack spells the legacy stream 1 on cuda, we spell it 0 everywhere
     current_caller_stream =
         stream && *stream == 1 ? std::optional<std::uintptr_t>(0) : stream;
-    current_caller_orders_inputs = order_inputs;
 }

--- a/madspace/src/driver/context.cpp
+++ b/madspace/src/driver/context.cpp
@@ -99,8 +99,11 @@ MatrixElementApi::MatrixElementApi(
         void* instance;
         check_umami_status(_initialize(&instance, param_card.c_str()));
         return InstanceType(instance, [this, device](void* proc) {
-            device->activate();
-            _free(proc);
+            try {
+                device->activate();
+                _free(proc);
+            } catch (...) {
+            }
         });
     });
 }
@@ -349,7 +352,7 @@ ContextPtr madspace::default_hip_context(std::size_t index) {
 }
 
 ContextPtr madspace::default_device_context(DevicePtr device) {
-    static std::unordered_map<DevicePtr, ContextPtr> default_contexts;
+    static auto& default_contexts = *new std::unordered_map<DevicePtr, ContextPtr>;
     if (auto search = default_contexts.find(device); search != default_contexts.end()) {
         return search->second;
     } else {

--- a/madspace/src/driver/context.cpp
+++ b/madspace/src/driver/context.cpp
@@ -13,6 +13,7 @@ using json = nlohmann::json;
 namespace {
 UmamiStatus umami_key_query_not_implemented(bool const**, int*) { return UMAMI_ERROR_NOT_IMPLEMENTED; }
 thread_local std::optional<std::uintptr_t> current_caller_stream;
+thread_local bool current_caller_orders_inputs = true;
 } // namespace
 
 MatrixElementApi::MatrixElementApi(
@@ -309,7 +310,9 @@ void Context::load_globals(const std::string& dir) {
     }
 }
 
-Tensor Context::cached_tensor(std::size_t size) {
+// shared by every runtime on this context, so a block only comes back out on its
+// own stream
+Tensor Context::cached_tensor(std::size_t size, std::uintptr_t stream) {
     auto& tensors = _tensor_cache.get();
     int largest_unused = -1, size_pos = 0;
     for (int i = 0; auto& tensor : tensors) {
@@ -317,7 +320,7 @@ Tensor Context::cached_tensor(std::size_t size) {
         if (size >= byte_size) {
             size_pos = i;
         }
-        if (tensor.is_only_reference()) {
+        if (tensor.is_only_reference() && tensor.stream() == stream) {
             if (byte_size >= size) {
                 return tensor;
             }
@@ -333,6 +336,7 @@ Tensor Context::cached_tensor(std::size_t size) {
     }
     std::size_t word_count = (size + 7) / 8;
     Tensor new_tensor(DataType::dt_float, {word_count}, device());
+    new_tensor.set_stream(stream);
     tensors.insert(tensors.begin() + size_pos, new_tensor);
     return new_tensor;
 }
@@ -367,6 +371,18 @@ std::optional<std::uintptr_t> madspace::caller_stream() {
     return current_caller_stream;
 }
 
-void madspace::set_caller_stream(std::optional<std::uintptr_t> stream) {
-    current_caller_stream = stream;
+std::optional<std::uintptr_t> madspace::caller_input_stream() {
+    return current_caller_orders_inputs ? current_caller_stream : std::nullopt;
+}
+
+void madspace::set_caller_stream(
+    std::optional<std::uintptr_t> stream, bool order_inputs
+) {
+    if (stream && *stream == 2) {
+        throw std::invalid_argument("the per-thread default stream is not supported");
+    }
+    // dlpack spells the legacy stream 1 on cuda, we spell it 0 everywhere
+    current_caller_stream =
+        stream && *stream == 1 ? std::optional<std::uintptr_t>(0) : stream;
+    current_caller_orders_inputs = order_inputs;
 }

--- a/madspace/src/driver/context.cpp
+++ b/madspace/src/driver/context.cpp
@@ -353,8 +353,7 @@ ContextPtr madspace::default_hip_context(std::size_t index) {
 }
 
 ContextPtr madspace::default_device_context(DevicePtr device) {
-    // leaked on purpose, the contexts hold gpu resources that must not be freed
-    // after the cuda runtime has shut down
+    // leaked on purpose, the gpu resources must not be freed at interpreter exit
     static auto& default_contexts = *new std::unordered_map<DevicePtr, ContextPtr>;
     if (auto search = default_contexts.find(device); search != default_contexts.end()) {
         return search->second;

--- a/madspace/src/gpu/device.cu
+++ b/madspace/src/gpu/device.cu
@@ -26,6 +26,17 @@ void GpuDevice::free_on_stream(void* ptr, std::uintptr_t stream) const {
     ignore_error(gpuFreeAsync(ptr, reinterpret_cast<gpuStream_t>(stream)));
 }
 
+void GpuDevice::order_streams(std::uintptr_t from, std::uintptr_t to) const {
+    activate();
+    static thread_local gpuEvent_t event = [] {
+        gpuEvent_t created;
+        check_error(gpuEventCreate(&created));
+        return created;
+    }();
+    check_error(gpuEventRecord(event, reinterpret_cast<gpuStream_t>(from)));
+    check_error(gpuStreamWaitEvent(reinterpret_cast<gpuStream_t>(to), event));
+}
+
 void GpuDevice::memcpy(void* to, void* from, std::size_t size) const {
     activate();
     check_error(gpuMemcpy(to, from, size, gpuMemcpyDefault));

--- a/madspace/src/gpu/device.cu
+++ b/madspace/src/gpu/device.cu
@@ -91,7 +91,7 @@ MemPool::MemPool(
         cached_sizes_and_tensors,
     gpuStream_t stream
 ) :
-    _device(device) {
+    _device(device), _stream(stream) {
     std::size_t pool_count = 0;
     for (auto& [pool_index, size, parent_tensor, zero_init] :
          cached_sizes_and_tensors) {
@@ -128,7 +128,9 @@ MemPool::~MemPool() {
             for (auto& [size, item] : stream_free_pointers) {
                 auto& [ptr, parent] = item;
                 if (!parent) {
-                    _device.free_on_stream(ptr, 0);
+                    _device.free_on_stream(
+                        ptr, reinterpret_cast<std::uintptr_t>(_stream)
+                    );
                 }
             }
         }

--- a/madspace/src/gpu/device.cu
+++ b/madspace/src/gpu/device.cu
@@ -6,6 +6,19 @@ using namespace madspace;
 using namespace madspace::gpu;
 using namespace madspace::kernels;
 
+namespace {
+// the operations below run on the per-thread default stream, which is not ordered
+// against the stream these tensors were left on
+template <typename... T>
+void wait_for(const T&... tensors) {
+    for (const Tensor* tensor : {&tensors...}) {
+        if (auto stream = tensor->stream()) {
+            check_error(gpuStreamSynchronize(reinterpret_cast<gpuStream_t>(*stream)));
+        }
+    }
+}
+} // namespace
+
 std::pair<void*, Tensor> GpuDevice::allocate(std::size_t size, AllocHint hint) const {
     activate();
     void* ptr;
@@ -47,24 +60,28 @@ void GpuDevice::memcpy(void* to, void* from, std::size_t size) const {
 
 void GpuDevice::tensor_copy(const Tensor& source, Tensor& target) const {
     activate();
+    wait_for(source, target);
     AsyncGpuDevice(*this, gpuStreamPerThread, 0).tensor_copy(source, target);
     check_error(gpuStreamSynchronize(gpuStreamPerThread));
 }
 
 void GpuDevice::tensor_zero(Tensor& tensor) const {
     activate();
+    wait_for(tensor);
     AsyncGpuDevice(*this, gpuStreamPerThread, 0).tensor_zero(tensor);
     check_error(gpuStreamSynchronize(gpuStreamPerThread));
 }
 
 void GpuDevice::tensor_add(const Tensor& source, Tensor& target) const {
     activate();
+    wait_for(source, target);
     AsyncGpuDevice(*this, gpuStreamPerThread, 0).tensor_add(source, target);
     check_error(gpuStreamSynchronize(gpuStreamPerThread));
 }
 
 void GpuDevice::tensor_cpu(const Tensor& source, Tensor& target) const {
     activate();
+    wait_for(source);
     check_error(
         gpuMemcpy(target.data(), source.data(), source.byte_size(), gpuMemcpyDefault)
     );
@@ -83,6 +100,7 @@ void GpuDevice::adam_step(
     double weight_decay
 ) const {
     activate();
+    wait_for(gradient, parameter, exp_avg, exp_avg_sq);
     AsyncGpuDevice device(*this, gpuStreamPerThread, 0);
     tensor_foreach_dynamic<kernel_adam_step<GpuTypes>, 1, 3>(
         {&gradient},

--- a/madspace/src/gpu/device.cu
+++ b/madspace/src/gpu/device.cu
@@ -21,6 +21,11 @@ void GpuDevice::free(void* ptr) const {
     check_error(gpuFree(ptr));
 }
 
+void GpuDevice::free_on_stream(void* ptr, std::uintptr_t stream) const {
+    activate();
+    check_error(gpuFreeAsync(ptr, reinterpret_cast<gpuStream_t>(stream)));
+}
+
 void GpuDevice::memcpy(void* to, void* from, std::size_t size) const {
     activate();
     check_error(gpuMemcpy(to, from, size, gpuMemcpyDefault));
@@ -123,7 +128,7 @@ MemPool::~MemPool() {
             for (auto& [size, item] : stream_free_pointers) {
                 auto& [ptr, parent] = item;
                 if (!parent) {
-                    check_error(gpuFree(ptr));
+                    _device.free_on_stream(ptr, 0);
                 }
             }
         }

--- a/madspace/src/gpu/device.cu
+++ b/madspace/src/gpu/device.cu
@@ -125,7 +125,6 @@ MemPool::MemPool(
             pool.capacity = parent_tensor.byte_size();
         } else {
             pool.parent_tensor = Tensor(DataType::dt_float, {word_count}, async_device);
-            pool.parent_tensor.set_stream(reinterpret_cast<std::uintptr_t>(stream));
             pool.capacity = word_count * 8;
         }
         pool.needed_size = word_count * 8;

--- a/madspace/src/gpu/device.cu
+++ b/madspace/src/gpu/device.cu
@@ -1,5 +1,6 @@
 #include "../kernels/kernels.hpp"
 #include "device.hpp"
+#include "madspace/driver/context.hpp"
 #include "tensor.cuh"
 
 using namespace madspace;
@@ -7,10 +8,12 @@ using namespace madspace::gpu;
 using namespace madspace::kernels;
 
 namespace {
-// the operations below run on the per-thread default stream, which is not ordered
-// against the stream these tensors were left on
 template <typename... T>
 void wait_for(const T&... tensors) {
+    auto caller = caller_stream();
+    if (caller && *caller != 0) {
+        check_error(gpuStreamSynchronize(reinterpret_cast<gpuStream_t>(*caller)));
+    }
     for (const Tensor* tensor : {&tensors...}) {
         if (auto stream = tensor->stream()) {
             check_error(gpuStreamSynchronize(reinterpret_cast<gpuStream_t>(*stream)));
@@ -34,12 +37,12 @@ void GpuDevice::free(void* ptr) const {
     check_error(gpuFree(ptr));
 }
 
-void GpuDevice::free_on_stream(void* ptr, std::uintptr_t stream) const {
+void GpuDevice::free_on_stream(void* ptr, void* stream) const {
     activate();
-    check_error(gpuFreeAsync(ptr, reinterpret_cast<gpuStream_t>(stream)));
+    check_error(gpuFreeAsync(ptr, static_cast<gpuStream_t>(stream)));
 }
 
-void GpuDevice::order_streams(std::uintptr_t from, std::uintptr_t to) const {
+void GpuDevice::order_streams(void* from, void* to) const {
     activate();
     static thread_local std::vector<gpuEvent_t> events;
     if (events.size() <= static_cast<std::size_t>(_index)) {
@@ -49,8 +52,8 @@ void GpuDevice::order_streams(std::uintptr_t from, std::uintptr_t to) const {
     if (!event) {
         check_error(gpuEventCreate(&event));
     }
-    check_error(gpuEventRecord(event, reinterpret_cast<gpuStream_t>(from)));
-    check_error(gpuStreamWaitEvent(reinterpret_cast<gpuStream_t>(to), event));
+    check_error(gpuEventRecord(event, static_cast<gpuStream_t>(from)));
+    check_error(gpuStreamWaitEvent(static_cast<gpuStream_t>(to), event));
 }
 
 void GpuDevice::memcpy(void* to, void* from, std::size_t size) const {
@@ -161,9 +164,7 @@ MemPool::~MemPool() {
                 auto& [ptr, parent] = item;
                 if (!parent) {
                     try {
-                        _device.free_on_stream(
-                            ptr, reinterpret_cast<std::uintptr_t>(_stream)
-                        );
+                        _device.free_on_stream(ptr, _stream);
                     } catch (...) {
                     }
                 }

--- a/madspace/src/gpu/device.cu
+++ b/madspace/src/gpu/device.cu
@@ -17,22 +17,25 @@ std::pair<void*, Tensor> GpuDevice::allocate(std::size_t size, AllocHint hint) c
 }
 
 void GpuDevice::free(void* ptr) const {
-    ignore_error(gpuSetDevice(_index));
-    ignore_error(gpuFree(ptr));
+    activate();
+    check_error(gpuFree(ptr));
 }
 
 void GpuDevice::free_on_stream(void* ptr, std::uintptr_t stream) const {
-    ignore_error(gpuSetDevice(_index));
-    ignore_error(gpuFreeAsync(ptr, reinterpret_cast<gpuStream_t>(stream)));
+    activate();
+    check_error(gpuFreeAsync(ptr, reinterpret_cast<gpuStream_t>(stream)));
 }
 
 void GpuDevice::order_streams(std::uintptr_t from, std::uintptr_t to) const {
     activate();
-    static thread_local gpuEvent_t event = [] {
-        gpuEvent_t created;
-        check_error(gpuEventCreate(&created));
-        return created;
-    }();
+    static thread_local std::vector<gpuEvent_t> events;
+    if (events.size() <= static_cast<std::size_t>(_index)) {
+        events.resize(_index + 1);
+    }
+    gpuEvent_t& event = events.at(_index);
+    if (!event) {
+        check_error(gpuEventCreate(&event));
+    }
     check_error(gpuEventRecord(event, reinterpret_cast<gpuStream_t>(from)));
     check_error(gpuStreamWaitEvent(reinterpret_cast<gpuStream_t>(to), event));
 }
@@ -122,6 +125,7 @@ MemPool::MemPool(
             pool.capacity = parent_tensor.byte_size();
         } else {
             pool.parent_tensor = Tensor(DataType::dt_float, {word_count}, async_device);
+            pool.parent_tensor.set_stream(reinterpret_cast<std::uintptr_t>(stream));
             pool.capacity = word_count * 8;
         }
         pool.needed_size = word_count * 8;
@@ -139,9 +143,12 @@ MemPool::~MemPool() {
             for (auto& [size, item] : stream_free_pointers) {
                 auto& [ptr, parent] = item;
                 if (!parent) {
-                    _device.free_on_stream(
-                        ptr, reinterpret_cast<std::uintptr_t>(_stream)
-                    );
+                    try {
+                        _device.free_on_stream(
+                            ptr, reinterpret_cast<std::uintptr_t>(_stream)
+                        );
+                    } catch (...) {
+                    }
                 }
             }
         }

--- a/madspace/src/gpu/device.cu
+++ b/madspace/src/gpu/device.cu
@@ -17,13 +17,13 @@ std::pair<void*, Tensor> GpuDevice::allocate(std::size_t size, AllocHint hint) c
 }
 
 void GpuDevice::free(void* ptr) const {
-    activate();
-    check_error(gpuFree(ptr));
+    ignore_error(gpuSetDevice(_index));
+    ignore_error(gpuFree(ptr));
 }
 
 void GpuDevice::free_on_stream(void* ptr, std::uintptr_t stream) const {
-    activate();
-    check_error(gpuFreeAsync(ptr, reinterpret_cast<gpuStream_t>(stream)));
+    ignore_error(gpuSetDevice(_index));
+    ignore_error(gpuFreeAsync(ptr, reinterpret_cast<gpuStream_t>(stream)));
 }
 
 void GpuDevice::memcpy(void* to, void* from, std::size_t size) const {

--- a/madspace/src/gpu/device.hpp
+++ b/madspace/src/gpu/device.hpp
@@ -42,6 +42,7 @@ public:
     virtual std::pair<void*, Tensor>
     allocate(std::size_t size, AllocHint hint) const override;
     void free(void* ptr) const override;
+    void free_on_stream(void* ptr, std::uintptr_t stream) const override;
     void memcpy(void* to, void* from, std::size_t size) const override;
 
     void tensor_copy(const Tensor& source, Tensor& target) const override;
@@ -128,6 +129,8 @@ private:
 
 class AsyncGpuDevice {
 public:
+    static constexpr bool stream_ordered_alloc = true;
+
     AsyncGpuDevice(
         const GpuDevice& device,
         gpuStream_t stream,

--- a/madspace/src/gpu/device.hpp
+++ b/madspace/src/gpu/device.hpp
@@ -129,6 +129,7 @@ private:
     std::vector<PoolItem> _pools;
     std::unordered_map<void*, AllocItem> _allocs;
     const GpuDevice& _device;
+    gpuStream_t _stream;
 };
 
 class AsyncGpuDevice {

--- a/madspace/src/gpu/device.hpp
+++ b/madspace/src/gpu/device.hpp
@@ -32,6 +32,10 @@ inline void check_error(gpuError_t error) {
 
 inline void check_error() { check_error(gpuGetLastError()); }
 
+inline void ignore_error(gpuError_t) {}
+inline void ignore_error(gpublasStatus_t) {}
+inline void ignore_error(gpurandStatus_t) {}
+
 class GpuDevice : public Device {
 public:
 #ifdef __CUDACC__

--- a/madspace/src/gpu/device.hpp
+++ b/madspace/src/gpu/device.hpp
@@ -46,8 +46,8 @@ public:
     virtual std::pair<void*, Tensor>
     allocate(std::size_t size, AllocHint hint) const override;
     void free(void* ptr) const override;
-    void free_on_stream(void* ptr, std::uintptr_t stream) const override;
-    void order_streams(std::uintptr_t from, std::uintptr_t to) const override;
+    void free_on_stream(void* ptr, void* stream) const override;
+    void order_streams(void* from, void* to) const override;
     void memcpy(void* to, void* from, std::size_t size) const override;
 
     void tensor_copy(const Tensor& source, Tensor& target) const override;
@@ -57,7 +57,6 @@ public:
     DevicePtr device_ptr() const override { return this; }
     DeviceType device_type() const override { return gpu_device_type; }
     void activate() const override { check_error(gpuSetDevice(_index)); }
-    int device_index() const override { return _index; }
     void adam_step(
         const Tensor& gradient,
         Tensor& parameter,

--- a/madspace/src/gpu/device.hpp
+++ b/madspace/src/gpu/device.hpp
@@ -47,6 +47,7 @@ public:
     allocate(std::size_t size, AllocHint hint) const override;
     void free(void* ptr) const override;
     void free_on_stream(void* ptr, std::uintptr_t stream) const override;
+    void order_streams(std::uintptr_t from, std::uintptr_t to) const override;
     void memcpy(void* to, void* from, std::size_t size) const override;
 
     void tensor_copy(const Tensor& source, Tensor& target) const override;

--- a/madspace/src/gpu/device.hpp
+++ b/madspace/src/gpu/device.hpp
@@ -57,6 +57,7 @@ public:
     DevicePtr device_ptr() const override { return this; }
     DeviceType device_type() const override { return gpu_device_type; }
     void activate() const override { check_error(gpuSetDevice(_index)); }
+    int device_index() const override { return _index; }
     void adam_step(
         const Tensor& gradient,
         Tensor& parameter,

--- a/madspace/src/gpu/gpu_abstraction.cuh
+++ b/madspace/src/gpu/gpu_abstraction.cuh
@@ -1,8 +1,7 @@
 #pragma once
 
-// our lanes are blocking streams, ordered against the legacy stream but not against
-// the per-thread one this flag would put at handle 0
-#if defined(CUDA_API_PER_THREAD_DEFAULT_STREAM) || \
+// our lanes are blocking streams, ordered against the legacy stream but not this one
+#if defined(CUDA_API_PER_THREAD_DEFAULT_STREAM) ||                                     \
     defined(__HIP_API_PER_THREAD_DEFAULT_STREAM__)
 #error "madspace cannot be built with the per-thread default stream"
 #endif

--- a/madspace/src/gpu/gpu_abstraction.cuh
+++ b/madspace/src/gpu/gpu_abstraction.cuh
@@ -1,5 +1,12 @@
 #pragma once
 
+// stream handle 0 has to mean the legacy stream: our lanes are blocking streams, so
+// everything freed on it is ordered against them, which per-thread streams are not
+#if defined(CUDA_API_PER_THREAD_DEFAULT_STREAM) || \
+    defined(__HIP_API_PER_THREAD_DEFAULT_STREAM__)
+#error "madspace does not support per-thread default streams"
+#endif
+
 #ifdef __CUDACC__
 
 #include <cub/cub.cuh>
@@ -32,6 +39,9 @@
 #define gpuEventDestroy cudaEventDestroy
 #define gpuStreamWaitEvent cudaStreamWaitEvent
 #define gpuEventRecord cudaEventRecord
+#define gpuEventQuery cudaEventQuery
+#define gpuEventSynchronize cudaEventSynchronize
+#define gpuErrorNotReady cudaErrorNotReady
 #define gpuDeviceSynchronize cudaDeviceSynchronize
 
 #define gpublasStatus_t cublasStatus_t
@@ -90,6 +100,9 @@
 #define gpuEventDestroy hipEventDestroy
 #define gpuStreamWaitEvent(stream, event) hipStreamWaitEvent(stream, event, 0)
 #define gpuEventRecord hipEventRecord
+#define gpuEventQuery hipEventQuery
+#define gpuEventSynchronize hipEventSynchronize
+#define gpuErrorNotReady hipErrorNotReady
 #define gpuDeviceSynchronize hipDeviceSynchronize
 
 #define gpublasStatus_t rocblas_status

--- a/madspace/src/gpu/gpu_abstraction.cuh
+++ b/madspace/src/gpu/gpu_abstraction.cuh
@@ -1,10 +1,10 @@
 #pragma once
 
-// stream handle 0 has to mean the legacy stream: our lanes are blocking streams, so
-// everything freed on it is ordered against them, which per-thread streams are not
+// our lanes are blocking streams, ordered against the legacy stream but not against
+// the per-thread one this flag would put at handle 0
 #if defined(CUDA_API_PER_THREAD_DEFAULT_STREAM) || \
     defined(__HIP_API_PER_THREAD_DEFAULT_STREAM__)
-#error "madspace does not support per-thread default streams"
+#error "madspace cannot be built with the per-thread default stream"
 #endif
 
 #ifdef __CUDACC__

--- a/madspace/src/gpu/runtime.cu
+++ b/madspace/src/gpu/runtime.cu
@@ -1799,6 +1799,7 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
         [stream_count]() {
             std::vector<gpuStream_t> streams(stream_count);
             for (auto& item : streams) {
+                // blocking, a caller on the legacy default stream relies on it
                 check_error(gpuStreamCreate(&item));
             }
             return streams;
@@ -1886,9 +1887,7 @@ TensorVec GpuRuntime::run(const TensorVec& inputs) {
     auto stream_handle = reinterpret_cast<std::uintptr_t>(main_stream);
     TensorVec outputs;
     switch_stream(main_stream, events);
-    MemPool mem_pool(
-        gpu_device, load_pool_size_cache(false, stream_handle), main_stream
-    );
+    MemPool mem_pool(gpu_device, load_pool_size_cache(false, !caller), main_stream);
     StreamGuard stream_guard{main_stream, streams};
     fork_streams(main_stream, streams, events);
 
@@ -1918,9 +1917,11 @@ TensorVec GpuRuntime::run(const TensorVec& inputs) {
     for (auto& local : locals) {
         local.reset_on_stream(stream_handle);
     }
-    check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
-    if (!caller) {
+    if (caller) {
+        check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
+    } else {
         check_error(gpuStreamSynchronize(main_stream));
+        _last_stream.get().reset();
     }
     stream_guard.dismissed = true;
     return outputs;
@@ -1944,12 +1945,9 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
     auto caller = caller_stream();
     gpuStream_t main_stream =
         caller && *caller != 0 ? reinterpret_cast<gpuStream_t>(*caller) : streams.at(0);
-    auto stream_handle = reinterpret_cast<std::uintptr_t>(main_stream);
     TensorVec outputs;
     switch_stream(main_stream, events);
-    MemPool mem_pool(
-        gpu_device, load_pool_size_cache(false, stream_handle), main_stream
-    );
+    MemPool mem_pool(gpu_device, load_pool_size_cache(false, true), main_stream);
     StreamGuard stream_guard{main_stream, streams};
     fork_streams(main_stream, streams, events);
 
@@ -2021,11 +2019,9 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     auto caller = caller_stream();
     gpuStream_t main_stream =
         caller && *caller != 0 ? reinterpret_cast<gpuStream_t>(*caller) : streams.at(0);
-    auto stream_handle = reinterpret_cast<std::uintptr_t>(main_stream);
     switch_stream(main_stream, events);
-    MemPool mem_pool(
-        gpu_device, load_pool_size_cache(true, stream_handle), main_stream
-    );
+    MemPool mem_pool(gpu_device, load_pool_size_cache(true, true), main_stream);
+    StreamGuard stream_guard{main_stream, streams};
     AsyncGpuDevice init_device(gpu_device, main_stream, 0, &mem_pool);
     Tensor all_global_grads(
         DataType::dt_float,
@@ -2035,7 +2031,6 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     );
     // all_global_grads.zero(init_device);
     TensorVec global_grads = all_global_grads.split_and_reshape(_grad_global_shapes);
-    StreamGuard stream_guard{main_stream, streams};
     for (auto [index, grad] : zip(_grad_global_indices, global_grads)) {
         local_grads[index] = grad;
     }
@@ -2086,14 +2081,15 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
 }
 
 std::vector<std::tuple<std::size_t, std::size_t, Tensor, bool>>
-GpuRuntime::load_pool_size_cache(bool backward, std::uintptr_t stream) {
+// a cached block can only be handed out again if the call that used it synchronized
+GpuRuntime::load_pool_size_cache(bool backward, bool synchronizes) {
     auto cache = backward ? _pool_size_cache_backward.load() : _pool_size_cache.load();
     std::vector<std::tuple<std::size_t, std::size_t, Tensor, bool>> ret;
     if (cache) {
         //auto& thread_prev_caches =
             //backward ? _prev_caches_backward.get() : _prev_caches.get();
         for (auto [pool_index, size] : *cache) {
-            Tensor new_cache = _context->cached_tensor(size, stream);
+            Tensor new_cache = synchronizes ? _context->cached_tensor(size) : Tensor();
             /*if (pool_index < thread_prev_caches.size()) {
                 Tensor& prev_cache = thread_prev_caches.at(pool_index);
                 if (prev_cache && prev_cache.is_only_reference()) {

--- a/madspace/src/gpu/runtime.cu
+++ b/madspace/src/gpu/runtime.cu
@@ -1505,11 +1505,13 @@ private:
 };
 
 struct StreamGuard {
+    gpuStream_t main_stream;
     const std::vector<gpuStream_t>& streams;
     bool dismissed = false;
 
     ~StreamGuard() {
         if (!dismissed) {
+            ignore_error(gpuStreamSynchronize(main_stream));
             for (auto stream : streams) {
                 ignore_error(gpuStreamSynchronize(stream));
             }
@@ -1542,6 +1544,7 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
         },
         [](gpurandGenerator_t handle) { ignore_error(gpurandDestroyGenerator(handle)); }
     ),
+    _last_stream(context->thread_pool(), []() { return std::optional<gpuStream_t>{}; }),
     _prev_caches(context->thread_pool(), []() { return TensorVec{}; }),
     _prev_caches_backward(context->thread_pool(), []() { return TensorVec{}; }) {
     if (context->device()->device_type() != GpuDevice::gpu_device_type) {
@@ -1807,6 +1810,7 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
         }
     );
     std::size_t max_event_count = std::max(event_count, backward_event_count);
+    _stream_switch_event = max_event_count++;
     if (stream_count > 1) {
         _fork_event = max_event_count++;
         for (std::size_t stream = 1; stream < stream_count; ++stream) {
@@ -1856,6 +1860,17 @@ void GpuRuntime::join_streams(
     }
 }
 
+// the blas and rand handles are reused across calls with no ordering of their own
+void GpuRuntime::switch_stream(
+    gpuStream_t main_stream, const std::vector<gpuEvent_t>& events
+) {
+    auto& last_stream = _last_stream.get();
+    if (last_stream && *last_stream != main_stream) {
+        check_error(gpuStreamWaitEvent(main_stream, events.at(_stream_switch_event)));
+    }
+    last_stream = main_stream;
+}
+
 TensorVec GpuRuntime::run(const TensorVec& inputs) {
     auto& gpu_device = *static_cast<const GpuDevice*>(_context->device());
     auto& streams = _streams.get();
@@ -1863,14 +1878,20 @@ TensorVec GpuRuntime::run(const TensorVec& inputs) {
     gpu_device.activate();
     auto locals = _locals_init;
     std::copy(inputs.begin(), inputs.end(), locals.begin());
-    gpuStream_t main_stream = streams.at(0);
+    auto caller = caller_stream();
+    gpuStream_t main_stream =
+        caller && *caller != 0 ? reinterpret_cast<gpuStream_t>(*caller) : streams.at(0);
+    auto stream_handle = reinterpret_cast<std::uintptr_t>(main_stream);
     TensorVec outputs;
-    MemPool mem_pool(gpu_device, load_pool_size_cache(false), main_stream);
-    StreamGuard stream_guard{streams};
+    switch_stream(main_stream, events);
+    MemPool mem_pool(
+        gpu_device, load_pool_size_cache(false, stream_handle), main_stream
+    );
+    StreamGuard stream_guard{main_stream, streams};
     fork_streams(main_stream, streams, events);
 
     for (auto& instr : _instructions) {
-        gpuStream_t stream = streams.at(instr.stream);
+        gpuStream_t stream = instr.stream == 0 ? main_stream : streams.at(instr.stream);
         AsyncGpuDevice device(gpu_device, stream, instr.stream, &mem_pool);
         for (auto event : instr.wait_events) {
             check_error(gpuStreamWaitEvent(stream, events.at(event)));
@@ -1890,11 +1911,15 @@ TensorVec GpuRuntime::run(const TensorVec& inputs) {
     //update_cached_tensors(mem_pool.reset(main_stream), false);
     for (auto index : _output_indices) {
         outputs.push_back(locals[index]);
+        outputs.back().set_stream(caller);
     }
     for (auto& local : locals) {
-        local.reset_on_stream(reinterpret_cast<std::uintptr_t>(main_stream));
+        local.reset_on_stream(stream_handle);
     }
-    check_error(gpuStreamSynchronize(main_stream));
+    check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
+    if (!caller) {
+        check_error(gpuStreamSynchronize(main_stream));
+    }
     stream_guard.dismissed = true;
     return outputs;
 }
@@ -1914,14 +1939,20 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
     std::copy(
         input_requires_grad.begin(), input_requires_grad.end(), requires_grad.begin()
     );
-    gpuStream_t main_stream = streams.at(0);
+    auto caller = caller_stream();
+    gpuStream_t main_stream =
+        caller && *caller != 0 ? reinterpret_cast<gpuStream_t>(*caller) : streams.at(0);
+    auto stream_handle = reinterpret_cast<std::uintptr_t>(main_stream);
     TensorVec outputs;
-    MemPool mem_pool(gpu_device, load_pool_size_cache(false), main_stream);
-    StreamGuard stream_guard{streams};
+    switch_stream(main_stream, events);
+    MemPool mem_pool(
+        gpu_device, load_pool_size_cache(false, stream_handle), main_stream
+    );
+    StreamGuard stream_guard{main_stream, streams};
     fork_streams(main_stream, streams, events);
 
     for (auto [instr, instr_eval_grad] : zip(_instructions, eval_grad)) {
-        gpuStream_t stream = streams.at(instr.stream);
+        gpuStream_t stream = instr.stream == 0 ? main_stream : streams.at(instr.stream);
         AsyncGpuDevice device(gpu_device, stream, instr.stream, &mem_pool);
         if (instr.differentiable) {
             for (auto input_index : instr.input_indices) {
@@ -1964,6 +1995,7 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
     for (auto index : _output_indices) {
         outputs.push_back(locals[index]);
     }
+    check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
     check_error(gpuStreamSynchronize(main_stream));
     stream_guard.dismissed = true;
     return {outputs, locals, eval_grad};
@@ -1984,18 +2016,27 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     for (auto [index, grad] : zip(_output_indices, output_grads)) {
         local_grads[index] = grad;
     }
-    gpuStream_t main_stream = streams.at(0);
-    MemPool mem_pool(gpu_device, load_pool_size_cache(true), main_stream);
+    auto caller = caller_stream();
+    gpuStream_t main_stream =
+        caller && *caller != 0 ? reinterpret_cast<gpuStream_t>(*caller) : streams.at(0);
+    auto stream_handle = reinterpret_cast<std::uintptr_t>(main_stream);
+    switch_stream(main_stream, events);
+    MemPool mem_pool(
+        gpu_device, load_pool_size_cache(true, stream_handle), main_stream
+    );
+    Tensor all_global_grads;
+    TensorVec global_grads;
+    StreamGuard stream_guard{main_stream, streams};
 
     AsyncGpuDevice init_device(gpu_device, main_stream, 0, &mem_pool);
-    Tensor all_global_grads(
+    all_global_grads = Tensor(
         DataType::dt_float,
         {_grad_global_total_size},
         init_device,
         AllocHint::global_grad
     );
     // all_global_grads.zero(init_device);
-    TensorVec global_grads = all_global_grads.split_and_reshape(_grad_global_shapes);
+    global_grads = all_global_grads.split_and_reshape(_grad_global_shapes);
     for (auto [index, grad] : zip(_grad_global_indices, global_grads)) {
         local_grads[index] = grad;
     }
@@ -2036,7 +2077,9 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     }*/
     update_pool_size_cache(mem_pool.total_sizes(), true);
     //update_cached_tensors(mem_pool.reset(main_stream), true);
+    check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
     check_error(gpuStreamSynchronize(main_stream));
+    stream_guard.dismissed = true;
     return {
         {local_grads.begin(), local_grads.begin() + _input_count},
         return_contiguous_grads ? TensorVec{all_global_grads} : global_grads
@@ -2044,14 +2087,14 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
 }
 
 std::vector<std::tuple<std::size_t, std::size_t, Tensor, bool>>
-GpuRuntime::load_pool_size_cache(bool backward) {
+GpuRuntime::load_pool_size_cache(bool backward, std::uintptr_t stream) {
     auto cache = backward ? _pool_size_cache_backward.load() : _pool_size_cache.load();
     std::vector<std::tuple<std::size_t, std::size_t, Tensor, bool>> ret;
     if (cache) {
         //auto& thread_prev_caches =
             //backward ? _prev_caches_backward.get() : _prev_caches.get();
         for (auto [pool_index, size] : *cache) {
-            Tensor new_cache = _context->cached_tensor(size);
+            Tensor new_cache = _context->cached_tensor(size, stream);
             /*if (pool_index < thread_prev_caches.size()) {
                 Tensor& prev_cache = thread_prev_caches.at(pool_index);
                 if (prev_cache && prev_cache.is_only_reference()) {

--- a/madspace/src/gpu/runtime.cu
+++ b/madspace/src/gpu/runtime.cu
@@ -1952,9 +1952,9 @@ void GpuRuntime::switch_stream(
 
 TensorVec GpuRuntime::run(const TensorVec& inputs) {
     auto& gpu_device = *static_cast<const GpuDevice*>(_context->device());
+    gpu_device.activate();
     auto& streams = _streams.get();
     auto& events = _events.get();
-    gpu_device.activate();
     auto locals = _locals_init;
     std::copy(inputs.begin(), inputs.end(), locals.begin());
     auto caller = caller_stream();
@@ -2009,9 +2009,9 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
     const TensorVec& inputs, const std::vector<bool>& input_requires_grad
 ) {
     auto& gpu_device = *static_cast<const GpuDevice*>(_context->device());
+    gpu_device.activate();
     auto& streams = _streams.get();
     auto& events = _events.get();
-    gpu_device.activate();
     auto locals = _locals_init;
     auto requires_grad = _requires_grad_init;
     std::vector<bool> store_local(locals.size());
@@ -2095,9 +2095,9 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     bool return_contiguous_grads
 ) {
     auto& gpu_device = *static_cast<const GpuDevice*>(_context->device());
+    gpu_device.activate();
     auto& streams = _streams.get();
     auto& events = _events.get();
-    gpu_device.activate();
     TensorVec local_grads(stored_locals.size());
     TensorVec locals(stored_locals);
     auto caller = caller_stream();

--- a/madspace/src/gpu/runtime.cu
+++ b/madspace/src/gpu/runtime.cu
@@ -1776,7 +1776,6 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
 
     for (auto& out : function.outputs()) {
         _output_indices.push_back(out.local_index);
-        update_sync(out.local_index, 0, _wait_events);
     }
 
     _streams = ThreadResource<std::vector<gpuStream_t>>(
@@ -1795,6 +1794,12 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
         }
     );
     std::size_t max_event_count = std::max(event_count, backward_event_count);
+    if (stream_count > 1) {
+        _fork_event = max_event_count++;
+        for (std::size_t stream = 1; stream < stream_count; ++stream) {
+            _join_events.push_back(max_event_count++);
+        }
+    }
     _events = ThreadResource<std::vector<gpuEvent_t>>(
         context->thread_pool(),
         [max_event_count]() {
@@ -1812,6 +1817,32 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
     );
 }
 
+void GpuRuntime::fork_streams(
+    gpuStream_t main_stream,
+    const std::vector<gpuStream_t>& streams,
+    const std::vector<gpuEvent_t>& events
+) const {
+    if (!_fork_event) {
+        return;
+    }
+    check_error(gpuEventRecord(events.at(*_fork_event), main_stream));
+    for (std::size_t stream = 1; stream < streams.size(); ++stream) {
+        check_error(gpuStreamWaitEvent(streams.at(stream), events.at(*_fork_event)));
+    }
+}
+
+void GpuRuntime::join_streams(
+    gpuStream_t main_stream,
+    const std::vector<gpuStream_t>& streams,
+    const std::vector<gpuEvent_t>& events
+) const {
+    for (std::size_t stream = 1; stream < streams.size(); ++stream) {
+        gpuEvent_t event = events.at(_join_events.at(stream - 1));
+        check_error(gpuEventRecord(event, streams.at(stream)));
+        check_error(gpuStreamWaitEvent(main_stream, event));
+    }
+}
+
 TensorVec GpuRuntime::run(const TensorVec& inputs) {
     auto& gpu_device = *static_cast<const GpuDevice*>(_context->device());
     auto& streams = _streams.get();
@@ -1821,6 +1852,7 @@ TensorVec GpuRuntime::run(const TensorVec& inputs) {
     std::copy(inputs.begin(), inputs.end(), locals.begin());
     gpuStream_t main_stream = streams.at(0);
     MemPool mem_pool(gpu_device, load_pool_size_cache(false), main_stream);
+    fork_streams(main_stream, streams, events);
 
     for (auto& instr : _instructions) {
         gpuStream_t stream = streams.at(instr.stream);
@@ -1838,9 +1870,7 @@ TensorVec GpuRuntime::run(const TensorVec& inputs) {
             check_error(gpuEventRecord(events.at(instr.record_event), stream));
         }
     }
-    for (auto event : _wait_events) {
-        check_error(gpuStreamWaitEvent(main_stream, events.at(event)));
-    }
+    join_streams(main_stream, streams, events);
     update_pool_size_cache(mem_pool.total_sizes(), false);
     //update_cached_tensors(mem_pool.reset(main_stream), false);
     TensorVec outputs;
@@ -1868,6 +1898,7 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
     );
     gpuStream_t main_stream = streams.at(0);
     MemPool mem_pool(gpu_device, load_pool_size_cache(false), main_stream);
+    fork_streams(main_stream, streams, events);
 
     for (auto [instr, instr_eval_grad] : zip(_instructions, eval_grad)) {
         gpuStream_t stream = streams.at(instr.stream);
@@ -1907,9 +1938,7 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
             check_error(gpuEventRecord(events.at(instr.record_event), stream));
         }
     }
-    for (auto event : _wait_events) {
-        check_error(gpuStreamWaitEvent(main_stream, events.at(event)));
-    }
+    join_streams(main_stream, streams, events);
     update_pool_size_cache(mem_pool.total_sizes(), false);
     //update_cached_tensors(mem_pool.reset(main_stream), false);
     TensorVec outputs;

--- a/madspace/src/gpu/runtime.cu
+++ b/madspace/src/gpu/runtime.cu
@@ -1860,7 +1860,9 @@ void GpuRuntime::join_streams(
     }
 }
 
-// the blas and rand handles are reused across calls with no ordering of their own
+// the blas and rand handles are reused across calls with no ordering of their own, so
+// a call has to wait for the last one that left work queued on a different stream. only
+// run() does; the grad paths synchronize and clear the mark
 void GpuRuntime::switch_stream(
     gpuStream_t main_stream, const std::vector<gpuEvent_t>& events
 ) {
@@ -1995,8 +1997,8 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
     for (auto index : _output_indices) {
         outputs.push_back(locals[index]);
     }
-    check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
     check_error(gpuStreamSynchronize(main_stream));
+    _last_stream.get().reset();
     stream_guard.dismissed = true;
     return {outputs, locals, eval_grad};
 }
@@ -2024,19 +2026,16 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     MemPool mem_pool(
         gpu_device, load_pool_size_cache(true, stream_handle), main_stream
     );
-    Tensor all_global_grads;
-    TensorVec global_grads;
-    StreamGuard stream_guard{main_stream, streams};
-
     AsyncGpuDevice init_device(gpu_device, main_stream, 0, &mem_pool);
-    all_global_grads = Tensor(
+    Tensor all_global_grads(
         DataType::dt_float,
         {_grad_global_total_size},
         init_device,
         AllocHint::global_grad
     );
     // all_global_grads.zero(init_device);
-    global_grads = all_global_grads.split_and_reshape(_grad_global_shapes);
+    TensorVec global_grads = all_global_grads.split_and_reshape(_grad_global_shapes);
+    StreamGuard stream_guard{main_stream, streams};
     for (auto [index, grad] : zip(_grad_global_indices, global_grads)) {
         local_grads[index] = grad;
     }
@@ -2077,8 +2076,8 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     }*/
     update_pool_size_cache(mem_pool.total_sizes(), true);
     //update_cached_tensors(mem_pool.reset(main_stream), true);
-    check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
     check_error(gpuStreamSynchronize(main_stream));
+    _last_stream.get().reset();
     stream_guard.dismissed = true;
     return {
         {local_grads.begin(), local_grads.begin() + _input_count},

--- a/madspace/src/gpu/runtime.cu
+++ b/madspace/src/gpu/runtime.cu
@@ -1516,7 +1516,7 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
             check_error(gpublasCreate(&handle));
             return handle;
         },
-        [](gpublasHandle_t handle) { check_error(gpublasDestroy(handle)); }
+        [](gpublasHandle_t handle) { ignore_error(gpublasDestroy(handle)); }
     ),
     _gpurand_generator(
         context->thread_pool(),
@@ -1527,7 +1527,7 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
             check_error(gpurandSetPseudoRandomGeneratorSeed(handle, rand_dev()));
             return handle;
         },
-        [](gpurandGenerator_t handle) { check_error(gpurandDestroyGenerator(handle)); }
+        [](gpurandGenerator_t handle) { ignore_error(gpurandDestroyGenerator(handle)); }
     ),
     _prev_caches(context->thread_pool(), []() { return TensorVec{}; }),
     _prev_caches_backward(context->thread_pool(), []() { return TensorVec{}; }) {
@@ -1790,7 +1790,7 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
         },
         [](auto& streams) {
             for (auto item : streams) {
-                check_error(gpuStreamDestroy(item));
+                ignore_error(gpuStreamDestroy(item));
             }
         }
     );
@@ -1806,7 +1806,7 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
         },
         [](auto& events) {
             for (auto item : events) {
-                check_error(gpuEventDestroy(item));
+                ignore_error(gpuEventDestroy(item));
             }
         }
     );

--- a/madspace/src/gpu/runtime.cu
+++ b/madspace/src/gpu/runtime.cu
@@ -1545,6 +1545,19 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
         [](gpurandGenerator_t handle) { ignore_error(gpurandDestroyGenerator(handle)); }
     ),
     _last_stream(context->thread_pool(), []() { return std::optional<gpuStream_t>{}; }),
+    _held_inputs(
+        context->thread_pool(),
+        []() { return HeldInputs{}; },
+        [](HeldInputs& held) {
+            for (auto& [event, tensors] : held.items) {
+                ignore_error(gpuEventSynchronize(event));
+                ignore_error(gpuEventDestroy(event));
+            }
+            for (auto event : held.free_events) {
+                ignore_error(gpuEventDestroy(event));
+            }
+        }
+    ),
     _prev_caches(context->thread_pool(), []() { return TensorVec{}; }),
     _prev_caches_backward(context->thread_pool(), []() { return TensorVec{}; }) {
     if (context->device()->device_type() != GpuDevice::gpu_device_type) {
@@ -1861,9 +1874,43 @@ void GpuRuntime::join_streams(
     }
 }
 
-// the blas and rand handles are reused across calls with no ordering of their own, so
-// a call has to wait for the last one that left work queued on a different stream. only
-// run() does; the grad paths synchronize and clear the mark
+void GpuRuntime::release_inputs() {
+    auto& held = _held_inputs.get();
+    gpuError_t error = gpuSuccess;
+    auto done = std::ranges::remove_if(held.items, [&](auto& item) {
+        auto status = gpuEventQuery(item.first);
+        if (status == gpuErrorNotReady) {
+            return false;
+        }
+        if (status != gpuSuccess) {
+            error = status;
+        }
+        held.free_events.push_back(item.first);
+        return true;
+    });
+    held.items.erase(done.begin(), done.end());
+    check_error(error);
+}
+
+void GpuRuntime::hold_inputs(const TensorVec& inputs, gpuStream_t stream) {
+    // the dlpack capsules keep the producer's memory alive, so they must outlive the
+    // work reading it, which is still queued when a caller stream lets us return early
+    release_inputs();
+    auto& held = _held_inputs.get();
+    gpuEvent_t event;
+    if (held.free_events.empty()) {
+        check_error(gpuEventCreate(&event));
+    } else {
+        event = held.free_events.back();
+        held.free_events.pop_back();
+    }
+    held.items.emplace_back(event, inputs);
+    check_error(gpuEventRecord(event, stream));
+}
+
+// a call that returned early left work queued, and the next one shares its handles, its
+// pool blocks and the async pool with it, so a call on a different stream has to wait
+// for it. only run() leaves the mark; the grad paths synchronize and clear it
 void GpuRuntime::switch_stream(
     gpuStream_t main_stream, const std::vector<gpuEvent_t>& events
 ) {
@@ -1919,9 +1966,11 @@ TensorVec GpuRuntime::run(const TensorVec& inputs) {
     }
     if (caller) {
         check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
+        hold_inputs(inputs, main_stream);
     } else {
         check_error(gpuStreamSynchronize(main_stream));
         _last_stream.get().reset();
+        release_inputs();
     }
     stream_guard.dismissed = true;
     return outputs;
@@ -1996,7 +2045,12 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
         outputs.push_back(locals[index]);
     }
     check_error(gpuStreamSynchronize(main_stream));
+    // everything is done, and a lane handle would not survive the runtime
+    for (auto& local : locals) {
+        local.set_stream(std::nullopt);
+    }
     _last_stream.get().reset();
+    release_inputs();
     stream_guard.dismissed = true;
     return {outputs, locals, eval_grad};
 }
@@ -2072,7 +2126,12 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     update_pool_size_cache(mem_pool.total_sizes(), true);
     //update_cached_tensors(mem_pool.reset(main_stream), true);
     check_error(gpuStreamSynchronize(main_stream));
+    for (auto& grad : local_grads) {
+        grad.set_stream(std::nullopt);
+    }
+    all_global_grads.set_stream(std::nullopt);
     _last_stream.get().reset();
+    release_inputs();
     stream_guard.dismissed = true;
     return {
         {local_grads.begin(), local_grads.begin() + _input_count},

--- a/madspace/src/gpu/runtime.cu
+++ b/madspace/src/gpu/runtime.cu
@@ -1504,7 +1504,6 @@ private:
     std::vector<bool> _sync_matrix;
 };
 
-// a call that throws never held its inputs, so its queued work has to be drained
 struct StreamGuard {
     gpuStream_t main_stream;
     const std::vector<gpuStream_t>& streams;
@@ -1546,6 +1545,8 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
         },
         [](gpurandGenerator_t handle) { ignore_error(gpurandDestroyGenerator(handle)); }
     ),
+    _prev_caches(context->thread_pool(), []() { return TensorVec{}; }),
+    _prev_caches_backward(context->thread_pool(), []() { return TensorVec{}; }),
     _held_inputs(
         context->thread_pool(),
         []() { return HeldInputs{}; },
@@ -1558,9 +1559,7 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
                 ignore_error(gpuEventDestroy(event));
             }
         }
-    ),
-    _prev_caches(context->thread_pool(), []() { return TensorVec{}; }),
-    _prev_caches_backward(context->thread_pool(), []() { return TensorVec{}; }) {
+    ) {
     if (context->device()->device_type() != GpuDevice::gpu_device_type) {
         throw std::runtime_error("Context has incompatible device");
     }
@@ -1816,8 +1815,6 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
     }
     for (auto& out : function.outputs()) {
         _output_indices.push_back(out.local_index);
-        // an output that is read again or returned twice is accumulated into, and that
-        // must not happen in the caller's tensor
         _copy_output_grads.push_back(
             grad_accumulated.at(out.local_index) ||
             output_counts.at(out.local_index) > 1
@@ -1894,33 +1891,36 @@ void GpuRuntime::join_streams(
 void GpuRuntime::release_inputs() {
     auto& held = _held_inputs.get();
     gpuError_t error = gpuSuccess;
-    auto done = std::ranges::remove_if(held.items, [&](auto& item) {
-        auto status = gpuEventQuery(item.first);
-        if (status == gpuErrorNotReady) {
-            return false;
-        }
-        if (status != gpuSuccess) {
-            error = status;
-        }
-        held.free_events.push_back(item.first);
-        return true;
-    });
-    held.items.erase(done.begin(), done.end());
+    held.items.erase(
+        std::remove_if(
+            held.items.begin(),
+            held.items.end(),
+            [&](auto& item) {
+                auto status = gpuEventQuery(item.first);
+                if (status != gpuSuccess) {
+                    if (status != gpuErrorNotReady) {
+                        error = status;
+                    }
+                    return false;
+                }
+                held.free_events.push_back(item.first);
+                return true;
+            }
+        ),
+        held.items.end()
+    );
     check_error(error);
 }
 
 void GpuRuntime::hold_inputs(
-    const TensorVec& inputs, gpuStream_t stream, bool own_lane
+    const TensorVec& inputs, gpuStream_t stream, bool legacy_caller
 ) {
-    // the capsules keep the producer's memory alive until the work reading it is done.
-    // memory of our own that this stream frees is already ordered behind that work,
-    // and a free on the legacy stream is ordered behind every blocking lane of ours
     release_inputs();
     auto handle = reinterpret_cast<std::uintptr_t>(stream);
     TensorVec kept;
     for (auto& input : inputs) {
         auto input_stream = input.stream();
-        if (input && input_stream != handle && !(own_lane && input_stream == 0)) {
+        if (input && input_stream != handle && !(legacy_caller && input_stream == 0)) {
             kept.push_back(input);
         }
     }
@@ -1935,12 +1935,11 @@ void GpuRuntime::hold_inputs(
         event = held.free_events.back();
         held.free_events.pop_back();
     }
-    held.items.emplace_back(event, std::move(kept));
     check_error(gpuEventRecord(event, stream));
+    held.items.emplace_back(event, std::move(kept));
 }
 
-// the next call shares the handles, the pool blocks and the async pool with one that
-// returned early, so on a different stream it has to wait for it
+// the cublas and curand handles are shared, so a new stream waits for the last one
 void GpuRuntime::switch_stream(
     gpuStream_t main_stream, const std::vector<gpuEvent_t>& events
 ) {
@@ -2074,9 +2073,8 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
     for (auto index : _output_indices) {
         outputs.push_back(locals[index]);
     }
-    // the locals outlive the call, and a lane handle would not survive the runtime
-    for (auto& local : locals) {
-        local.set_stream(caller);
+    for (std::size_t i = _input_count; i < locals.size(); ++i) {
+        locals[i].set_stream(caller);
     }
     if (caller) {
         check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
@@ -2132,7 +2130,6 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     // all_global_grads.zero(init_device);
     TensorVec global_grads = all_global_grads.split_and_reshape(_grad_global_shapes);
     for (auto [index, grad] : zip(_grad_global_indices, global_grads)) {
-        // a global that is also an output was seeded above
         if (local_grads[index]) {
             grad.add(local_grads[index], init_device);
         }

--- a/madspace/src/gpu/runtime.cu
+++ b/madspace/src/gpu/runtime.cu
@@ -1504,6 +1504,19 @@ private:
     std::vector<bool> _sync_matrix;
 };
 
+struct StreamGuard {
+    const std::vector<gpuStream_t>& streams;
+    bool dismissed = false;
+
+    ~StreamGuard() {
+        if (!dismissed) {
+            for (auto stream : streams) {
+                ignore_error(gpuStreamSynchronize(stream));
+            }
+        }
+    }
+};
+
 } // namespace
 
 GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
@@ -1851,7 +1864,9 @@ TensorVec GpuRuntime::run(const TensorVec& inputs) {
     auto locals = _locals_init;
     std::copy(inputs.begin(), inputs.end(), locals.begin());
     gpuStream_t main_stream = streams.at(0);
+    TensorVec outputs;
     MemPool mem_pool(gpu_device, load_pool_size_cache(false), main_stream);
+    StreamGuard stream_guard{streams};
     fork_streams(main_stream, streams, events);
 
     for (auto& instr : _instructions) {
@@ -1873,11 +1888,14 @@ TensorVec GpuRuntime::run(const TensorVec& inputs) {
     join_streams(main_stream, streams, events);
     update_pool_size_cache(mem_pool.total_sizes(), false);
     //update_cached_tensors(mem_pool.reset(main_stream), false);
-    TensorVec outputs;
     for (auto index : _output_indices) {
         outputs.push_back(locals[index]);
     }
+    for (auto& local : locals) {
+        local.reset_on_stream(reinterpret_cast<std::uintptr_t>(main_stream));
+    }
     check_error(gpuStreamSynchronize(main_stream));
+    stream_guard.dismissed = true;
     return outputs;
 }
 
@@ -1897,7 +1915,9 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
         input_requires_grad.begin(), input_requires_grad.end(), requires_grad.begin()
     );
     gpuStream_t main_stream = streams.at(0);
+    TensorVec outputs;
     MemPool mem_pool(gpu_device, load_pool_size_cache(false), main_stream);
+    StreamGuard stream_guard{streams};
     fork_streams(main_stream, streams, events);
 
     for (auto [instr, instr_eval_grad] : zip(_instructions, eval_grad)) {
@@ -1941,11 +1961,11 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
     join_streams(main_stream, streams, events);
     update_pool_size_cache(mem_pool.total_sizes(), false);
     //update_cached_tensors(mem_pool.reset(main_stream), false);
-    TensorVec outputs;
     for (auto index : _output_indices) {
         outputs.push_back(locals[index]);
     }
     check_error(gpuStreamSynchronize(main_stream));
+    stream_guard.dismissed = true;
     return {outputs, locals, eval_grad};
 }
 

--- a/madspace/src/gpu/runtime.cu
+++ b/madspace/src/gpu/runtime.cu
@@ -1504,6 +1504,7 @@ private:
     std::vector<bool> _sync_matrix;
 };
 
+// a call that throws never held its inputs, so its queued work has to be drained
 struct StreamGuard {
     gpuStream_t main_stream;
     const std::vector<gpuStream_t>& streams;
@@ -1524,6 +1525,7 @@ struct StreamGuard {
 GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
     _context(context),
     _input_count(function_arg.inputs().size()),
+    _last_stream(context->thread_pool(), []() { return std::optional<gpuStream_t>{}; }),
     _gpublas_handle(
         context->thread_pool(),
         []() {
@@ -1544,7 +1546,6 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
         },
         [](gpurandGenerator_t handle) { ignore_error(gpurandDestroyGenerator(handle)); }
     ),
-    _last_stream(context->thread_pool(), []() { return std::optional<gpuStream_t>{}; }),
     _held_inputs(
         context->thread_pool(),
         []() { return HeldInputs{}; },
@@ -1803,8 +1804,24 @@ GpuRuntime::GpuRuntime(const Function& function_arg, ContextPtr context) :
         );
     }
 
+    std::vector<bool> grad_accumulated(function.locals().size());
+    SizeVec output_counts(function.locals().size());
+    for (auto& instr : function.instructions()) {
+        for (auto& in : instr.inputs) {
+            grad_accumulated.at(in.local_index) = true;
+        }
+    }
+    for (auto& out : function.outputs()) {
+        ++output_counts.at(out.local_index);
+    }
     for (auto& out : function.outputs()) {
         _output_indices.push_back(out.local_index);
+        // an output that is read again or returned twice is accumulated into, and that
+        // must not happen in the caller's tensor
+        _copy_output_grads.push_back(
+            grad_accumulated.at(out.local_index) ||
+            output_counts.at(out.local_index) > 1
+        );
     }
 
     _streams = ThreadResource<std::vector<gpuStream_t>>(
@@ -1892,10 +1909,24 @@ void GpuRuntime::release_inputs() {
     check_error(error);
 }
 
-void GpuRuntime::hold_inputs(const TensorVec& inputs, gpuStream_t stream) {
-    // the dlpack capsules keep the producer's memory alive, so they must outlive the
-    // work reading it, which is still queued when a caller stream lets us return early
+void GpuRuntime::hold_inputs(
+    const TensorVec& inputs, gpuStream_t stream, bool own_lane
+) {
+    // the capsules keep the producer's memory alive until the work reading it is done.
+    // memory of our own that this stream frees is already ordered behind that work,
+    // and a free on the legacy stream is ordered behind every blocking lane of ours
     release_inputs();
+    auto handle = reinterpret_cast<std::uintptr_t>(stream);
+    TensorVec kept;
+    for (auto& input : inputs) {
+        auto input_stream = input.stream();
+        if (input && input_stream != handle && !(own_lane && input_stream == 0)) {
+            kept.push_back(input);
+        }
+    }
+    if (kept.empty()) {
+        return;
+    }
     auto& held = _held_inputs.get();
     gpuEvent_t event;
     if (held.free_events.empty()) {
@@ -1904,13 +1935,12 @@ void GpuRuntime::hold_inputs(const TensorVec& inputs, gpuStream_t stream) {
         event = held.free_events.back();
         held.free_events.pop_back();
     }
-    held.items.emplace_back(event, inputs);
+    held.items.emplace_back(event, std::move(kept));
     check_error(gpuEventRecord(event, stream));
 }
 
-// a call that returned early left work queued, and the next one shares its handles, its
-// pool blocks and the async pool with it, so a call on a different stream has to wait
-// for it. only run() leaves the mark; the grad paths synchronize and clear it
+// the next call shares the handles, the pool blocks and the async pool with one that
+// returned early, so on a different stream it has to wait for it
 void GpuRuntime::switch_stream(
     gpuStream_t main_stream, const std::vector<gpuEvent_t>& events
 ) {
@@ -1966,7 +1996,7 @@ TensorVec GpuRuntime::run(const TensorVec& inputs) {
     }
     if (caller) {
         check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
-        hold_inputs(inputs, main_stream);
+        hold_inputs(inputs, main_stream, *caller == 0);
     } else {
         check_error(gpuStreamSynchronize(main_stream));
         _last_stream.get().reset();
@@ -1996,7 +2026,7 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
         caller && *caller != 0 ? reinterpret_cast<gpuStream_t>(*caller) : streams.at(0);
     TensorVec outputs;
     switch_stream(main_stream, events);
-    MemPool mem_pool(gpu_device, load_pool_size_cache(false, true), main_stream);
+    MemPool mem_pool(gpu_device, load_pool_size_cache(false, !caller), main_stream);
     StreamGuard stream_guard{main_stream, streams};
     fork_streams(main_stream, streams, events);
 
@@ -2044,13 +2074,18 @@ std::tuple<TensorVec, TensorVec, std::vector<bool>> GpuRuntime::run_with_grad(
     for (auto index : _output_indices) {
         outputs.push_back(locals[index]);
     }
-    check_error(gpuStreamSynchronize(main_stream));
-    // everything is done, and a lane handle would not survive the runtime
+    // the locals outlive the call, and a lane handle would not survive the runtime
     for (auto& local : locals) {
-        local.set_stream(std::nullopt);
+        local.set_stream(caller);
     }
-    _last_stream.get().reset();
-    release_inputs();
+    if (caller) {
+        check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
+        hold_inputs(inputs, main_stream, *caller == 0);
+    } else {
+        check_error(gpuStreamSynchronize(main_stream));
+        _last_stream.get().reset();
+        release_inputs();
+    }
     stream_guard.dismissed = true;
     return {outputs, locals, eval_grad};
 }
@@ -2067,16 +2102,27 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     gpu_device.activate();
     TensorVec local_grads(stored_locals.size());
     TensorVec locals(stored_locals);
-    for (auto [index, grad] : zip(_output_indices, output_grads)) {
-        local_grads[index] = grad;
-    }
     auto caller = caller_stream();
     gpuStream_t main_stream =
         caller && *caller != 0 ? reinterpret_cast<gpuStream_t>(*caller) : streams.at(0);
     switch_stream(main_stream, events);
-    MemPool mem_pool(gpu_device, load_pool_size_cache(true, true), main_stream);
+    MemPool mem_pool(gpu_device, load_pool_size_cache(true, !caller), main_stream);
     StreamGuard stream_guard{main_stream, streams};
     AsyncGpuDevice init_device(gpu_device, main_stream, 0, &mem_pool);
+    for (auto [index, grad, copy] :
+         zip(_output_indices, output_grads, _copy_output_grads)) {
+        auto& local_grad = local_grads[index];
+        if (!grad) {
+            continue;
+        }
+        if (local_grad) {
+            local_grad.add(grad, init_device);
+        } else if (copy) {
+            local_grad = grad.copy(init_device, AllocHint::local_grad);
+        } else {
+            local_grad = grad;
+        }
+    }
     Tensor all_global_grads(
         DataType::dt_float,
         {_grad_global_total_size},
@@ -2086,6 +2132,10 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     // all_global_grads.zero(init_device);
     TensorVec global_grads = all_global_grads.split_and_reshape(_grad_global_shapes);
     for (auto [index, grad] : zip(_grad_global_indices, global_grads)) {
+        // a global that is also an output was seeded above
+        if (local_grads[index]) {
+            grad.add(local_grads[index], init_device);
+        }
         local_grads[index] = grad;
     }
 
@@ -2125,13 +2175,20 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
     }*/
     update_pool_size_cache(mem_pool.total_sizes(), true);
     //update_cached_tensors(mem_pool.reset(main_stream), true);
-    check_error(gpuStreamSynchronize(main_stream));
     for (auto& grad : local_grads) {
-        grad.set_stream(std::nullopt);
+        grad.set_stream(caller);
     }
-    all_global_grads.set_stream(std::nullopt);
-    _last_stream.get().reset();
-    release_inputs();
+    all_global_grads.set_stream(caller);
+    if (caller) {
+        check_error(gpuEventRecord(events.at(_stream_switch_event), main_stream));
+        TensorVec held(output_grads);
+        held.insert(held.end(), stored_locals.begin(), stored_locals.end());
+        hold_inputs(held, main_stream, *caller == 0);
+    } else {
+        check_error(gpuStreamSynchronize(main_stream));
+        _last_stream.get().reset();
+        release_inputs();
+    }
     stream_guard.dismissed = true;
     return {
         {local_grads.begin(), local_grads.begin() + _input_count},
@@ -2140,7 +2197,6 @@ std::pair<TensorVec, TensorVec> GpuRuntime::run_backward(
 }
 
 std::vector<std::tuple<std::size_t, std::size_t, Tensor, bool>>
-// a cached block can only be handed out again if the call that used it synchronized
 GpuRuntime::load_pool_size_cache(bool backward, bool synchronizes) {
     auto cache = backward ? _pool_size_cache_backward.load() : _pool_size_cache.load();
     std::vector<std::tuple<std::size_t, std::size_t, Tensor, bool>> ret;

--- a/madspace/src/gpu/runtime.hpp
+++ b/madspace/src/gpu/runtime.hpp
@@ -49,7 +49,7 @@ public:
 
 private:
     std::vector<std::tuple<std::size_t, std::size_t, Tensor, bool>>
-    load_pool_size_cache(bool backward, std::uintptr_t stream);
+    load_pool_size_cache(bool backward, bool synchronizes);
     void update_pool_size_cache(
         const std::vector<std::pair<std::size_t, std::size_t>>& total_sizes,
         bool backward

--- a/madspace/src/gpu/runtime.hpp
+++ b/madspace/src/gpu/runtime.hpp
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <map>
+#include <optional>
 
 namespace madspace {
 namespace gpu {
@@ -56,6 +57,16 @@ private:
     void update_cached_tensors(
         const std::vector<std::pair<std::size_t, Tensor>>& tensors, bool backward
     );
+    void fork_streams(
+        gpuStream_t main_stream,
+        const std::vector<gpuStream_t>& streams,
+        const std::vector<gpuEvent_t>& events
+    ) const;
+    void join_streams(
+        gpuStream_t main_stream,
+        const std::vector<gpuStream_t>& streams,
+        const std::vector<gpuEvent_t>& events
+    ) const;
     std::vector<Instruction> _instructions;
     SizeVec _output_indices;
     std::size_t _input_count;
@@ -67,7 +78,8 @@ private:
     ContextPtr _context;
     ThreadResource<std::vector<gpuStream_t>> _streams;
     ThreadResource<std::vector<gpuEvent_t>> _events;
-    std::vector<std::size_t> _wait_events;
+    std::optional<std::size_t> _fork_event;
+    std::vector<std::size_t> _join_events;
     std::vector<std::size_t> _backward_wait_events;
     ThreadResource<gpublasHandle_t> _gpublas_handle;
     ThreadResource<gpurandGenerator_t> _gpurand_generator;

--- a/madspace/src/gpu/runtime.hpp
+++ b/madspace/src/gpu/runtime.hpp
@@ -43,6 +43,7 @@ public:
         const std::vector<bool>& eval_grad,
         bool return_contiguous_grads
     ) override;
+    void release_inputs() override;
     Context& context() { return *_context; }
     gpublasHandle_t gpublas_handle() { return _gpublas_handle.get(); }
     gpurandGenerator_t gpurand_generator() { return _gpurand_generator.get(); }
@@ -68,6 +69,7 @@ private:
         const std::vector<gpuEvent_t>& events
     ) const;
     void switch_stream(gpuStream_t main_stream, const std::vector<gpuEvent_t>& events);
+    void hold_inputs(const TensorVec& inputs, gpuStream_t stream);
     std::vector<Instruction> _instructions;
     SizeVec _output_indices;
     std::size_t _input_count;
@@ -86,6 +88,12 @@ private:
     std::vector<std::size_t> _backward_wait_events;
     ThreadResource<gpublasHandle_t> _gpublas_handle;
     ThreadResource<gpurandGenerator_t> _gpurand_generator;
+    // destroyed before the handles above, because it waits for the work using them
+    struct HeldInputs {
+        std::vector<std::pair<gpuEvent_t, TensorVec>> items;
+        std::vector<gpuEvent_t> free_events;
+    };
+    ThreadResource<HeldInputs> _held_inputs;
     std::atomic<std::shared_ptr<std::unordered_map<std::size_t, std::size_t>>>
         _pool_size_cache;
     std::atomic<std::shared_ptr<std::unordered_map<std::size_t, std::size_t>>>

--- a/madspace/src/gpu/runtime.hpp
+++ b/madspace/src/gpu/runtime.hpp
@@ -49,7 +49,7 @@ public:
 
 private:
     std::vector<std::tuple<std::size_t, std::size_t, Tensor, bool>>
-    load_pool_size_cache(bool backward);
+    load_pool_size_cache(bool backward, std::uintptr_t stream);
     void update_pool_size_cache(
         const std::vector<std::pair<std::size_t, std::size_t>>& total_sizes,
         bool backward
@@ -67,6 +67,7 @@ private:
         const std::vector<gpuStream_t>& streams,
         const std::vector<gpuEvent_t>& events
     ) const;
+    void switch_stream(gpuStream_t main_stream, const std::vector<gpuEvent_t>& events);
     std::vector<Instruction> _instructions;
     SizeVec _output_indices;
     std::size_t _input_count;
@@ -78,6 +79,8 @@ private:
     ContextPtr _context;
     ThreadResource<std::vector<gpuStream_t>> _streams;
     ThreadResource<std::vector<gpuEvent_t>> _events;
+    ThreadResource<std::optional<gpuStream_t>> _last_stream;
+    std::size_t _stream_switch_event;
     std::optional<std::size_t> _fork_event;
     std::vector<std::size_t> _join_events;
     std::vector<std::size_t> _backward_wait_events;

--- a/madspace/src/gpu/runtime.hpp
+++ b/madspace/src/gpu/runtime.hpp
@@ -49,6 +49,7 @@ public:
     gpurandGenerator_t gpurand_generator() { return _gpurand_generator.get(); }
 
 private:
+    // a cached block can only be handed out again if the call that used it synchronized
     std::vector<std::tuple<std::size_t, std::size_t, Tensor, bool>>
     load_pool_size_cache(bool backward, bool synchronizes);
     void update_pool_size_cache(
@@ -69,9 +70,10 @@ private:
         const std::vector<gpuEvent_t>& events
     ) const;
     void switch_stream(gpuStream_t main_stream, const std::vector<gpuEvent_t>& events);
-    void hold_inputs(const TensorVec& inputs, gpuStream_t stream);
+    void hold_inputs(const TensorVec& inputs, gpuStream_t stream, bool own_lane);
     std::vector<Instruction> _instructions;
     SizeVec _output_indices;
+    std::vector<bool> _copy_output_grads;
     std::size_t _input_count;
     TensorVec _locals_init;
     std::vector<bool> _requires_grad_init;
@@ -88,11 +90,11 @@ private:
     std::vector<std::size_t> _backward_wait_events;
     ThreadResource<gpublasHandle_t> _gpublas_handle;
     ThreadResource<gpurandGenerator_t> _gpurand_generator;
-    // destroyed before the handles above, because it waits for the work using them
     struct HeldInputs {
         std::vector<std::pair<gpuEvent_t, TensorVec>> items;
         std::vector<gpuEvent_t> free_events;
     };
+    // last, so it is destroyed first: it waits for the work using the handles above
     ThreadResource<HeldInputs> _held_inputs;
     std::atomic<std::shared_ptr<std::unordered_map<std::size_t, std::size_t>>>
         _pool_size_cache;

--- a/madspace/src/gpu/runtime.hpp
+++ b/madspace/src/gpu/runtime.hpp
@@ -49,6 +49,11 @@ public:
     gpurandGenerator_t gpurand_generator() { return _gpurand_generator.get(); }
 
 private:
+    struct HeldInputs {
+        std::vector<std::pair<gpuEvent_t, TensorVec>> items;
+        std::vector<gpuEvent_t> free_events;
+    };
+
     // a cached block can only be handed out again if the call that used it synchronized
     std::vector<std::tuple<std::size_t, std::size_t, Tensor, bool>>
     load_pool_size_cache(bool backward, bool synchronizes);
@@ -70,7 +75,7 @@ private:
         const std::vector<gpuEvent_t>& events
     ) const;
     void switch_stream(gpuStream_t main_stream, const std::vector<gpuEvent_t>& events);
-    void hold_inputs(const TensorVec& inputs, gpuStream_t stream, bool own_lane);
+    void hold_inputs(const TensorVec& inputs, gpuStream_t stream, bool legacy_caller);
     std::vector<Instruction> _instructions;
     SizeVec _output_indices;
     std::vector<bool> _copy_output_grads;
@@ -90,18 +95,14 @@ private:
     std::vector<std::size_t> _backward_wait_events;
     ThreadResource<gpublasHandle_t> _gpublas_handle;
     ThreadResource<gpurandGenerator_t> _gpurand_generator;
-    struct HeldInputs {
-        std::vector<std::pair<gpuEvent_t, TensorVec>> items;
-        std::vector<gpuEvent_t> free_events;
-    };
-    // last, so it is destroyed first: it waits for the work using the handles above
-    ThreadResource<HeldInputs> _held_inputs;
     std::atomic<std::shared_ptr<std::unordered_map<std::size_t, std::size_t>>>
         _pool_size_cache;
     std::atomic<std::shared_ptr<std::unordered_map<std::size_t, std::size_t>>>
         _pool_size_cache_backward;
     ThreadResource<TensorVec> _prev_caches;
     ThreadResource<TensorVec> _prev_caches_backward;
+    // last, so it is destroyed first: it waits for the work using the members above
+    ThreadResource<HeldInputs> _held_inputs;
 };
 
 extern "C" Runtime*

--- a/madspace/src/python/function_runtime.cpp
+++ b/madspace/src/python/function_runtime.cpp
@@ -78,11 +78,13 @@ std::tuple<std::vector<Tensor>, Runtime*> check_and_convert_args(
     }
     std::vector<Tensor> inputs;
     DevicePtr expected_device = nullptr;
+    auto stream = madspace::caller_input_stream();
     for (int i = 0; i < n_args; ++i) {
         auto& arg = args.at(i);
         auto& input_type = func_runtime._function.inputs().at(i).type;
-        auto tensor =
-            dlpack_to_tensor(arg, input_type, i, expected_device, dlpack_version_cache);
+        auto tensor = dlpack_to_tensor(
+            arg, input_type, i, expected_device, dlpack_version_cache, stream
+        );
         if (expected_device == nullptr && tensor &&
             tensor.dtype() != DataType::batch_sizes) {
             expected_device = tensor.device();
@@ -156,12 +158,17 @@ py::object madspace_py::tensor_to_dlpack(
         default:
             break;
         }
+        std::uintptr_t consumer = consumer_stream(stream);
+        if (auto producer = tensor.stream(); producer && *producer != consumer) {
+            tensor.device()->order_streams(*producer, consumer);
+            tensor.set_stream(consumer);
+        }
         ManagerContext* context = new ManagerContext{
             {tensor.shape().begin(), tensor.shape().end()},
             {tensor.stride().begin(), tensor.stride().end()},
             {},
             tensor,
-            consumer_stream(stream)
+            consumer
         };
         auto [device_type, device_id] = dlpack_device(tensor);
         dl_tensor = new DLManagedTensor{
@@ -200,7 +207,8 @@ Tensor madspace_py::dlpack_to_tensor(
     std::optional<Type> expected_type,
     std::size_t arg_index,
     DevicePtr expected_device,
-    bool* dlpack_version_cache
+    bool* dlpack_version_cache,
+    std::optional<std::uintptr_t> stream
 ) {
     if (tensor.is_none()) {
         return {};
@@ -213,7 +221,7 @@ Tensor madspace_py::dlpack_to_tensor(
     // host tensor, neither of them with a TypeError, so ask for the device first.
     // dlpack spells the default stream 1 on cuda and 0 on rocm, our handle for it is 0
     py::dict stream_arg;
-    if (auto stream = madspace::caller_stream()) {
+    if (stream) {
         std::tuple<int, int> dl_device;
         try {
             dl_device = tensor.attr("__dlpack_device__")().cast<std::tuple<int, int>>();
@@ -524,9 +532,15 @@ FunctionRuntime::call_backward(
     std::vector<Tensor> arg_out;
     DevicePtr expected_device = nullptr;
     std::size_t arg_index = 0;
+    auto stream = madspace::caller_input_stream();
     for (auto& grad : output_grads) {
         auto tensor = dlpack_to_tensor(
-            grad, std::nullopt, arg_index, expected_device, &_dlpack_version_cache
+            grad,
+            std::nullopt,
+            arg_index,
+            expected_device,
+            &_dlpack_version_cache,
+            stream
         );
         if (expected_device == nullptr && tensor &&
             tensor.dtype() != DataType::batch_sizes) {
@@ -538,7 +552,12 @@ FunctionRuntime::call_backward(
     std::vector<Tensor> arg_locals;
     for (auto& local : stored_locals) {
         auto tensor = dlpack_to_tensor(
-            local, std::nullopt, arg_index, expected_device, &_dlpack_version_cache
+            local,
+            std::nullopt,
+            arg_index,
+            expected_device,
+            &_dlpack_version_cache,
+            stream
         );
         if (expected_device == nullptr && tensor &&
             tensor.dtype() != DataType::batch_sizes) {

--- a/madspace/src/python/function_runtime.cpp
+++ b/madspace/src/python/function_runtime.cpp
@@ -22,7 +22,10 @@ struct ManagerContext {
 
 void deleter(struct DLManagedTensor* self) noexcept {
     ManagerContext* context = static_cast<ManagerContext*>(self->manager_ctx);
-    context->tensor.reset_on_stream(context->stream);
+    try {
+        context->tensor.reset_on_stream(context->stream);
+    } catch (...) {
+    }
     delete context;
     delete self;
 };
@@ -78,13 +81,11 @@ std::tuple<std::vector<Tensor>, Runtime*> check_and_convert_args(
     }
     std::vector<Tensor> inputs;
     DevicePtr expected_device = nullptr;
-    auto stream = madspace::caller_input_stream();
     for (int i = 0; i < n_args; ++i) {
         auto& arg = args.at(i);
         auto& input_type = func_runtime._function.inputs().at(i).type;
-        auto tensor = dlpack_to_tensor(
-            arg, input_type, i, expected_device, dlpack_version_cache, stream
-        );
+        auto tensor =
+            dlpack_to_tensor(arg, input_type, i, expected_device, dlpack_version_cache);
         if (expected_device == nullptr && tensor &&
             tensor.dtype() != DataType::batch_sizes) {
             expected_device = tensor.device();
@@ -207,8 +208,7 @@ Tensor madspace_py::dlpack_to_tensor(
     std::optional<Type> expected_type,
     std::size_t arg_index,
     DevicePtr expected_device,
-    bool* dlpack_version_cache,
-    std::optional<std::uintptr_t> stream
+    bool* dlpack_version_cache
 ) {
     if (tensor.is_none()) {
         return {};
@@ -221,7 +221,7 @@ Tensor madspace_py::dlpack_to_tensor(
     // host tensor, neither of them with a TypeError, so ask for the device first.
     // dlpack spells the default stream 1 on cuda and 0 on rocm, our handle for it is 0
     py::dict stream_arg;
-    if (stream) {
+    if (auto stream = madspace::caller_input_stream()) {
         std::tuple<int, int> dl_device;
         try {
             dl_device = tensor.attr("__dlpack_device__")().cast<std::tuple<int, int>>();
@@ -234,12 +234,10 @@ Tensor madspace_py::dlpack_to_tensor(
             );
         }
         auto [device_type, device_id] = dl_device;
-        if (device_id == 0) {
-            if (device_type == kDLCUDA) {
-                stream_arg["stream"] = *stream == 0 ? 1 : *stream;
-            } else if (device_type == kDLROCM) {
-                stream_arg["stream"] = *stream;
-            }
+        if (device_id == 0 && device_type == kDLCUDA) {
+            stream_arg["stream"] = *stream == 0 ? 1 : *stream;
+        } else if (device_id == 0 && device_type == kDLROCM) {
+            stream_arg["stream"] = *stream;
         }
     }
 
@@ -532,15 +530,9 @@ FunctionRuntime::call_backward(
     std::vector<Tensor> arg_out;
     DevicePtr expected_device = nullptr;
     std::size_t arg_index = 0;
-    auto stream = madspace::caller_input_stream();
     for (auto& grad : output_grads) {
         auto tensor = dlpack_to_tensor(
-            grad,
-            std::nullopt,
-            arg_index,
-            expected_device,
-            &_dlpack_version_cache,
-            stream
+            grad, std::nullopt, arg_index, expected_device, &_dlpack_version_cache
         );
         if (expected_device == nullptr && tensor &&
             tensor.dtype() != DataType::batch_sizes) {
@@ -552,12 +544,7 @@ FunctionRuntime::call_backward(
     std::vector<Tensor> arg_locals;
     for (auto& local : stored_locals) {
         auto tensor = dlpack_to_tensor(
-            local,
-            std::nullopt,
-            arg_index,
-            expected_device,
-            &_dlpack_version_cache,
-            stream
+            local, std::nullopt, arg_index, expected_device, &_dlpack_version_cache
         );
         if (expected_device == nullptr && tensor &&
             tensor.dtype() != DataType::batch_sizes) {

--- a/madspace/src/python/function_runtime.cpp
+++ b/madspace/src/python/function_runtime.cpp
@@ -16,12 +16,20 @@ struct ManagerContext {
     std::vector<int64_t> stride;
     std::vector<int64_t> batch_sizes;
     Tensor tensor;
+    std::uintptr_t stream = 0;
 };
 
-void deleter(struct DLManagedTensor* self) {
-    delete static_cast<ManagerContext*>(self->manager_ctx);
+void deleter(struct DLManagedTensor* self) noexcept {
+    ManagerContext* context = static_cast<ManagerContext*>(self->manager_ctx);
+    context->tensor.reset_on_stream(context->stream);
+    delete context;
     delete self;
 };
+
+std::uintptr_t consumer_stream(std::optional<std::int64_t> stream) {
+    // no stream, 1 (legacy default) and -1 (unsynchronized) all mean the null stream
+    return !stream || *stream <= 1 ? 0 : static_cast<std::uintptr_t>(*stream);
+}
 
 Runtime* get_runtime(FunctionRuntime& func_runtime, DevicePtr expected_device) {
     Runtime* runtime;
@@ -105,7 +113,6 @@ py::object madspace_py::tensor_to_dlpack(
     std::optional<std::tuple<int, int>> dl_device,
     std::optional<bool> copy
 ) {
-    // TODO: honor the stream argument
     if (!tensor) {
         return py::none();
     }
@@ -152,7 +159,8 @@ py::object madspace_py::tensor_to_dlpack(
             {tensor.shape().begin(), tensor.shape().end()},
             {tensor.stride().begin(), tensor.stride().end()},
             {},
-            tensor
+            tensor,
+            consumer_stream(stream)
         };
         auto [device_type, device_id] = dlpack_device(tensor);
         dl_tensor = new DLManagedTensor{

--- a/madspace/src/python/function_runtime.cpp
+++ b/madspace/src/python/function_runtime.cpp
@@ -1,6 +1,7 @@
 #include "function_runtime.hpp"
 
 #include <algorithm>
+#include <array>
 #include <format>
 #include <ranges>
 #include <stdexcept>
@@ -24,14 +25,12 @@ struct ManagerContext {
 void deleter(struct DLManagedTensor* self) noexcept {
     ManagerContext* context = static_cast<ManagerContext*>(self->manager_ctx);
     try {
-        // another export may have moved the storage onto a later stream, so hand our
-        // reads over to it instead of freeing behind its back
-        std::uintptr_t free_stream =
-            context->tensor.stream().value_or(context->stream);
+        // the free below is ordered on our stream, which has to wait for the reads the
+        // consumer queued, so the consumer has to outlive the stream it named
+        std::uintptr_t free_stream = context->tensor.stream().value_or(0);
         if (free_stream != context->stream) {
             context->tensor.device()->order_streams(context->stream, free_stream);
         }
-        context->tensor.reset_on_stream(free_stream);
     } catch (...) {
     }
     delete context;
@@ -39,9 +38,8 @@ void deleter(struct DLManagedTensor* self) noexcept {
 };
 
 std::uintptr_t consumer_stream(std::optional<std::int64_t> stream, int device_type) {
-    // dlpack spells the default stream 1 on cuda and 0 on rocm, ours is 0 everywhere.
-    // 2, and 1 on rocm, name the per-thread default stream, which our blocking lanes
-    // are not ordered against
+    // dlpack spells the default stream 1 on cuda and 0 on rocm, ours is 0 everywhere,
+    // and 2, or 1 on rocm, is the per-thread one our lanes are not ordered against
     if (!stream) {
         return 0;
     }
@@ -51,6 +49,22 @@ std::uintptr_t consumer_stream(std::optional<std::int64_t> stream, int device_ty
         );
     }
     return *stream <= 1 ? 0 : static_cast<std::uintptr_t>(*stream);
+}
+
+// torch orders everything it has queued, not just the tensor it was asked about, so one
+// of its tensors orders a whole call. anyone else is asked for every tensor
+bool orders_whole_stream(PyObject* type) {
+    static std::array<py::handle, 2> torch_types;
+    if (!torch_types[0]) {
+        auto modules = py::module_::import("sys").attr("modules");
+        if (!modules.contains("torch")) {
+            return false;
+        }
+        py::object torch = modules["torch"];
+        torch_types[0] = py::object(torch.attr("Tensor")).release();
+        torch_types[1] = py::object(torch.attr("nn").attr("Parameter")).release();
+    }
+    return type == torch_types[0].ptr() || type == torch_types[1].ptr();
 }
 
 Runtime* get_runtime(FunctionRuntime& func_runtime, DevicePtr expected_device) {
@@ -119,13 +133,14 @@ std::tuple<std::vector<Tensor>, Runtime*> check_and_convert_args(
 } // namespace
 
 std::tuple<int, int> madspace_py::dlpack_device(Tensor tensor) {
+    int index = tensor.device()->device_index();
     switch (tensor.device()->device_type()) {
     case DeviceType::cpu:
         return {kDLCPU, 0};
     case DeviceType::cuda:
-        return {kDLCUDA, 0};
+        return {kDLCUDA, index};
     case DeviceType::hip:
-        return {kDLROCM, 0};
+        return {kDLROCM, index};
     default:
         throw std::logic_error("unreachable");
     }
@@ -184,13 +199,8 @@ py::object madspace_py::tensor_to_dlpack(
         std::uintptr_t consumer = consumer_stream(stream, device_type);
         if (stream && *stream == -1) {
             consumer = tensor.stream().value_or(consumer);
-        } else {
-            if (auto producer = tensor.stream();
-                producer && *producer != consumer) {
-                tensor.device()->order_streams(*producer, consumer);
-            }
-            // every consumer has to be recorded, the last one out does the free
-            tensor.set_stream(consumer);
+        } else if (auto producer = tensor.stream(); producer && *producer != consumer) {
+            tensor.device()->order_streams(*producer, consumer);
         }
         ManagerContext* context = new ManagerContext{
             {tensor.shape().begin(), tensor.shape().end()},
@@ -245,12 +255,9 @@ Tensor madspace_py::dlpack_to_tensor(
     py::object dlpack_func = tensor.attr("__dlpack__");
     py::object capsule_obj;
 
-    // a producer that orders everything it has queued against our stream only has to be
-    // asked once, so the other arguments of its type take the cheap path. ours is not
-    // one of them, it orders a single storage. numpy rejects every stream and torch
-    // rejects every stream but None and -1 for a host tensor, neither of them with a
-    // TypeError, so ask for the device first. dlpack spells the default stream 1 on
-    // cuda and 0 on rocm, our handle for it is 0
+    // ordering a producer against our stream costs ten times the rest of the import,
+    // so a type that orders everything is only asked once. host tensors are rejected
+    // without a TypeError by numpy and torch alike, so ask for the device first
     py::dict stream_arg;
     PyTypeObject* producer = Py_TYPE(tensor.ptr());
     if (!(expected_type && expected_type->dtype == DataType::batch_sizes) &&
@@ -275,7 +282,8 @@ Tensor madspace_py::dlpack_to_tensor(
             stream_arg["stream"] = device_type == kDLCUDA && stream == 0
                                        ? 1
                                        : static_cast<std::int64_t>(stream);
-            if (ordered_producers && !py::isinstance<Tensor>(tensor)) {
+            if (ordered_producers &&
+                orders_whole_stream(reinterpret_cast<PyObject*>(producer))) {
                 ordered_producers->push_back(producer);
             }
         }
@@ -576,34 +584,31 @@ FunctionRuntime::call_backward(
     const std::vector<py::object>& stored_locals,
     const std::vector<bool>& eval_grad
 ) {
-    std::vector<Tensor> arg_out;
     DevicePtr expected_device = nullptr;
     std::vector<PyTypeObject*> ordered_producers;
     std::size_t arg_index = 0;
-    for (auto& grad : output_grads) {
-        auto tensor = dlpack_to_tensor(
-            grad, std::nullopt, arg_index, expected_device, &_dlpack_version_cache,
-            &ordered_producers
-        );
+    auto convert = [&](const py::object& arg) {
+        // one of our own tensors needs neither the protocol nor a hold
+        Tensor tensor = py::isinstance<Tensor>(arg)
+            ? arg.cast<Tensor>()
+            : dlpack_to_tensor(
+                  arg, std::nullopt, arg_index, expected_device,
+                  &_dlpack_version_cache, &ordered_producers
+              );
         if (expected_device == nullptr && tensor &&
             tensor.dtype() != DataType::batch_sizes) {
             expected_device = tensor.device();
         }
-        arg_out.push_back(tensor);
         ++arg_index;
+        return tensor;
+    };
+    std::vector<Tensor> arg_out;
+    for (auto& grad : output_grads) {
+        arg_out.push_back(convert(grad));
     }
     std::vector<Tensor> arg_locals;
     for (auto& local : stored_locals) {
-        auto tensor = dlpack_to_tensor(
-            local, std::nullopt, arg_index, expected_device, &_dlpack_version_cache,
-            &ordered_producers
-        );
-        if (expected_device == nullptr && tensor &&
-            tensor.dtype() != DataType::batch_sizes) {
-            expected_device = tensor.device();
-        }
-        arg_locals.push_back(tensor);
-        ++arg_index;
+        arg_locals.push_back(convert(local));
     }
     // TODO: checks here
     Runtime* runtime = get_runtime(*this, expected_device);

--- a/madspace/src/python/function_runtime.cpp
+++ b/madspace/src/python/function_runtime.cpp
@@ -25,11 +25,12 @@ struct ManagerContext {
 void deleter(struct DLManagedTensor* self) noexcept {
     ManagerContext* context = static_cast<ManagerContext*>(self->manager_ctx);
     try {
-        // the free below is ordered on our stream, which has to wait for the reads the
-        // consumer queued, so the consumer has to outlive the stream it named
         std::uintptr_t free_stream = context->tensor.stream().value_or(0);
         if (free_stream != context->stream) {
-            context->tensor.device()->order_streams(context->stream, free_stream);
+            context->tensor.device()->order_streams(
+                reinterpret_cast<void*>(context->stream),
+                reinterpret_cast<void*>(free_stream)
+            );
         }
     } catch (...) {
     }
@@ -38,8 +39,6 @@ void deleter(struct DLManagedTensor* self) noexcept {
 };
 
 std::uintptr_t consumer_stream(std::optional<std::int64_t> stream, int device_type) {
-    // dlpack spells the default stream 1 on cuda and 0 on rocm, ours is 0 everywhere,
-    // and 2, or 1 on rocm, is the per-thread one our lanes are not ordered against
     if (!stream) {
         return 0;
     }
@@ -51,9 +50,7 @@ std::uintptr_t consumer_stream(std::optional<std::int64_t> stream, int device_ty
     return *stream <= 1 ? 0 : static_cast<std::uintptr_t>(*stream);
 }
 
-// torch orders everything it has queued, not just the tensor it was asked about, so one
-// of its tensors orders a whole call. anyone else is asked for every tensor
-bool orders_whole_stream(PyObject* type) {
+bool orders_whole_stream(PyTypeObject* type) {
     static std::array<py::handle, 2> torch_types;
     if (!torch_types[0]) {
         auto modules = py::module_::import("sys").attr("modules");
@@ -64,7 +61,8 @@ bool orders_whole_stream(PyObject* type) {
         torch_types[0] = py::object(torch.attr("Tensor")).release();
         torch_types[1] = py::object(torch.attr("nn").attr("Parameter")).release();
     }
-    return type == torch_types[0].ptr() || type == torch_types[1].ptr();
+    PyObject* obj = reinterpret_cast<PyObject*>(type);
+    return obj == torch_types[0].ptr() || obj == torch_types[1].ptr();
 }
 
 Runtime* get_runtime(FunctionRuntime& func_runtime, DevicePtr expected_device) {
@@ -118,7 +116,11 @@ std::tuple<std::vector<Tensor>, Runtime*> check_and_convert_args(
         auto& arg = args.at(i);
         auto& input_type = func_runtime._function.inputs().at(i).type;
         auto tensor = dlpack_to_tensor(
-            arg, input_type, i, expected_device, dlpack_version_cache,
+            arg,
+            input_type,
+            i,
+            expected_device,
+            dlpack_version_cache,
             &ordered_producers
         );
         if (expected_device == nullptr && tensor &&
@@ -133,14 +135,13 @@ std::tuple<std::vector<Tensor>, Runtime*> check_and_convert_args(
 } // namespace
 
 std::tuple<int, int> madspace_py::dlpack_device(Tensor tensor) {
-    int index = tensor.device()->device_index();
     switch (tensor.device()->device_type()) {
     case DeviceType::cpu:
         return {kDLCPU, 0};
     case DeviceType::cuda:
-        return {kDLCUDA, index};
+        return {kDLCUDA, 0};
     case DeviceType::hip:
-        return {kDLROCM, index};
+        return {kDLROCM, 0};
     default:
         throw std::logic_error("unreachable");
     }
@@ -200,7 +201,9 @@ py::object madspace_py::tensor_to_dlpack(
         if (stream && *stream == -1) {
             consumer = tensor.stream().value_or(consumer);
         } else if (auto producer = tensor.stream(); producer && *producer != consumer) {
-            tensor.device()->order_streams(*producer, consumer);
+            tensor.device()->order_streams(
+                reinterpret_cast<void*>(*producer), reinterpret_cast<void*>(consumer)
+            );
         }
         ManagerContext* context = new ManagerContext{
             {tensor.shape().begin(), tensor.shape().end()},
@@ -255,15 +258,12 @@ Tensor madspace_py::dlpack_to_tensor(
     py::object dlpack_func = tensor.attr("__dlpack__");
     py::object capsule_obj;
 
-    // ordering a producer against our stream costs ten times the rest of the import,
-    // so a type that orders everything is only asked once. host tensors are rejected
-    // without a TypeError by numpy and torch alike, so ask for the device first
     py::dict stream_arg;
     PyTypeObject* producer = Py_TYPE(tensor.ptr());
     if (!(expected_type && expected_type->dtype == DataType::batch_sizes) &&
         !(expected_device && expected_device->device_type() == DeviceType::cpu) &&
         !(ordered_producers &&
-          std::ranges::find(*ordered_producers, producer) !=
+          std::find(ordered_producers->begin(), ordered_producers->end(), producer) !=
               ordered_producers->end())) {
         std::uintptr_t stream = madspace::caller_stream().value_or(0);
         std::tuple<int, int> dl_device;
@@ -280,10 +280,9 @@ Tensor madspace_py::dlpack_to_tensor(
         auto [device_type, device_id] = dl_device;
         if (device_id == 0 && (device_type == kDLCUDA || device_type == kDLROCM)) {
             stream_arg["stream"] = device_type == kDLCUDA && stream == 0
-                                       ? 1
-                                       : static_cast<std::int64_t>(stream);
-            if (ordered_producers &&
-                orders_whole_stream(reinterpret_cast<PyObject*>(producer))) {
+                ? 1
+                : static_cast<std::int64_t>(stream);
+            if (ordered_producers && orders_whole_stream(producer)) {
                 ordered_producers->push_back(producer);
             }
         }
@@ -588,12 +587,15 @@ FunctionRuntime::call_backward(
     std::vector<PyTypeObject*> ordered_producers;
     std::size_t arg_index = 0;
     auto convert = [&](const py::object& arg) {
-        // one of our own tensors needs neither the protocol nor a hold
         Tensor tensor = py::isinstance<Tensor>(arg)
             ? arg.cast<Tensor>()
             : dlpack_to_tensor(
-                  arg, std::nullopt, arg_index, expected_device,
-                  &_dlpack_version_cache, &ordered_producers
+                  arg,
+                  std::nullopt,
+                  arg_index,
+                  expected_device,
+                  &_dlpack_version_cache,
+                  &ordered_producers
               );
         if (expected_device == nullptr && tensor &&
             tensor.dtype() != DataType::batch_sizes) {

--- a/madspace/src/python/function_runtime.cpp
+++ b/madspace/src/python/function_runtime.cpp
@@ -1,5 +1,6 @@
 #include "function_runtime.hpp"
 
+#include <algorithm>
 #include <format>
 #include <ranges>
 #include <stdexcept>
@@ -23,16 +24,33 @@ struct ManagerContext {
 void deleter(struct DLManagedTensor* self) noexcept {
     ManagerContext* context = static_cast<ManagerContext*>(self->manager_ctx);
     try {
-        context->tensor.reset_on_stream(context->stream);
+        // another export may have moved the storage onto a later stream, so hand our
+        // reads over to it instead of freeing behind its back
+        std::uintptr_t free_stream =
+            context->tensor.stream().value_or(context->stream);
+        if (free_stream != context->stream) {
+            context->tensor.device()->order_streams(context->stream, free_stream);
+        }
+        context->tensor.reset_on_stream(free_stream);
     } catch (...) {
     }
     delete context;
     delete self;
 };
 
-std::uintptr_t consumer_stream(std::optional<std::int64_t> stream) {
-    // no stream, 1 (legacy default) and -1 (unsynchronized) all mean the null stream
-    return !stream || *stream <= 1 ? 0 : static_cast<std::uintptr_t>(*stream);
+std::uintptr_t consumer_stream(std::optional<std::int64_t> stream, int device_type) {
+    // dlpack spells the default stream 1 on cuda and 0 on rocm, ours is 0 everywhere.
+    // 2, and 1 on rocm, name the per-thread default stream, which our blocking lanes
+    // are not ordered against
+    if (!stream) {
+        return 0;
+    }
+    if (*stream == 2 || (device_type == kDLROCM && *stream == 1)) {
+        throw py::buffer_error(
+            std::format("dlpack stream {} is not supported", *stream)
+        );
+    }
+    return *stream <= 1 ? 0 : static_cast<std::uintptr_t>(*stream);
 }
 
 Runtime* get_runtime(FunctionRuntime& func_runtime, DevicePtr expected_device) {
@@ -81,11 +99,14 @@ std::tuple<std::vector<Tensor>, Runtime*> check_and_convert_args(
     }
     std::vector<Tensor> inputs;
     DevicePtr expected_device = nullptr;
+    std::vector<PyTypeObject*> ordered_producers;
     for (int i = 0; i < n_args; ++i) {
         auto& arg = args.at(i);
         auto& input_type = func_runtime._function.inputs().at(i).type;
-        auto tensor =
-            dlpack_to_tensor(arg, input_type, i, expected_device, dlpack_version_cache);
+        auto tensor = dlpack_to_tensor(
+            arg, input_type, i, expected_device, dlpack_version_cache,
+            &ordered_producers
+        );
         if (expected_device == nullptr && tensor &&
             tensor.dtype() != DataType::batch_sizes) {
             expected_device = tensor.device();
@@ -159,9 +180,16 @@ py::object madspace_py::tensor_to_dlpack(
         default:
             break;
         }
-        std::uintptr_t consumer = consumer_stream(stream);
-        if (auto producer = tensor.stream(); producer && *producer != consumer) {
-            tensor.device()->order_streams(*producer, consumer);
+        auto [device_type, device_id] = dlpack_device(tensor);
+        std::uintptr_t consumer = consumer_stream(stream, device_type);
+        if (stream && *stream == -1) {
+            consumer = tensor.stream().value_or(consumer);
+        } else {
+            if (auto producer = tensor.stream();
+                producer && *producer != consumer) {
+                tensor.device()->order_streams(*producer, consumer);
+            }
+            // every consumer has to be recorded, the last one out does the free
             tensor.set_stream(consumer);
         }
         ManagerContext* context = new ManagerContext{
@@ -171,7 +199,6 @@ py::object madspace_py::tensor_to_dlpack(
             tensor,
             consumer
         };
-        auto [device_type, device_id] = dlpack_device(tensor);
         dl_tensor = new DLManagedTensor{
             {context->tensor.data(),
              DLDevice{static_cast<DLDeviceType>(device_type), device_id},
@@ -208,7 +235,8 @@ Tensor madspace_py::dlpack_to_tensor(
     std::optional<Type> expected_type,
     std::size_t arg_index,
     DevicePtr expected_device,
-    bool* dlpack_version_cache
+    bool* dlpack_version_cache,
+    std::vector<PyTypeObject*>* ordered_producers
 ) {
     if (tensor.is_none()) {
         return {};
@@ -217,11 +245,20 @@ Tensor madspace_py::dlpack_to_tensor(
     py::object dlpack_func = tensor.attr("__dlpack__");
     py::object capsule_obj;
 
-    // numpy rejects every stream and torch rejects every stream but None and -1 for a
-    // host tensor, neither of them with a TypeError, so ask for the device first.
-    // dlpack spells the default stream 1 on cuda and 0 on rocm, our handle for it is 0
+    // a producer that orders everything it has queued against our stream only has to be
+    // asked once, so the other arguments of its type take the cheap path. ours is not
+    // one of them, it orders a single storage. numpy rejects every stream and torch
+    // rejects every stream but None and -1 for a host tensor, neither of them with a
+    // TypeError, so ask for the device first. dlpack spells the default stream 1 on
+    // cuda and 0 on rocm, our handle for it is 0
     py::dict stream_arg;
-    if (auto stream = madspace::caller_input_stream()) {
+    PyTypeObject* producer = Py_TYPE(tensor.ptr());
+    if (!(expected_type && expected_type->dtype == DataType::batch_sizes) &&
+        !(expected_device && expected_device->device_type() == DeviceType::cpu) &&
+        !(ordered_producers &&
+          std::ranges::find(*ordered_producers, producer) !=
+              ordered_producers->end())) {
+        std::uintptr_t stream = madspace::caller_stream().value_or(0);
         std::tuple<int, int> dl_device;
         try {
             dl_device = tensor.attr("__dlpack_device__")().cast<std::tuple<int, int>>();
@@ -234,10 +271,13 @@ Tensor madspace_py::dlpack_to_tensor(
             );
         }
         auto [device_type, device_id] = dl_device;
-        if (device_id == 0 && device_type == kDLCUDA) {
-            stream_arg["stream"] = *stream == 0 ? 1 : *stream;
-        } else if (device_id == 0 && device_type == kDLROCM) {
-            stream_arg["stream"] = *stream;
+        if (device_id == 0 && (device_type == kDLCUDA || device_type == kDLROCM)) {
+            stream_arg["stream"] = device_type == kDLCUDA && stream == 0
+                                       ? 1
+                                       : static_cast<std::int64_t>(stream);
+            if (ordered_producers && !py::isinstance<Tensor>(tensor)) {
+                ordered_producers->push_back(producer);
+            }
         }
     }
 
@@ -264,6 +304,9 @@ Tensor madspace_py::dlpack_to_tensor(
         try {
             capsule_obj = dlpack_func(**stream_arg);
         } catch (py::error_already_set& e) {
+            if (!e.matches(PyExc_TypeError)) {
+                throw;
+            }
             capsule_obj = dlpack_func(
                 "max_version"_a =
                     std::make_tuple(DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION),
@@ -494,6 +537,12 @@ Tensor madspace_py::dlpack_to_tensor(
     return ret_tensor;
 }
 
+void FunctionRuntime::release_inputs() {
+    for (auto& entry : _runtimes) {
+        entry.second->release_inputs();
+    }
+}
+
 std::vector<Tensor> FunctionRuntime::call(std::vector<py::object> args) {
     auto [inputs, runtime] =
         check_and_convert_args(args, *this, &_dlpack_version_cache);
@@ -529,10 +578,12 @@ FunctionRuntime::call_backward(
 ) {
     std::vector<Tensor> arg_out;
     DevicePtr expected_device = nullptr;
+    std::vector<PyTypeObject*> ordered_producers;
     std::size_t arg_index = 0;
     for (auto& grad : output_grads) {
         auto tensor = dlpack_to_tensor(
-            grad, std::nullopt, arg_index, expected_device, &_dlpack_version_cache
+            grad, std::nullopt, arg_index, expected_device, &_dlpack_version_cache,
+            &ordered_producers
         );
         if (expected_device == nullptr && tensor &&
             tensor.dtype() != DataType::batch_sizes) {
@@ -544,7 +595,8 @@ FunctionRuntime::call_backward(
     std::vector<Tensor> arg_locals;
     for (auto& local : stored_locals) {
         auto tensor = dlpack_to_tensor(
-            local, std::nullopt, arg_index, expected_device, &_dlpack_version_cache
+            local, std::nullopt, arg_index, expected_device, &_dlpack_version_cache,
+            &ordered_producers
         );
         if (expected_device == nullptr && tensor &&
             tensor.dtype() != DataType::batch_sizes) {

--- a/madspace/src/python/function_runtime.cpp
+++ b/madspace/src/python/function_runtime.cpp
@@ -5,6 +5,7 @@
 #include <stdexcept>
 
 #include "dlpack.h"
+#include "madspace/driver/context.hpp"
 
 using namespace madspace_py;
 using namespace pybind11::literals;
@@ -208,17 +209,44 @@ Tensor madspace_py::dlpack_to_tensor(
     py::object dlpack_func = tensor.attr("__dlpack__");
     py::object capsule_obj;
 
+    // numpy rejects every stream and torch rejects every stream but None and -1 for a
+    // host tensor, neither of them with a TypeError, so ask for the device first.
+    // dlpack spells the default stream 1 on cuda and 0 on rocm, our handle for it is 0
+    py::dict stream_arg;
+    if (auto stream = madspace::caller_stream()) {
+        std::tuple<int, int> dl_device;
+        try {
+            dl_device = tensor.attr("__dlpack_device__")().cast<std::tuple<int, int>>();
+        } catch (const py::cast_error&) {
+            throw std::invalid_argument(
+                std::format(
+                    "Argument {}: __dlpack_device__ must return a pair of ints",
+                    arg_index + 1
+                )
+            );
+        }
+        auto [device_type, device_id] = dl_device;
+        if (device_id == 0) {
+            if (device_type == kDLCUDA) {
+                stream_arg["stream"] = *stream == 0 ? 1 : *stream;
+            } else if (device_type == kDLROCM) {
+                stream_arg["stream"] = *stream;
+            }
+        }
+    }
+
     // catching exceptions is extremely expensive so we cache whether to use the new or
     // old version of the dlpack protocol
     if (dlpack_version_cache == nullptr || !*dlpack_version_cache) {
         try {
             capsule_obj = dlpack_func(
                 "max_version"_a =
-                    std::make_tuple(DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION)
+                    std::make_tuple(DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION),
+                **stream_arg
             );
         } catch (py::error_already_set& e) {
             if (e.matches(PyExc_TypeError)) {
-                capsule_obj = dlpack_func();
+                capsule_obj = dlpack_func(**stream_arg);
                 if (dlpack_version_cache != nullptr) {
                     *dlpack_version_cache = true;
                 }
@@ -228,11 +256,12 @@ Tensor madspace_py::dlpack_to_tensor(
         }
     } else {
         try {
-            capsule_obj = dlpack_func();
+            capsule_obj = dlpack_func(**stream_arg);
         } catch (py::error_already_set& e) {
             capsule_obj = dlpack_func(
                 "max_version"_a =
-                    std::make_tuple(DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION)
+                    std::make_tuple(DLPACK_MAJOR_VERSION, DLPACK_MINOR_VERSION),
+                **stream_arg
             );
             *dlpack_version_cache = false;
         }

--- a/madspace/src/python/function_runtime.cpp
+++ b/madspace/src/python/function_runtime.cpp
@@ -100,14 +100,21 @@ std::tuple<int, int> madspace_py::dlpack_device(Tensor tensor) {
 
 py::object madspace_py::tensor_to_dlpack(
     Tensor tensor,
-    std::optional<int> stream,
+    std::optional<std::int64_t> stream,
     std::optional<std::tuple<int, int>> max_version,
-    std::optional<int> dl_device,
+    std::optional<std::tuple<int, int>> dl_device,
     std::optional<bool> copy
 ) {
-    // TODO: do something with the arguments
+    // TODO: honor the stream argument
     if (!tensor) {
         return py::none();
+    }
+
+    if (copy && *copy) {
+        throw py::buffer_error("dlpack export cannot copy the tensor");
+    }
+    if (dl_device && *dl_device != dlpack_device(tensor)) {
+        throw py::buffer_error("dlpack export cannot change the device");
     }
 
     DLManagedTensor* dl_tensor;

--- a/madspace/src/python/function_runtime.hpp
+++ b/madspace/src/python/function_runtime.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <pybind11/pybind11.h>
 #include <unordered_map>
 #include <vector>
@@ -15,9 +16,9 @@ namespace madspace_py {
 std::tuple<int, int> dlpack_device(Tensor tensor);
 py::object tensor_to_dlpack(
     Tensor tensor,
-    std::optional<int> stream = std::nullopt,
+    std::optional<std::int64_t> stream = std::nullopt,
     std::optional<std::tuple<int, int>> max_version = std::nullopt,
-    std::optional<int> dl_device = std::nullopt,
+    std::optional<std::tuple<int, int>> dl_device = std::nullopt,
     std::optional<bool> copy = std::nullopt
 );
 Tensor dlpack_to_tensor(

--- a/madspace/src/python/function_runtime.hpp
+++ b/madspace/src/python/function_runtime.hpp
@@ -26,8 +26,7 @@ Tensor dlpack_to_tensor(
     std::optional<Type> expected_type = std::nullopt,
     std::size_t arg_index = 0,
     DevicePtr expected_device = nullptr,
-    bool* dlpack_version_cache = nullptr,
-    std::optional<std::uintptr_t> stream = std::nullopt
+    bool* dlpack_version_cache = nullptr
 );
 
 struct FunctionRuntime {

--- a/madspace/src/python/function_runtime.hpp
+++ b/madspace/src/python/function_runtime.hpp
@@ -26,7 +26,8 @@ Tensor dlpack_to_tensor(
     std::optional<Type> expected_type = std::nullopt,
     std::size_t arg_index = 0,
     DevicePtr expected_device = nullptr,
-    bool* dlpack_version_cache = nullptr
+    bool* dlpack_version_cache = nullptr,
+    std::optional<std::uintptr_t> stream = std::nullopt
 );
 
 struct FunctionRuntime {

--- a/madspace/src/python/function_runtime.hpp
+++ b/madspace/src/python/function_runtime.hpp
@@ -26,7 +26,8 @@ Tensor dlpack_to_tensor(
     std::optional<Type> expected_type = std::nullopt,
     std::size_t arg_index = 0,
     DevicePtr expected_device = nullptr,
-    bool* dlpack_version_cache = nullptr
+    bool* dlpack_version_cache = nullptr,
+    std::vector<PyTypeObject*>* ordered_producers = nullptr
 );
 
 struct FunctionRuntime {
@@ -50,6 +51,7 @@ struct FunctionRuntime {
         const std::vector<py::object>& stored_locals,
         const std::vector<bool>& eval_grad
     );
+    void release_inputs();
 
     Function _function;
     ContextPtr _context;

--- a/madspace/src/python/madspace.cpp
+++ b/madspace/src/python/madspace.cpp
@@ -282,6 +282,14 @@ PYBIND11_MODULE(_madspace_py, m) {
     m.def("default_context", &default_context);
     m.def("default_cuda_context", &default_cuda_context, py::arg("index") = 0);
     m.def("default_hip_context", &default_hip_context, py::arg("index") = 0);
+    m.def("get_stream", &caller_stream);
+    m.def("get_input_stream", &caller_input_stream);
+    m.def(
+        "set_stream",
+        &set_caller_stream,
+        py::arg("stream"),
+        py::arg("order_inputs") = true
+    );
 
     py::classh<FunctionRuntime>(m, "FunctionRuntime", py::dynamic_attr())
         .def(py::init<Function>(), py::arg("function"))
@@ -980,9 +988,17 @@ PYBIND11_MODULE(_madspace_py, m) {
         .def(
             "add_data",
             [](VegasGridOptimizer& opt, py::object values, py::object counts) {
+                auto stream = caller_input_stream();
                 opt.add_data(
-                    dlpack_to_tensor(values, batch_float, 0),
-                    dlpack_to_tensor(counts, batch_float_array(opt.input_dim()), 1)
+                    dlpack_to_tensor(values, batch_float, 0, nullptr, nullptr, stream),
+                    dlpack_to_tensor(
+                        counts,
+                        batch_float_array(opt.input_dim()),
+                        1,
+                        nullptr,
+                        nullptr,
+                        stream
+                    )
                 );
             },
             py::arg("values"),
@@ -1001,10 +1017,16 @@ PYBIND11_MODULE(_madspace_py, m) {
             "add_data",
             [](DiscreteOptimizer& opt, std::vector<py::object> values_and_counts) {
                 TensorVec input_tensors;
+                auto stream = caller_input_stream();
                 for (std::size_t i = 1; auto& input : values_and_counts) {
-                    input_tensors.push_back(
-                        dlpack_to_tensor(input, i % 2 == 0 ? batch_int : batch_float, i)
-                    );
+                    input_tensors.push_back(dlpack_to_tensor(
+                        input,
+                        i % 2 == 0 ? batch_int : batch_float,
+                        i,
+                        nullptr,
+                        nullptr,
+                        stream
+                    ));
                     ++i;
                 }
                 opt.add_data(input_tensors);
@@ -1057,11 +1079,12 @@ PYBIND11_MODULE(_madspace_py, m) {
                 TensorVec tensors;
                 tensors.reserve(inputs.size());
                 bool dlpack_version_cache = false;
+                auto stream = caller_input_stream();
                 for (std::size_t i = 0;
                      auto [input, type] : zip(inputs, opt.input_types())) {
-                    tensors.push_back(
-                        dlpack_to_tensor(input, type, i, device, &dlpack_version_cache)
-                    );
+                    tensors.push_back(dlpack_to_tensor(
+                        input, type, i, device, &dlpack_version_cache, stream
+                    ));
                     ++i;
                 }
                 return opt.step(tensors);

--- a/madspace/src/python/madspace.cpp
+++ b/madspace/src/python/madspace.cpp
@@ -283,20 +283,15 @@ PYBIND11_MODULE(_madspace_py, m) {
     m.def("default_cuda_context", &default_cuda_context, py::arg("index") = 0);
     m.def("default_hip_context", &default_hip_context, py::arg("index") = 0);
     m.def("get_stream", &caller_stream);
-    m.def("get_input_stream", &caller_input_stream);
-    m.def(
-        "set_stream",
-        &set_caller_stream,
-        py::arg("stream"),
-        py::arg("order_inputs") = true
-    );
+    m.def("set_stream", &set_caller_stream, py::arg("stream"));
 
     py::classh<FunctionRuntime>(m, "FunctionRuntime", py::dynamic_attr())
         .def(py::init<Function>(), py::arg("function"))
         .def(py::init<Function, ContextPtr>(), py::arg("function"), py::arg("context"))
         .def("call", &FunctionRuntime::call)
         .def("call_with_grad", &FunctionRuntime::call_with_grad)
-        .def("call_backward", &FunctionRuntime::call_backward);
+        .def("call_backward", &FunctionRuntime::call_backward)
+        .def("release_inputs", &FunctionRuntime::release_inputs);
 
     auto& fb =
         py::classh<FunctionBuilder>(m, "FunctionBuilder")
@@ -1009,10 +1004,12 @@ PYBIND11_MODULE(_madspace_py, m) {
             "add_data",
             [](DiscreteOptimizer& opt, std::vector<py::object> values_and_counts) {
                 TensorVec input_tensors;
+                std::vector<PyTypeObject*> ordered_producers;
                 for (std::size_t i = 1; auto& input : values_and_counts) {
-                    input_tensors.push_back(
-                        dlpack_to_tensor(input, i % 2 == 0 ? batch_int : batch_float, i)
-                    );
+                    input_tensors.push_back(dlpack_to_tensor(
+                        input, i % 2 == 0 ? batch_int : batch_float, i, nullptr,
+                        nullptr, &ordered_producers
+                    ));
                     ++i;
                 }
                 opt.add_data(input_tensors);
@@ -1065,11 +1062,13 @@ PYBIND11_MODULE(_madspace_py, m) {
                 TensorVec tensors;
                 tensors.reserve(inputs.size());
                 bool dlpack_version_cache = false;
+                std::vector<PyTypeObject*> ordered_producers;
                 for (std::size_t i = 0;
                      auto [input, type] : zip(inputs, opt.input_types())) {
-                    tensors.push_back(
-                        dlpack_to_tensor(input, type, i, device, &dlpack_version_cache)
-                    );
+                    tensors.push_back(dlpack_to_tensor(
+                        input, type, i, device, &dlpack_version_cache,
+                        &ordered_producers
+                    ));
                     ++i;
                 }
                 return opt.step(tensors);

--- a/madspace/src/python/madspace.cpp
+++ b/madspace/src/python/madspace.cpp
@@ -1007,8 +1007,12 @@ PYBIND11_MODULE(_madspace_py, m) {
                 std::vector<PyTypeObject*> ordered_producers;
                 for (std::size_t i = 1; auto& input : values_and_counts) {
                     input_tensors.push_back(dlpack_to_tensor(
-                        input, i % 2 == 0 ? batch_int : batch_float, i, nullptr,
-                        nullptr, &ordered_producers
+                        input,
+                        i % 2 == 0 ? batch_int : batch_float,
+                        i,
+                        nullptr,
+                        nullptr,
+                        &ordered_producers
                     ));
                     ++i;
                 }
@@ -1066,7 +1070,11 @@ PYBIND11_MODULE(_madspace_py, m) {
                 for (std::size_t i = 0;
                      auto [input, type] : zip(inputs, opt.input_types())) {
                     tensors.push_back(dlpack_to_tensor(
-                        input, type, i, device, &dlpack_version_cache,
+                        input,
+                        type,
+                        i,
+                        device,
+                        &dlpack_version_cache,
                         &ordered_producers
                     ));
                     ++i;

--- a/madspace/src/python/madspace.cpp
+++ b/madspace/src/python/madspace.cpp
@@ -988,17 +988,9 @@ PYBIND11_MODULE(_madspace_py, m) {
         .def(
             "add_data",
             [](VegasGridOptimizer& opt, py::object values, py::object counts) {
-                auto stream = caller_input_stream();
                 opt.add_data(
-                    dlpack_to_tensor(values, batch_float, 0, nullptr, nullptr, stream),
-                    dlpack_to_tensor(
-                        counts,
-                        batch_float_array(opt.input_dim()),
-                        1,
-                        nullptr,
-                        nullptr,
-                        stream
-                    )
+                    dlpack_to_tensor(values, batch_float, 0),
+                    dlpack_to_tensor(counts, batch_float_array(opt.input_dim()), 1)
                 );
             },
             py::arg("values"),
@@ -1017,16 +1009,10 @@ PYBIND11_MODULE(_madspace_py, m) {
             "add_data",
             [](DiscreteOptimizer& opt, std::vector<py::object> values_and_counts) {
                 TensorVec input_tensors;
-                auto stream = caller_input_stream();
                 for (std::size_t i = 1; auto& input : values_and_counts) {
-                    input_tensors.push_back(dlpack_to_tensor(
-                        input,
-                        i % 2 == 0 ? batch_int : batch_float,
-                        i,
-                        nullptr,
-                        nullptr,
-                        stream
-                    ));
+                    input_tensors.push_back(
+                        dlpack_to_tensor(input, i % 2 == 0 ? batch_int : batch_float, i)
+                    );
                     ++i;
                 }
                 opt.add_data(input_tensors);
@@ -1079,12 +1065,11 @@ PYBIND11_MODULE(_madspace_py, m) {
                 TensorVec tensors;
                 tensors.reserve(inputs.size());
                 bool dlpack_version_cache = false;
-                auto stream = caller_input_stream();
                 for (std::size_t i = 0;
                      auto [input, type] : zip(inputs, opt.input_types())) {
-                    tensors.push_back(dlpack_to_tensor(
-                        input, type, i, device, &dlpack_version_cache, stream
-                    ));
+                    tensors.push_back(
+                        dlpack_to_tensor(input, type, i, device, &dlpack_version_cache)
+                    );
                     ++i;
                 }
                 return opt.step(tensors);

--- a/madspace/src/python/madspace.cpp
+++ b/madspace/src/python/madspace.cpp
@@ -236,6 +236,7 @@ PYBIND11_MODULE(_madspace_py, m) {
         .def(
             "__dlpack__",
             &tensor_to_dlpack,
+            py::kw_only(),
             py::arg("stream") = std::nullopt,
             py::arg("max_version") = std::nullopt,
             py::arg("dl_device") = std::nullopt,


### PR DESCRIPTION
Several modifications to make the code more flexible for external users of the `madspace` package, focusing on the application of https://arxiv.org/abs/2608.23022. Also tried to generally make the stream handling in `madspace` cleaner/safer.

On a NVIDIA RTX PRO 500 Blackwell GPU this made a batchsize=1k evaluation of 3-body `TPropagatorMapping.map_forward` 2x faster (384mus -> 177mus, because `cudaFreeAsync`) and significantly reduced host occupation (3.21ms -> 0.37ms at batchsize=100k, because no stream sync). I didn't find any scenario that gets slower.

I used claude for the code edits.

### Bug fixes
- MadSpace released memory while external kernels still read it; use `cudaFreeAsync` instead of `cudaFree` to fix this
- Imported inputs were not properly ordered; fixed by always passing the DLPack `stream` argument
- DLPack protocol ignored arguments `stream`, `copy`, `max_version`; now they are used
- GPU calls after CUDA runtime shutdown cause issues; now fixed
- Several smaller bugs in gradient handling with external tensors

### New features
- External users can set the madspace stream through a context manager, for instance `with madspace.stream(torch.cuda.current_stream().cuda_stream): ...`; avoids overhead from stream syncs
- `fork_streams` and `join_streams` keep each stream clean until passing it back to the caller
- Stream ordering across the DLPack boundary
- `release_inputs()` to give manual control about when tensors held in `madspace` are cleaned

### Comments
- Tested the changes on CPU and CUDA, not on HIP and ROCm
- Code only supports single-GPU; mismatched `dl_device` raises an error
- The `_prev_caches`, `_prev_caches_backward`, `update_cached_tensors`, `MemPool::reset` and `_backward_wait_events` functions are called only from commented-out code