### PR TITLE
madspace: write N LHE files from combine_to_lhe, and have MadSpin use it

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -4557,6 +4557,13 @@ class MadSpinInterface(extended_cmd.Cmd):
             # multiplier of its own so a generation child can never land on the
             # stream of an unweighting/max-weight worker (those use 7919).
             random.seed((int(self.seed) if self.seed else 0) + 104729 * seed_offset)
+            # Start the child's accounting from zero. It inherited the parent's
+            # dicts through the fork, and everything already in them has been
+            # charged in the parent too -- reporting it back would double it.
+            times = self.__dict__.get('_phase_times')
+            if times is not None:
+                times.clear()
+                self._phase_counts.clear()
             self._gen_nb_core = nb_core
             self.seed = (int(self.seed) + 1000003 * seed_offset) % (30081 * 30081)
             self.options['seed'] = self.seed
@@ -4572,7 +4579,16 @@ class MadSpinInterface(extended_cmd.Cmd):
                                          for k, v in out.items()),
                            'width': width,
                            'channel_widths': dict((str(k), v) for k, v
-                                                  in channel_widths.items())},
+                                                  in channel_widths.items()),
+                           # The phase timings too, or every phase of the decay
+                           # generation -- decay_event_generation, the largest
+                           # of them all -- dies here with the child and is
+                           # simply missing from the run's report. See
+                           # _generate_decays for how they are added back.
+                           'phase_times': dict(
+                               self.__dict__.get('_phase_times') or {}),
+                           'phase_counts': dict(
+                               self.__dict__.get('_phase_counts') or {})},
                           fp)
         except Exception as exc:
             import traceback
@@ -4632,6 +4648,15 @@ class MadSpinInterface(extended_cmd.Cmd):
             if 'error' in data:
                 raise Exception("MadSpin: the decay generation of pdg %s failed:\n%s"
                                 % (pdg, data.get('tb', data['error'])))
+            # Put the child's phase timings back into this process's accounting.
+            # They are a SUM OVER PARTICLES of work that ran concurrently, so
+            # they are work done, not wall time, and can exceed the wall time of
+            # the fork that contained them -- which is why they are charged to
+            # their own phases and never to a parent phase measured out here.
+            for name, dt in (data.get('phase_times') or {}).items():
+                self._add_phase(name, dt, count=0)
+            for name, count in (data.get('phase_counts') or {}).items():
+                self._add_count(name, count)
             channel_widths = dict((int(k), v) for k, v
                                   in data.get('channel_widths', {}).items())
             # The per-channel width goes back in with the paths: an mg7 pool has

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -2741,8 +2741,9 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         The pool is left in the layout the parallel unweighting expects of any
         backend -- one LHE file per worker, under ``Events/<run_name>/`` -- so
-        that mg7 goes down exactly the same paths madevent does. See below for
-        why LHE rather than the (faster to read) numpy event file.
+        that mg7 goes down exactly the same paths madevent does. mg7 writes the
+        per-worker files itself (see below); see further below for why LHE
+        rather than the (faster to read) numpy event file.
         """
         run_card_path = pjoin(decay_dir, 'Cards', 'run_card.toml')
         run_card = banner.RunCardMG7(run_card_path)
@@ -2762,6 +2763,24 @@ class MadSpinInterface(extended_cmd.Cmd):
         # the owner->waiter publish contract, i.e. an extension of the one
         # protocol surface where a publish/open race can live. Not worth 5%.
         run_card['run']['output_format'] = 'lhe'
+
+        # One file per unweighting worker. mg7 writes them itself -- madspace's
+        # combine_to_lhe deals the events out round-robin as it formats them --
+        # so the pool is never materialised as one file and then split. That is
+        # what ``nb_output_files`` asks for; it is mg7's ``nb_unweight_output``.
+        #
+        # mg7 still names its own Events/run_NN directory, so the files land
+        # there and have to be moved to the paths the rest of MadSpin expects of
+        # any backend (below). The move is N renames within one filesystem, and
+        # it buys back the atomicity the refill protocol wants: the canonical
+        # directory never contains a half-written pool, which is the same reason
+        # _materialise_refill_pool builds in a .part directory.
+        #
+        # Each file gets its own <init> block with the channel's partial width,
+        # so it is still self-describing (see below). Left uncompressed: they
+        # are read back immediately and gzip is pure overhead here.
+        nb_split = self._decay_pool_split()
+        run_card['run']['nb_output_files'] = max(1, int(nb_split))
         run_card.write(run_card_path)
         with open(pjoin(decay_dir, 'Cards', 'param_card.dat'), 'w') as fsock:
             fsock.write(self.banner['slha'])
@@ -2784,19 +2803,68 @@ class MadSpinInterface(extended_cmd.Cmd):
                 'the mg7 decay generator failed in %s (exit %s); see %s'
                 % (decay_dir, returncode, log_path))
         after = set(misc.glob('*', events_dir)) if os.path.isdir(events_dir) else set()
-        new_runs = sorted(after - before)
+        # mg7 names its own run directory (Events/run_NN) and drops info.json in
+        # it, which is what identifies it among anything else that may have
+        # appeared under Events/ while the launcher ran.
+        new_runs = sorted(path for path in after - before
+                          if os.path.exists(pjoin(path, 'info.json')))
         if not new_runs:
             raise self.InvalidCmd(
                 'the mg7 decay generator produced no run directory in %s' % events_dir)
         run_dir = new_runs[-1]
 
-        for name in ('events.lhe', 'events.lhe.gz'):
-            events_path = pjoin(run_dir, name)
-            if os.path.exists(events_path):
-                break
+        targets = []
+        if nb_split > 1:
+            # Where the rest of MadSpin expects any backend's pool to be: the
+            # same paths madevent reaches through ``nb_unweight_output``. Two
+            # things fall out of the pool being THERE rather than anywhere else:
+            # a worker opens its own file instead of striding the whole pool
+            # (which costs it a full parse of every other worker's events), and
+            # on a refill these paths *are* _refill_pool_paths, so
+            # _generate_refill_pool finds sources == targets and does no further
+            # work.
+            targets = lhe_parser.EventFile.unweight_output_paths(
+                pjoin(decay_dir, 'Events', run_name, 'unweighted_events.lhe'),
+                nb_split)
+            sources = [pjoin(run_dir, 'events_%d.lhe' % i)
+                       for i in range(nb_split)]
+            single = pjoin(run_dir, 'events.lhe')
+            target_dir = os.path.dirname(targets[0])
+            if not os.path.isdir(target_dir):
+                os.makedirs(target_dir)
+            if all(os.path.exists(path) for path in sources):
+                # The whole point of nb_output_files: mg7 already wrote one
+                # file per worker, so there is nothing to split -- only N
+                # renames within the same filesystem, which also keep the
+                # canonical directory from ever holding a half-written pool.
+                for source, target in zip(sources, targets):
+                    os.replace(source, target)
+            elif os.path.exists(single):
+                # A madspace too old to write several files wrote one instead
+                # (it says so in the log). Deal it out here, which is what
+                # MadSpin did for every mg7 run before nb_output_files existed.
+                logger.info('mg7 wrote a single pool; splitting it in python. '
+                            'Rebuild madspace to have mg7 write the per-worker '
+                            'files directly.')
+                with self._phase('decay_mg7_split'):
+                    self._split_pool_round_robin([single], targets)
+                try:
+                    os.remove(single)
+                except OSError:
+                    pass
+            else:
+                raise self.InvalidCmd(
+                    'the mg7 decay generator wrote neither %s nor %s (see %s)'
+                    % (sources[0], single, log_path))
+            banner_path = targets[0]
         else:
-            raise self.InvalidCmd(
-                'the mg7 decay generator produced no LHE file in %s' % run_dir)
+            for name in ('events.lhe', 'events.lhe.gz'):
+                banner_path = pjoin(run_dir, name)
+                if os.path.exists(banner_path):
+                    break
+            else:
+                raise self.InvalidCmd(
+                    'the mg7 decay generator produced no LHE file in %s' % run_dir)
 
         # Timing breakdown, best effort: the launcher reports how long the
         # integration itself took, and the rest of the subprocess wall time is
@@ -2815,44 +2883,15 @@ class MadSpinInterface(extended_cmd.Cmd):
                                 for stage in run_times.values()
                                 if isinstance(stage, dict)))
 
-        pool = lhe_parser.EventFile(events_path)
-        # <init> of a 1 -> n process carries a width in GeV, not a cross section
+        pool = lhe_parser.EventFile(banner_path)
+        # <init> of a 1 -> n process carries a width in GeV, not a cross
+        # section. Every slice carries the same banner, so slice 0 answers for
+        # the pool -- which is also what makes a slice openable by path alone.
         width = pool.cross
-
-        # Deal the pool out into one file per unweighting worker, at the paths
-        # the rest of MadSpin already expects any backend to use -- the same
-        # ones madevent reaches through the run_card's ``nb_unweight_output``.
-        # Two things fall out of writing them THERE rather than anywhere else:
-        # a worker opens its own file instead of striding the whole pool (which
-        # costs it a full parse of every other worker's events), and on a refill
-        # these paths *are* _refill_pool_paths, so _generate_refill_pool finds
-        # sources == targets and does no further work. Left uncompressed: they
-        # are read back immediately and gzip is pure overhead here.
-        nb_split = self._decay_pool_split()
-        if nb_split <= 1:
+        if not targets:
             pool.seek(0)
             return pool, width
         pool.close()
-        targets = lhe_parser.EventFile.unweight_output_paths(
-            pjoin(decay_dir, 'Events', run_name, 'unweighted_events.lhe'),
-            nb_split)
-        target_dir = os.path.dirname(targets[0])
-        if not os.path.isdir(target_dir):
-            os.makedirs(target_dir)
-        with self._phase('decay_mg7_split'):
-            self._split_pool_round_robin([events_path], targets)
-        # Between them the slices hold every event of the source -- the split
-        # reads it to the end or raises -- so keeping the source doubles what a
-        # pool costs on disk: another 241 MB per channel on the 100k benchmark,
-        # and a refill adds a generation rather than replacing one. Nothing
-        # reads it after this point (each slice carries its own banner, and the
-        # run directory keeps info.json and the generation log), so drop it once
-        # every slice is actually there.
-        if all(os.path.exists(path) for path in targets):
-            try:
-                os.remove(events_path)
-            except OSError:
-                pass
         return _ChainedEvents(targets), width
 
     # File in which a decay directory records the partial width that was

--- a/madgraph/iolibs/template_files/mg7/madevent.py
+++ b/madgraph/iolibs/template_files/mg7/madevent.py
@@ -968,13 +968,61 @@ class MadgraphProcess:
             )
         elif output_format == "lhe":
             self.lhe_completer = self.build_lhe_completer()
-            self.event_generator.combine_to_lhe(
-                os.path.join(self.run_path, "events.lhe"), self.lhe_completer,
-                self.build_lhe_meta(),
-            )
+            self.combine_to_lhe_files(self.lhe_output_files())
         else:
             raise ValueError("Unknown output format")
         self.save_gridpack()
+
+    def lhe_output_files(self) -> list:
+        """Where combine_to_lhe should write, as a list of paths.
+
+        One ``<run_path>/events.lhe`` normally; with [run] nb_output_files = N,
+        ``<run_path>/events_0.lhe`` ... ``events_{N-1}.lhe``, into which
+        madspace deals the events round-robin as it formats them. Every one of
+        them is a complete LHE file, with its own <init> block, so a reader can
+        open any of them by path alone.
+
+        This exists for a consumer that reads the events back in parallel: with
+        N files each of its workers parses only its own share, instead of
+        reading the whole stream and skipping the (N-1)/N of it that belongs to
+        somebody else. It is the mg7 counterpart of madevent's
+        ``nb_unweight_output``, and MadSpin's decay pools are what asked for it.
+        """
+        count = int(self.run_card["run"]["nb_output_files"])
+        if count <= 1:
+            return [os.path.join(self.run_path, "events.lhe")]
+        return [os.path.join(self.run_path, "events_%d.lhe" % i)
+                for i in range(count)]
+
+    def combine_to_lhe_files(self, files) -> None:
+        """Write the combined events into ``files``, using madspace's
+        multi-file combine_to_lhe, which fans them out as it formats them and
+        so never materialises the whole stream in one file.
+
+        madspace is not upgraded in lockstep with this template -- it can be an
+        older binary wheel -- and one built before that overload exists only
+        accepts a single path. Rather than reimplement the fan-out here, fall
+        back to the single ``events.lhe`` such a build can write and say so: a
+        caller that asked for several files is a caller that already knows how
+        to split one, and it can see from what is on disk which it got.
+        """
+        meta = self.build_lhe_meta()
+        single = os.path.join(self.run_path, "events.lhe")
+        if len(files) == 1:
+            # the str overload, so an older madspace is fine here too
+            self.event_generator.combine_to_lhe(files[0], self.lhe_completer, meta)
+            return
+        # LHEMultiFileWriter is the class the list overload is built on, so its
+        # presence is exactly the question "can this madspace write several
+        # files itself?".
+        if hasattr(ms, "LHEMultiFileWriter"):
+            self.event_generator.combine_to_lhe(files, self.lhe_completer, meta)
+            return
+        logging.getLogger("madevent").warning(
+            "nb_output_files = %d, but this madspace build can only write one "
+            "LHE file; writing %s instead", len(files), single
+        )
+        self.event_generator.combine_to_lhe(single, self.lhe_completer, meta)
 
     @staticmethod
     def _histogram_mean(hist):

--- a/madgraph/iolibs/template_files/mg7/run_card.toml
+++ b/madgraph/iolibs/template_files/mg7/run_card.toml
@@ -12,6 +12,7 @@ cpu_thread_pool_size = %(run.cpu_thread_pool_size)s
 gpu_thread_pool_size = %(run.gpu_thread_pool_size)s
 combine_thread_pool_size = %(run.combine_thread_pool_size)s
 output_format = %(run.output_format)s # options: compact_npy, lhe_npy, lhe
+nb_output_files = %(run.nb_output_files)s # split the events over this many LHE files (round-robin, each complete on its own)
 verbosity = %(run.verbosity)s # options: silent, pretty, log, auto (pretty if attached to a terminal, log otherwise)
 dummy_matrix_element = %(run.dummy_matrix_element)s
 

--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -6490,6 +6490,8 @@ class RunCardMG7(RunCard):
         self.add_toml_param('run', 'combine_thread_pool_size', -1, gridpack=True)
         self.add_toml_param('run', 'output_format', "lhe", gridpack=True,
             allowed=['compact_npy', 'lhe_npy', 'lhe'])
+        self.add_toml_param('run', 'nb_output_files', 1, gridpack=True,
+            comment="split the events over this many LHE files (round-robin, each a complete file with its own <init>); mirrors madevent's nb_unweight_output. Only for output_format = 'lhe'")
         self.add_toml_param('run', 'verbosity', "auto", gridpack=True,
             allowed=['silent', 'pretty', 'log', 'auto'])
         self.add_toml_param('run', 'dummy_matrix_element', False)

--- a/madspace/include/madspace/driver/event_generator.hpp
+++ b/madspace/include/madspace/driver/event_generator.hpp
@@ -48,6 +48,16 @@ public:
         LHECompleter& lhe_completer,
         const LHEMeta& meta = {}
     );
+    // Same, but dealing the combined events round-robin into several LHE files
+    // instead of one. Each file is complete on its own -- same header, same
+    // <init> block with the process cross sections -- so a consumer that wants
+    // to read the events in parallel can give one file to each of its workers
+    // and have every worker parse only its own share. See LHEMultiFileWriter.
+    void combine_to_lhe(
+        const std::vector<std::string>& file_names,
+        LHECompleter& lhe_completer,
+        const LHEMeta& meta = {}
+    );
     GeneratorStatus status() const { return _status; }
     std::vector<GeneratorStatus> channel_status() const;
     std::vector<Histogram> histograms() const;

--- a/madspace/include/madspace/driver/lhe_output.hpp
+++ b/madspace/include/madspace/driver/lhe_output.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <fstream>
+#include <memory>
 #include <random>
 #include <string>
 #include <unordered_map>
@@ -191,6 +192,45 @@ public:
 private:
     std::ofstream _file_stream;
     std::string _buffer;
+};
+
+// Writes one event stream into several LHE files at once, dealing the events
+// out round-robin. Every file is a complete, self-describing LHE file: it gets
+// its own copy of `meta`, so its own <header> and its own <init> block with the
+// process cross sections. A consumer can therefore open any one of them by path
+// alone, with nothing published beside it.
+//
+// The point of the fan-out is a reader that wants to consume the events in
+// parallel: with N files it opens the one that is its own, instead of reading
+// the whole stream and skipping the (N-1)/N of it that belongs to somebody
+// else. Round-robin rather than contiguous blocks because the files are then
+// balanced to within one event whatever the chunking, and because the split
+// cannot correlate with the order the stream happens to arrive in.
+//
+// Chunked, off-thread formatting is supported through reserve()/file_index():
+// reserve() hands out a run of consecutive positions in the stream, file_index()
+// says where each of them belongs, and the formatted text can then be handed
+// over with write_string() whenever it is ready -- in any order.
+class LHEMultiFileWriter {
+public:
+    LHEMultiFileWriter(const std::vector<std::string>& file_names, const LHEMeta& meta);
+
+    std::size_t file_count() const { return _writers.size(); }
+    // Which file the `event_index`-th event of the stream belongs to.
+    std::size_t file_index(std::size_t event_index) const {
+        return event_index % _writers.size();
+    }
+    // Claim `count` consecutive positions in the stream; returns the first.
+    std::size_t reserve(std::size_t count);
+    // Total number of positions claimed so far.
+    std::size_t event_count() const { return _event_count; }
+    void write_string(std::size_t file, const std::string& str);
+    // Convenience for a caller that formats one event at a time.
+    void write(const LHEEvent& event);
+
+private:
+    std::vector<std::unique_ptr<LHEFileWriter>> _writers;
+    std::size_t _event_count = 0;
 };
 
 } // namespace madspace

--- a/madspace/src/driver/event_generator.cpp
+++ b/madspace/src/driver/event_generator.cpp
@@ -453,6 +453,17 @@ void EventGenerator::combine_to_lhe_npy(
 void EventGenerator::combine_to_lhe(
     const std::string& file_name, LHECompleter& lhe_completer, const LHEMeta& meta
 ) {
+    // One file is the degenerate case of N: LHEMultiFileWriter with a single
+    // writer deals every event to file 0. Kept as one implementation so the two
+    // cannot drift apart.
+    combine_to_lhe(std::vector<std::string>{file_name}, lhe_completer, meta);
+}
+
+void EventGenerator::combine_to_lhe(
+    const std::vector<std::string>& file_names,
+    LHECompleter& lhe_completer,
+    const LHEMeta& meta
+) {
     reset_start_time();
     ThreadPool pool(_config.combine_thread_count);
     ThreadResource<std::mt19937> rand_gens(pool, []() {
@@ -460,7 +471,17 @@ void EventGenerator::combine_to_lhe(
         return std::mt19937(rand_device());
     });
     auto [channel_data, particle_count, norm_factor] = init_combine();
-    std::vector<std::pair<EventBuffer, std::string>> buffers;
+    LHEMultiFileWriter event_file(file_names, meta);
+    std::size_t file_count = event_file.file_count();
+    // One in-flight formatting job: the raw events read for it, the formatted
+    // text destined for each output file, and where in the event stream the
+    // chunk starts (which is what decides, per event, which file it goes to).
+    struct CombineJob {
+        EventBuffer in_buffer;
+        std::vector<std::string> out_buffers;
+        std::size_t first_index;
+    };
+    std::vector<CombineJob> jobs;
     std::vector<std::size_t> idle_buffers;
     DataLayout layout(
         EventRecord::layout(
@@ -472,11 +493,17 @@ void EventGenerator::combine_to_lhe(
             _channels.at(0)->particle_layout_extra_flags()
         )
     );
+    // Filled once and never resized again: the submitted jobs hold references
+    // into it for as long as they run.
+    jobs.reserve(2 * pool.thread_count());
     for (std::size_t i = 0; i < 2 * pool.thread_count(); ++i) {
-        buffers.push_back({{0, particle_count, layout}, {}});
+        jobs.push_back(CombineJob{
+            EventBuffer(0, particle_count, layout),
+            std::vector<std::string>(file_count),
+            0,
+        });
         idle_buffers.push_back(i);
     }
-    LHEFileWriter event_file(file_name, meta);
     std::size_t event_count = 0;
     std::size_t last_update_count = 0;
     bool done = false;
@@ -485,34 +512,44 @@ void EventGenerator::combine_to_lhe(
         _abort_check_function();
         while (idle_buffers.size() > 0 && !done) {
             std::size_t job_id = idle_buffers.back();
-            auto& [in_buffer, out_buffer] = buffers.at(job_id);
-            read_and_combine(channel_data, in_buffer, norm_factor);
-            if (in_buffer.event_count() == 0) {
+            auto& job = jobs.at(job_id);
+            read_and_combine(channel_data, job.in_buffer, norm_factor);
+            if (job.in_buffer.event_count() == 0) {
                 done = true;
                 break;
             }
             idle_buffers.pop_back();
-            pool.submit(
-                [job_id, this, &in_buffer, &out_buffer, &lhe_completer, &rand_gens] {
-                    LHEEvent lhe_event;
+            // Claimed here, on this thread, so the chunks keep the order they
+            // were read in even though they are formatted and written back out
+            // of order. Only the main thread ever calls reserve().
+            job.first_index = event_file.reserve(job.in_buffer.event_count());
+            pool.submit([job_id, &job, &event_file, this, &lhe_completer, &rand_gens] {
+                LHEEvent lhe_event;
+                for (auto& out_buffer : job.out_buffers) {
                     out_buffer.clear();
-                    for (std::size_t i = 0; i < in_buffer.event_count(); ++i) {
-                        fill_lhe_event(
-                            lhe_completer, lhe_event, in_buffer, i, rand_gens.get()
-                        );
-                        lhe_event.format_to(out_buffer);
-                    }
-                    return job_id;
                 }
-            );
+                for (std::size_t i = 0; i < job.in_buffer.event_count(); ++i) {
+                    fill_lhe_event(
+                        lhe_completer, lhe_event, job.in_buffer, i, rand_gens.get()
+                    );
+                    // file_index() only reads the (fixed) file count, so it is
+                    // safe to ask the writer from a worker thread.
+                    lhe_event.format_to(
+                        job.out_buffers[event_file.file_index(job.first_index + i)]
+                    );
+                }
+                return job_id;
+            });
         }
 
         auto done_jobs = pool.wait_multiple();
         for (std::size_t job_id : done_jobs) {
-            auto& [in_buffer, out_buffer] = buffers.at(job_id);
+            auto& job = jobs.at(job_id);
             idle_buffers.push_back(job_id);
-            event_file.write_string(out_buffer);
-            event_count += in_buffer.event_count();
+            for (std::size_t file = 0; file < file_count; ++file) {
+                event_file.write_string(file, job.out_buffers[file]);
+            }
+            event_count += job.in_buffer.event_count();
             if (event_count - last_update_count > 10000) {
                 print_combine_update(event_count);
                 last_update_count = event_count;

--- a/madspace/src/driver/lhe_output.cpp
+++ b/madspace/src/driver/lhe_output.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <stdexcept>
 #include <span>
 
 using namespace madspace;
@@ -806,3 +807,31 @@ void LHEFileWriter::write(const LHEEvent& event) {
 void LHEFileWriter::write_string(const std::string& str) { _file_stream << str; }
 
 LHEFileWriter::~LHEFileWriter() { _file_stream << "</LesHouchesEvents>\n"; }
+
+LHEMultiFileWriter::LHEMultiFileWriter(
+    const std::vector<std::string>& file_names, const LHEMeta& meta
+) {
+    if (file_names.empty()) {
+        throw std::invalid_argument(
+            "LHEMultiFileWriter needs at least one output file name"
+        );
+    }
+    _writers.reserve(file_names.size());
+    for (const auto& file_name : file_names) {
+        _writers.push_back(std::make_unique<LHEFileWriter>(file_name, meta));
+    }
+}
+
+std::size_t LHEMultiFileWriter::reserve(std::size_t count) {
+    std::size_t first = _event_count;
+    _event_count += count;
+    return first;
+}
+
+void LHEMultiFileWriter::write_string(std::size_t file, const std::string& str) {
+    _writers.at(file)->write_string(str);
+}
+
+void LHEMultiFileWriter::write(const LHEEvent& event) {
+    _writers.at(file_index(reserve(1)))->write(event);
+}

--- a/madspace/src/python/madspace.cpp
+++ b/madspace/src/python/madspace.cpp
@@ -1695,6 +1695,23 @@ PYBIND11_MODULE(_madspace_py, m) {
         )
         .def("write", &LHEFileWriter::write, py::arg("event"))
         .def("write_string", &LHEFileWriter::write_string, py::arg("str"));
+    py::classh<LHEMultiFileWriter>(m, "LHEMultiFileWriter")
+        .def(
+            py::init<const std::vector<std::string>&, const LHEMeta&>(),
+            py::arg("file_names"),
+            py::arg_v("meta", LHEMeta{}, "LHEMeta()")
+        )
+        .def_property_readonly("file_count", &LHEMultiFileWriter::file_count)
+        .def_property_readonly("event_count", &LHEMultiFileWriter::event_count)
+        .def("file_index", &LHEMultiFileWriter::file_index, py::arg("event_index"))
+        .def("reserve", &LHEMultiFileWriter::reserve, py::arg("count"))
+        .def(
+            "write_string",
+            &LHEMultiFileWriter::write_string,
+            py::arg("file"),
+            py::arg("string")
+        )
+        .def("write", &LHEMultiFileWriter::write, py::arg("event"));
 
     m.def("format_si_prefix", &format_si_prefix, py::arg("value"));
     m.def("format_with_error", &format_with_error, py::arg("value"), py::arg("error"));
@@ -1788,10 +1805,24 @@ PYBIND11_MODULE(_madspace_py, m) {
             py::arg("file_name"),
             py::arg("lhe_completer")
         )
+        // Overloaded: a single path writes one LHE file, a list of paths deals
+        // the same events round-robin into that many complete LHE files.
+        // pybind's list caster rejects str/bytes, so the two never collide.
         .def(
             "combine_to_lhe",
-            &EventGenerator::combine_to_lhe,
+            static_cast<void (EventGenerator::*)(
+                const std::string&, LHECompleter&, const LHEMeta&
+            )>(&EventGenerator::combine_to_lhe),
             py::arg("file_name"),
+            py::arg("lhe_completer"),
+            py::arg_v("meta", LHEMeta{}, "LHEMeta()")
+        )
+        .def(
+            "combine_to_lhe",
+            static_cast<void (EventGenerator::*)(
+                const std::vector<std::string>&, LHECompleter&, const LHEMeta&
+            )>(&EventGenerator::combine_to_lhe),
+            py::arg("file_names"),
             py::arg("lhe_completer"),
             py::arg_v("meta", LHEMeta{}, "LHEMeta()")
         )

--- a/madspace/tests/test_lhe_multifile.py
+++ b/madspace/tests/test_lhe_multifile.py
@@ -1,0 +1,294 @@
+"""Tests for LHEMultiFileWriter -- the fan-out behind the multi-file form of
+EventGenerator.combine_to_lhe.
+
+The contract a consumer relies on has three parts, and each is checked here:
+
+  * every output file is a *complete* LHE file, with its own <header> and its
+    own <init> block carrying the process cross sections, so it can be opened
+    by path alone with nothing published beside it;
+  * the events are dealt out round-robin, so the files are balanced to within
+    one event however the stream happens to be chunked;
+  * the same mapping holds whether events are written one at a time or through
+    the reserve()/file_index()/write_string() path the generator uses to format
+    chunks off-thread.
+"""
+
+import os
+import re
+import tempfile
+
+import pytest
+
+import madspace as ms
+
+# A recognisable <init> block: two processes with distinct cross sections. The
+# decay pools MadSpin reads care about exactly this number -- for a 1 -> n
+# process the "cross section" of the init block is the channel's partial width,
+# which is what picks a channel among a pdg's and sets the branching ratio.
+PROCESSES = [
+    ms.LHEProcess(
+        cross_section=1.4602897691,
+        cross_section_error=2.5e-3,
+        max_weight=7.25,
+        process_id=66,
+    ),
+    ms.LHEProcess(
+        cross_section=0.5,
+        cross_section_error=1.0e-3,
+        max_weight=1.5,
+        process_id=67,
+    ),
+]
+
+
+def make_meta():
+    return ms.LHEMeta(
+        beam1_pdg_id=2212,
+        beam2_pdg_id=2212,
+        beam1_energy=6500.0,
+        beam2_energy=6500.0,
+        beam1_pdf_authors=0,
+        beam2_pdf_authors=0,
+        beam1_pdf_id=247000,
+        beam2_pdf_id=247000,
+        weight_mode=3,
+        processes=PROCESSES,
+        headers=[
+            ms.LHEHeader(name="MGRunCard", content="a = b", escape_content=True)
+        ],
+    )
+
+
+def make_event(index):
+    """An event whose process_id is its position in the stream, so a file's
+    contents identify which events were dealt to it."""
+    return ms.LHEEvent(
+        process_id=index,
+        weight=1.0,
+        scale=91.188,
+        alpha_qed=0.0078,
+        alpha_qcd=0.118,
+        particles=[
+            ms.LHEParticle(
+                pdg_id=21,
+                status_code=ms.LHEParticle.status_incoming,
+                energy=100.0,
+            ),
+            ms.LHEParticle(
+                pdg_id=21,
+                status_code=ms.LHEParticle.status_outgoing,
+                energy=100.0,
+            ),
+        ],
+    )
+
+
+def event_ids(path):
+    """The process_ids of the events in an LHE file, in file order."""
+    with open(path) as fsock:
+        text = fsock.read()
+    ids = []
+    for body in re.findall(r"<event>\n(.*?)</event>", text, re.S):
+        # first line of an event body: nup idprup xwgtup scalup aqedup aqcdup
+        ids.append(int(body.split("\n")[0].split()[1]))
+    return ids
+
+
+def paths(tmpdir, count):
+    return [os.path.join(tmpdir, "unweighted_events_%d.lhe" % i) for i in range(count)]
+
+
+@pytest.fixture
+def tmpdir():
+    with tempfile.TemporaryDirectory() as directory:
+        yield directory
+
+
+# --------------------------------------------------------------------------
+# Every file is complete on its own
+# --------------------------------------------------------------------------
+
+
+def test_every_file_carries_its_own_init_block(tmpdir):
+    targets = paths(tmpdir, 4)
+    writer = ms.LHEMultiFileWriter(targets, make_meta())
+    for i in range(40):
+        writer.write(make_event(i))
+    del writer
+
+    for target in targets:
+        with open(target) as fsock:
+            text = fsock.read()
+        assert text.startswith('<LesHouchesEvents version="3.0">')
+        assert text.rstrip().endswith("</LesHouchesEvents>")
+        init = re.search(r"<init>\n(.*?)</init>", text, re.S)
+        assert init is not None, "no <init> block in %s" % target
+        lines = init.group(1).strip().split("\n")
+        # first line ends with the number of processes, then one line each
+        assert int(lines[0].split()[-1]) == len(PROCESSES)
+        assert len(lines) == 1 + len(PROCESSES)
+        for line, process in zip(lines[1:], PROCESSES):
+            assert float(line.split()[0]) == pytest.approx(process.cross_section)
+            assert int(line.split()[3]) == process.process_id
+
+
+def test_every_file_carries_the_header(tmpdir):
+    targets = paths(tmpdir, 3)
+    writer = ms.LHEMultiFileWriter(targets, make_meta())
+    writer.write(make_event(0))
+    del writer
+
+    for target in targets:
+        with open(target) as fsock:
+            text = fsock.read()
+        assert "<MGRunCard>" in text
+        assert "a = b" in text
+
+
+def test_a_file_with_no_events_is_still_a_valid_lhe_file(tmpdir):
+    # More files than events: the tail files get a banner and nothing else, and
+    # a reader must still be able to open them and find the cross section.
+    targets = paths(tmpdir, 5)
+    writer = ms.LHEMultiFileWriter(targets, make_meta())
+    writer.write(make_event(0))
+    writer.write(make_event(1))
+    del writer
+
+    assert [event_ids(t) for t in targets] == [[0], [1], [], [], []]
+    for target in targets[2:]:
+        with open(target) as fsock:
+            text = fsock.read()
+        assert "<init>" in text
+        assert text.rstrip().endswith("</LesHouchesEvents>")
+
+
+# --------------------------------------------------------------------------
+# The events are dealt out round-robin
+# --------------------------------------------------------------------------
+
+
+def test_events_are_dealt_round_robin(tmpdir):
+    targets = paths(tmpdir, 4)
+    writer = ms.LHEMultiFileWriter(targets, make_meta())
+    for i in range(23):
+        writer.write(make_event(i))
+    del writer
+
+    for i, target in enumerate(targets):
+        assert event_ids(target) == list(range(i, 23, 4))
+
+
+def test_files_are_balanced_to_within_one_event(tmpdir):
+    targets = paths(tmpdir, 7)
+    writer = ms.LHEMultiFileWriter(targets, make_meta())
+    for i in range(100):
+        writer.write(make_event(i))
+    del writer
+
+    counts = [len(event_ids(t)) for t in targets]
+    assert sum(counts) == 100
+    assert max(counts) - min(counts) <= 1
+
+
+def test_no_event_is_lost_or_duplicated(tmpdir):
+    targets = paths(tmpdir, 5)
+    writer = ms.LHEMultiFileWriter(targets, make_meta())
+    for i in range(53):
+        writer.write(make_event(i))
+    del writer
+
+    seen = sorted(sum((event_ids(t) for t in targets), []))
+    assert seen == list(range(53))
+
+
+# --------------------------------------------------------------------------
+# The chunked path the generator uses agrees with the one-at-a-time path
+# --------------------------------------------------------------------------
+
+
+def test_reserve_hands_out_consecutive_positions(tmpdir):
+    writer = ms.LHEMultiFileWriter(paths(tmpdir, 3), make_meta())
+    assert writer.event_count == 0
+    assert writer.reserve(10) == 0
+    assert writer.reserve(4) == 10
+    assert writer.event_count == 14
+
+
+def test_file_index_is_the_round_robin_mapping(tmpdir):
+    writer = ms.LHEMultiFileWriter(paths(tmpdir, 3), make_meta())
+    assert [writer.file_index(i) for i in range(7)] == [0, 1, 2, 0, 1, 2, 0]
+    assert writer.file_count == 3
+
+
+def test_chunked_writes_match_one_at_a_time(tmpdir):
+    """What combine_to_lhe does: claim a run of positions, format the chunk
+    into one string per output file, hand the strings over out of order."""
+    directory_a = os.path.join(tmpdir, "chunked")
+    directory_b = os.path.join(tmpdir, "serial")
+    os.makedirs(directory_a)
+    os.makedirs(directory_b)
+    chunked_targets = paths(directory_a, 4)
+    serial_targets = paths(directory_b, 4)
+
+    writer = ms.LHEMultiFileWriter(chunked_targets, make_meta())
+    chunks = []
+    index = 0
+    for size in (10, 7, 10, 3):
+        first = writer.reserve(size)
+        parts = ["" for _ in range(writer.file_count)]
+        for i in range(size):
+            parts[writer.file_index(first + i)] += _format(make_event(index))
+            index += 1
+        chunks.append(parts)
+    # ... handed back in a different order than they were claimed, which is what
+    # a thread pool does
+    for parts in [chunks[2], chunks[0], chunks[3], chunks[1]]:
+        for file, part in enumerate(parts):
+            writer.write_string(file, part)
+    del writer
+
+    serial = ms.LHEMultiFileWriter(serial_targets, make_meta())
+    for i in range(30):
+        serial.write(make_event(i))
+    del serial
+
+    for chunked, expected in zip(chunked_targets, serial_targets):
+        assert sorted(event_ids(chunked)) == sorted(event_ids(expected))
+
+
+def _format(event):
+    """Render one LHEEvent the way LHEFileWriter.write would, via a throwaway
+    single-file writer -- there is no direct binding for LHEEvent.format_to."""
+    with tempfile.TemporaryDirectory() as directory:
+        path = os.path.join(directory, "one.lhe")
+        writer = ms.LHEFileWriter(path, ms.LHEMeta())
+        writer.write(event)
+        del writer
+        with open(path) as fsock:
+            text = fsock.read()
+    body = re.search(r"(<event>\n.*?</event>\n)", text, re.S)
+    assert body is not None
+    return body.group(1)
+
+
+# --------------------------------------------------------------------------
+# Degenerate cases
+# --------------------------------------------------------------------------
+
+
+def test_one_file_is_the_ordinary_single_file_case(tmpdir):
+    targets = paths(tmpdir, 1)
+    writer = ms.LHEMultiFileWriter(targets, make_meta())
+    for i in range(5):
+        writer.write(make_event(i))
+    del writer
+
+    assert event_ids(targets[0]) == [0, 1, 2, 3, 4]
+    with open(targets[0]) as fsock:
+        text = fsock.read()
+    assert text.count("<init>") == 1
+
+
+def test_no_files_is_rejected(tmpdir):
+    with pytest.raises(ValueError):
+        ms.LHEMultiFileWriter([], make_meta())

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -11791,6 +11791,107 @@ class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
             self.assertTrue(os.path.exists(path), path)
 
 
+class TestTheForkDoesNotSwallowTheDecayGenerationTimings(unittest.TestCase):
+    """When two or more particles decay, ``_generate_decays`` forks one process
+    per particle and the generation runs entirely inside the children. The
+    phase accounting is in-process state, so everything charged there --
+    ``decay_event_generation``, the largest phase of a run, plus
+    ``decay_me_generate``, ``decay_me_output`` and the mg7 launcher phases --
+    used to die with the child and be simply absent from the run's report. That
+    is precisely the case every interesting benchmark is in (p p > t t~ decays
+    both tops), which left only ``total`` usable.
+
+    The child already marshals its results back through a small JSON file, so
+    the timings travel with them.
+
+    They are a sum over particles of work that ran CONCURRENTLY, so they are
+    work done and not wall time, and may exceed the wall time of the fork that
+    contained them. That is why they are charged to their own phases and never
+    folded into a phase measured in the parent.
+    """
+
+    def _stub(self, charge):
+        interface = interface_madspin.MadSpinInterface
+
+        class Stub(object):
+            _generate_decays = interface._generate_decays
+            _generate_decay_entry = interface._generate_decay_entry
+            _add_phase = interface._add_phase
+            _add_count = interface._add_count
+            _phase = interface._phase
+            _reader_paths = staticmethod(interface._reader_paths)
+            _reader_from_paths = staticmethod(lambda paths, cross=None: paths)
+
+            def _resolve_nb_core(self):
+                return 2
+
+            def generate_events(self, pdg, nb_gen, mg5, cumul=False,
+                                output_width=False):
+                charge(self, pdg)
+                reader = type('R', (), {'name': 'pool_%s.lhe' % pdg})()
+                return {0: reader}, 1.5, {0: 1.5}
+
+        stub = Stub()
+        stub.path_me = self.tmpdir
+        stub.seed = 42
+        stub.options = {}
+        stub.me_int = {}
+        stub.mg5cmd = None
+        stub._phase_times = collections.defaultdict(float)
+        stub._phase_counts = collections.defaultdict(int)
+        return stub
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix='ms_forkphase_')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    JOBS = {6: {'nb_gen': 10, 'cumul': False},
+            -6: {'nb_gen': 10, 'cumul': False}}
+
+    def test_the_children_report_what_they_charged(self):
+        def charge(stub, pdg):
+            stub._add_phase('decay_event_generation', 0.25)
+            stub._add_count('decay_event_generation_events_requested', 100)
+
+        stub = self._stub(charge)
+        out = stub._generate_decays(dict(self.JOBS), None)
+
+        self.assertEqual(sorted(out), [-6, 6])
+        # both children charged 0.25 s, and both are in the parent's totals
+        self.assertAlmostEqual(stub._phase_times['decay_event_generation'],
+                               0.5, places=6)
+        self.assertEqual(
+            stub._phase_counts['decay_event_generation_events_requested'], 200)
+
+    def test_nothing_charged_before_the_fork_is_counted_twice(self):
+        """The children inherit the parent's dicts through the fork. What was
+        already in them has been charged in the parent, so a child that sent it
+        back would double it."""
+        def charge(stub, pdg):
+            stub._add_phase('decay_event_generation', 0.25)
+
+        stub = self._stub(charge)
+        stub._add_phase('me_generation', 3.0)
+        stub._generate_decays(dict(self.JOBS), None)
+
+        self.assertAlmostEqual(stub._phase_times['me_generation'], 3.0,
+                               places=6)
+        self.assertAlmostEqual(stub._phase_times['decay_event_generation'],
+                               0.5, places=6)
+
+    def test_a_single_decaying_particle_never_forks_and_is_unaffected(self):
+        def charge(stub, pdg):
+            stub._add_phase('decay_event_generation', 0.25)
+
+        stub = self._stub(charge)
+        stub._generate_decays({6: {'nb_gen': 10, 'cumul': False}}, None)
+        self.assertAlmostEqual(stub._phase_times['decay_event_generation'],
+                               0.25, places=6)
+
+
 class TestDecayGeneratorIsAnOptionAtAll(unittest.TestCase):
     """`decay_generator` was declared by an add_param that a merge left AFTER
     the `return` of MadSpinOptions.__setitem__, i.e. as unreachable code.

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -11524,8 +11524,8 @@ class TestMg7IsOnlyDemotedForGridpack(unittest.TestCase):
 
 
 class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
-    """mg7 emits LHE, and MadSpin deals it out into one file per unweighting
-    worker at the canonical ``Events/<run_name>/unweighted_events_<i>.lhe``.
+    """mg7 emits LHE, one file per unweighting worker, and MadSpin puts those
+    files at the canonical ``Events/<run_name>/unweighted_events_<i>.lhe``.
 
     Both halves matter. LHE because a pool has to be reconstructible from a
     path alone -- across the generation fork and, on a refill, from the channel
@@ -11534,9 +11534,14 @@ class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
     handed a single file has to STRIDE it (_StridedEvents calls next() on every
     other worker's events too), i.e. parse the whole pool to read 1/N of it.
 
-    And writing them at those particular paths is what makes a refill free:
-    ``_refill_pool_paths`` is the same layout under the same ``run_name``, so
-    ``_generate_refill_pool`` finds sources == targets and does no further
+    mg7 does the splitting itself: MadSpin asks for it with the run_card's
+    ``nb_output_files``, and madspace deals the events out as it formats them,
+    so the pool is never written as one file and read back. mg7 names its own
+    Events/run_NN directory, so what is left on this side is N renames.
+
+    And the files ending up at those particular paths is what makes a refill
+    free: ``_refill_pool_paths`` is the same layout under the same ``run_name``,
+    so ``_generate_refill_pool`` finds sources == targets and does no further
     work -- the same branch madevent lands in.
     """
 
@@ -11557,15 +11562,25 @@ class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
 
     WIDTH = 1.4586029
 
-    def _write_launcher(self):
+    def _write_launcher(self, single_only=False):
         """A stand-in for ``bin/generate_events``: makes its own run directory
-        (mg7 names it, MadSpin does not) and writes an LHE pool there, with the
-        partial width in the <init> block exactly as combine_to_lhe does."""
+        (mg7 names it, MadSpin does not) and writes the pool there, with the
+        partial width in the <init> block exactly as combine_to_lhe does.
+
+        Honours the run_card's ``nb_output_files`` the way madevent.py does:
+        one ``events.lhe`` for 1, else ``events_<i>.lhe`` with the events dealt
+        round-robin and a full banner on each. ``single_only=True`` makes it
+        behave like a madspace too old to know the multi-file overload, which
+        writes ``events.lhe`` whatever was asked for."""
         lines = [
             '#!/usr/bin/env python3',
-            'import os',
+            'import os, re',
             'WIDTH = @WIDTH@',
             'NB = @NB@',
+            'SINGLE_ONLY = @SINGLE@',
+            'card = open(os.path.join("Cards", "run_card.toml")).read()',
+            'm = re.search(r"^nb_output_files\\s*=\\s*(\\d+)", card, re.M)',
+            'nb = int(m.group(1)) if m else 1',
             'run = None',
             'for i in range(1, 100):',
             '    cand = os.path.join("Events", "run_%02d" % i)',
@@ -11573,27 +11588,35 @@ class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
             '        run = cand',
             '        break',
             'os.makedirs(run)',
-            'f = open(os.path.join(run, "events.lhe"), "w")',
-            'f.write(\'<LesHouchesEvents version="3.0">\\n<header></header>\\n<init>\\n\')',
-            'f.write(" 2212 2212 6.5e+03 6.5e+03 0 0 247000 247000 -4 1\\n")',
-            'f.write(" %.7e 1.2908000e-03 %.7e 1\\n" % (WIDTH, WIDTH))',
-            'f.write("</init>\\n")',
+            'if nb <= 1 or SINGLE_ONLY:',
+            '    names = ["events.lhe"]',
+            'else:',
+            '    names = ["events_%d.lhe" % i for i in range(nb)]',
+            'fs = [open(os.path.join(run, n), "w") for n in names]',
+            'for f in fs:',
+            '    f.write(\'<LesHouchesEvents version="3.0">\\n<header></header>\\n<init>\\n\')',
+            '    f.write(" 2212 2212 6.5e+03 6.5e+03 0 0 247000 247000 -4 1\\n")',
+            '    f.write(" %.7e 1.2908000e-03 %.7e 1\\n" % (WIDTH, WIDTH))',
+            '    f.write("</init>\\n")',
             'for i in range(NB):',
+            '    f = fs[i % len(fs)]',
             '    f.write("<event>\\n")',
             '    f.write(" 3 1 +1.0e+00 1.73e+02 7.5467711e-03 1.178e-01\\n")',
             '    f.write("  6 -1 0 0 501 0 0. 0. 0. 1.73e+02 1.73e+02 0. 9.\\n")',
             '    f.write("  5 1 1 1 501 0 0. 0. %d. 8.65e+01 8.65e+01 0. 9.\\n" % i)',
             '    f.write(" 24 1 1 1 0 0 0. 0. 0. 8.65e+01 8.65e+01 0. 9.\\n")',
             '    f.write("</event>\\n")',
-            'f.write("</LesHouchesEvents>\\n")',
-            'f.close()',
+            'for f in fs:',
+            '    f.write("</LesHouchesEvents>\\n")',
+            '    f.close()',
             'info = open(os.path.join(run, "info.json"), "w")',
             'info.write(\'{"run_times": {"integrate": {"wall_time_sec": 2.5}}}\')',
             'info.close()',
         ]
         script = '\n'.join(lines) \
             .replace('@WIDTH@', repr(self.WIDTH)) \
-            .replace('@NB@', str(self.NB_EVENT))
+            .replace('@NB@', str(self.NB_EVENT)) \
+            .replace('@SINGLE@', 'True' if single_only else 'False')
         path = pjoin(self.decay_dir, 'bin', 'generate_events')
         with open(path, 'w') as fsock:
             fsock.write(script + '\n')
@@ -11636,6 +11659,19 @@ class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
         self._stub(1).generate_events_mg7(self.decay_dir, self.NB_EVENT)
         card = banner.RunCardMG7(pjoin(self.decay_dir, 'Cards', 'run_card.toml'))
         self.assertEqual(card['run']['output_format'], 'lhe')
+
+    def test_the_run_card_asks_mg7_for_one_file_per_worker(self):
+        """The whole handshake: MadSpin knows nb_core at generation time, so it
+        tells mg7 how many files to write rather than writing one and splitting
+        it afterwards."""
+        self._stub(4).generate_events_mg7(self.decay_dir, self.NB_EVENT)
+        card = banner.RunCardMG7(pjoin(self.decay_dir, 'Cards', 'run_card.toml'))
+        self.assertEqual(card['run']['nb_output_files'], 4)
+
+    def test_a_serial_run_asks_for_a_single_file(self):
+        self._stub(1).generate_events_mg7(self.decay_dir, self.NB_EVENT)
+        card = banner.RunCardMG7(pjoin(self.decay_dir, 'Cards', 'run_card.toml'))
+        self.assertEqual(card['run']['nb_output_files'], 1)
 
     def test_the_partial_width_comes_out_of_the_init_block(self):
         """The whole reason for LHE: the width travels with the file, so any
@@ -11707,6 +11743,39 @@ class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
         pool, _ = self._stub(1).generate_events_mg7(self.decay_dir,
                                                     self.NB_EVENT)
         self.assertTrue(os.path.exists(pool.name))
+
+    def test_the_pool_is_never_materialised_as_one_file(self):
+        """What the mg7-side split buys: at no point is there a single file
+        holding the whole pool, so nothing is written and read back to split it.
+        mg7 wrote the slices; MadSpin only moved them out of mg7's own run
+        directory into the canonical one."""
+        pool, _ = self._stub(4).generate_events_mg7(self.decay_dir,
+                                                    self.NB_EVENT)
+        run_dir = pjoin(self.decay_dir, 'Events', 'run_01')
+        self.assertFalse(os.path.exists(pjoin(run_dir, 'events.lhe')))
+        leftovers = [name for name in os.listdir(run_dir)
+                     if name.startswith('events')]
+        self.assertEqual(leftovers, [])
+        self.assertEqual(len(pool.paths), 4)
+
+    def test_an_older_madspace_falls_back_to_the_python_split(self):
+        """madspace is not upgraded in lockstep with MadSpin -- it can be an
+        older binary wheel that only knows how to write one file. It says so and
+        writes events.lhe; MadSpin then splits it exactly as it did before
+        nb_output_files existed, so the caller sees no difference at all."""
+        self._write_launcher(single_only=True)
+        pool, width = self._stub(4).generate_events_mg7(self.decay_dir,
+                                                        self.NB_EVENT)
+        self.assertEqual(len(pool.paths), 4)
+        self.assertAlmostEqual(width, self.WIDTH, places=6)
+        seen = []
+        for i, path in enumerate(pool.paths):
+            tags = self._tags(path)
+            self.assertEqual(tags, list(range(i, self.NB_EVENT, 4)))
+            seen.extend(tags)
+        self.assertEqual(sorted(seen), list(range(self.NB_EVENT)))
+        run_dir = pjoin(self.decay_dir, 'Events', 'run_01')
+        self.assertFalse(os.path.exists(pjoin(run_dir, 'events.lhe')))
 
     def test_a_refill_lands_exactly_on_the_paths_the_waiters_open(self):
         """The payoff of writing under ``Events/<run_name>/``: for a refill,


### PR DESCRIPTION
For the madspace author. **This is an optimisation, not a fix.** MadSpin already
gets the outcome this asks for, in Python, with no compiled dependency, and that
fallback stays in the tree and stays exercised. Please judge it on the numbers
below, which do not obviously carry it.

## The C++ change

`EventGenerator::combine_to_lhe` gains an overload taking a *list* of paths
instead of one, and deals the combined events round-robin into them as it
formats them:

```cpp
void combine_to_lhe(const std::vector<std::string>& file_names,
                    LHECompleter& lhe_completer, const LHEMeta& meta = {});
```

The fan-out is a new `LHEMultiFileWriter` in `lhe_output.hpp`: one
`LHEFileWriter` per path, all constructed from the same `LHEMeta`, so **every
output file is a complete LHE file** — its own `<header>`, its own `<init>`
block with the process cross sections. `reserve()` claims a run of stream
positions on the main thread before a chunk is submitted, `file_index()` maps
each position to a file; the worker formats into one string per file and hands
them over when it is done, in any order. The chunking, the thread pool and the
completion-order writeback are unchanged.

The single-path entry point now delegates to the list one with a one-element
list, so there is one implementation rather than two that can drift. Measured
below: that costs nothing.

Both overloads are exposed through pybind (the list caster rejects `str`, so
they cannot collide), along with `LHEMultiFileWriter` itself so the fan-out is
unit-testable without standing up a whole `EventGenerator`.

### Round-robin, not contiguous

`read_and_combine` hands out chunks of up to 1000 events. A contiguous split of
a 100k-event pool over 18 files would therefore be balanced only to within a
whole chunk — 1000 events on a ~5500-event slice — and a decay pool that runs
dry triggers a refill. Dealing per event is balanced to within one whatever the
chunking. Confirmed on the real benchmark: the 18 slices of one channel came out
16903/16903/…/16902, and every one of them carried
`1.4599439254e+00` in its own `<init>`.

Ordering *within* a file is not guaranteed — but it already was not, since jobs
completed out of order into a single writer, so nothing downstream loses a
property it had.

## Why MadSpin wants it

MadSpin's parallel unweighting gives each of N workers its own slice of a decay
pool. Handed one file instead, a worker has to *stride* it, and `_StridedEvents`
skips by calling `next()` on the other workers' events — so each of 18 workers
parses the whole pool to read 1/18 of it. The per-worker files also have to end
up at particular paths, because on a pool refill those paths *are* what the
waiting workers open.

## What the alternative already in this branch does

`c173250a5` (in the base branch) has MadSpin write madspace's single
`events.lhe` and then deal it out into the per-worker files itself, with
`_split_pool_round_robin`. Same layout, same banners, same everything — one
extra full write and full read of the pool.

That fallback is **still here and still reached**: madspace is not upgraded in
lockstep with MadSpin (it can be an older binary wheel), so `madevent.py` checks
whether this build has the overload, warns if not, writes the single file, and
MadSpin splits it exactly as before. There is a unit test that drives that path
with a launcher stub pretending to be the old madspace.

## The path problem, and why it is a count and not paths

madspace takes paths — that is the right primitive; it imposes no naming or
directory policy. But the mg7 run_card takes a **count**
(`nb_output_files`, mg7's counterpart of madevent's `nb_unweight_output`),
because the run_card is a user-facing card rendered from a template and a list
of absolute paths is not something a user sets. mg7 writes
`<run_path>/events_<i>.lhe`, and since mg7 names its own `Events/run_NN`
directory, MadSpin then moves them to
`Events/<run_name>/unweighted_events_<i>.lhe`.

That move is N renames inside one filesystem. It does not erase the gain — it is
not measurable at all. It also buys something back: the canonical directory
never contains a half-written pool, which is the same reason
`_materialise_refill_pool` builds in a `.part` directory. Writing straight into
it, as the Python split did, did not have that.

## The measurement

`ttbar_full` (`p p > t t~`, both tops fully decayed), spinmode PA, seed 42,
`nb_core = 18`, 18-core Apple silicon, warm back-to-back, three passes each with
the decay directories rebuilt every time. Means of `total`:

| config | 10k | 100k |
|---|---|---|
| madevent (original baseline) | 38.91 s | 90.14 s |
| mg7, MadSpin-side Python split (this branch's base) | 21.30 s | 37.61 s |
| mg7, madspace multi-file (this PR) | **21.05 s** | **36.32 s** |

Per-pass, so you can see the spread:

* 10k — madevent 35.64 / 40.51 / 40.57; python split 21.84 / 20.51 / 21.54;
  native 21.37 / 21.03 / 20.74
* 100k — madevent 89.06 / 90.00 / 91.37; python split 38.45 / 36.70 / 37.69;
  native 35.24 / 37.33 / 36.38

The phase this deletes, measured directly in the python-split runs:

| | `decay_mg7_split` | as % of total |
|---|---|---|
| 10k | 0.34 s | 1.6% |
| 100k | 1.11 s | 3.0% |

And the same question asked in isolation, away from MadSpin — `t > b u d~`,
300k events, four repetitions, madspace's own `combine` wall time out of
`info.json`:

| | wall |
|---|---|
| combine_to_lhe before this PR, 1 file | 0.284 s |
| combine_to_lhe after this PR, 1 file | 0.273 s |
| combine_to_lhe after this PR, 18 files | 0.285 s |
| MadSpin `_split_pool_round_robin`, the same pool → 18 files | 0.50 s |

So: **the single-file path does not regress**, the fan-out costs about
**0.01 s**, and it replaces a **0.50 s** Python pass. On the benchmark that is
1.11 s off a 37.6 s run.

### Verdict

Honestly: **the wall-clock case is weak.** 1.1 s on a 37 s run is 3%, and the
run-to-run spread of the benchmark is ±1.7 s, so the saving does not show up
reliably in `total` — the two mg7 configurations overlap, and one 100k pass had
the python split come out ahead. The measurement that *does* resolve it is the
phase timing, and the isolated combine bench. If a compiled dependency has to be
paid for in wall clock, this does not pay for it.

The stronger argument is not time but **peak disk**. The Python route
materialises the pool as one file *and* as the slices before deleting the
source: 276 MB per channel at 100k, two channels, so ~550 MB of transient extra
disk, and a refill adds a generation rather than replacing one. Writing the
slices directly never has both.

So: merge it if you think the primitive is worth having in madspace on its own
terms — it is a small, self-contained generalisation of an entry point that
already existed, and it makes the single-file case a special case of the general
one rather than a separate code path. Do not merge it expecting the benchmark to
move.

## Also here: a measurement fix

`decay_event_generation` — the largest phase of a run — was missing from the
report of every run where two or more particles decay, i.e. every benchmark
worth running, `p p > t t~` included. `_generate_decays` forks one process per
particle and the phase accounting is in-process state, so the child charged its
work to a dict the parent never saw. The child already marshals its results back
through a small JSON file; the timings now go with them. That is what makes the
`decay_mg7_split` row above exist at all — without it only `total` was usable,
and `total` cannot resolve this change.

Two things a reader has to know about those numbers: the child clears the
accounting it inherited through the fork (it has already been charged in the
parent), and what comes back is a *sum over particles of concurrent work*, so it
is work done, not wall time, and may exceed the wall time of the fork that
contained it. Hence `decay_event_generation` reading 114% of total in a madevent
run.

## Tests

* `madspace/tests/test_lhe_multifile.py` — 11 new tests on `LHEMultiFileWriter`:
  every file's own `<init>` and cross sections, the header on each, a file that
  got no events still being valid LHE, exact round-robin, balance to within one,
  nothing lost or duplicated, the chunked `reserve`/`file_index`/`write_string`
  path agreeing with the one-at-a-time path, one file behaving as the ordinary
  single-file case, and an empty file list rejected.
  Full madspace suite: 1494 pass (4 pre-existing failures need `scipy`, and
  `test_flow`/`test_mlp` need `torch`; neither is installed here).
* MadSpin unit suite: **570 → 577**, all green. The new ones cover the run_card
  handshake, mg7 writing the slices itself (nothing is ever materialised as one
  file), the old-madspace fallback, and the fork phase timings.
* End to end on a real generated process: `t > b u d~`, 20k events,
  `nb_output_files = 5` → five files of exactly 4000 events, each with
  `4.8954031474e-01` in its own `<init>`, all readable by MadSpin's
  `lhe_parser.EventFile`.

## One thing found on the way, not fixed here

One `cmake --build` of madspace produced a `libmadspace_cpu.dylib` of 2.3 MB
instead of 6.1 MB. It loaded fine and then threw
`std::runtime_error: empty tensor` during survey, reproducibly, on a process
that a good build handled without complaint. Wiping `build/` and reconfiguring
with the same arguments produced a library byte-for-byte the size of a
known-good one and the error went away; two further from-scratch builds since
have both been fine. So: seen once, not characterised. Flagging it only in case
it is familiar — a silently short library that fails at run time rather than at
link time is an unpleasant failure mode to hit twice.
