### PR TITLE
madspace: bind LHEEvent.alpha_qcd to the right member

### DIFF
--- a/madspace/src/python/madspace.cpp
+++ b/madspace/src/python/madspace.cpp
@@ -1621,7 +1621,7 @@ PYBIND11_MODULE(_madspace_py, m) {
         .def_readwrite("weight", &LHEEvent::weight)
         .def_readwrite("scale", &LHEEvent::scale)
         .def_readwrite("alpha_qed", &LHEEvent::alpha_qed)
-        .def_readwrite("alpha_qcd", &LHEEvent::process_id)
+        .def_readwrite("alpha_qcd", &LHEEvent::alpha_qcd)
         .def_readwrite("particles", &LHEEvent::particles);
     py::classh<LHECompleter::SubprocArgs>(m, "SubprocArgs")
         .def(

--- a/madspace/tests/test_lhe.py
+++ b/madspace/tests/test_lhe.py
@@ -161,6 +161,66 @@ def momentum(particle):
     return np.array([particle.energy, particle.px, particle.py, particle.pz])
 
 
+def test_event_attributes_are_bound_to_their_own_members():
+    """Every LHEEvent attribute must read back the value it was given.
+
+    Guards against copy-paste slips in the pybind11 binding block: a
+    def_readwrite pointing at the wrong struct member silently shadows another
+    field (alpha_qcd used to be bound to LHEEvent::process_id).
+    """
+    values = dict(
+        process_id=7,
+        weight=1.5,
+        scale=91.1876,
+        alpha_qed=0.0078125,
+        alpha_qcd=0.118,
+    )
+    event = ms.LHEEvent(**values)
+    for name, value in values.items():
+        assert getattr(event, name) == approx(value), name
+
+    # ... and each attribute must be independently writable, without any two of
+    # them aliasing the same member.
+    event = ms.LHEEvent()
+    for name, value in values.items():
+        setattr(event, name, value)
+    for name, value in values.items():
+        assert getattr(event, name) == approx(value), name
+
+
+def test_event_header_line_written_to_lhe():
+    """The event header line of the written LHE file carries the values set
+    from Python, in the order defined by arXiv:0109068 (NUP IDPRUP XWGTUP
+    SCALUP AQEDUP AQCDUP).
+
+    The attributes are set one by one rather than passed to the constructor, so
+    that this also covers the setter side of the def_readwrite bindings.
+    """
+    event = ms.LHEEvent()
+    event.process_id = 7
+    event.weight = 1.5
+    event.scale = 91.1876
+    event.alpha_qed = 0.0078125
+    event.alpha_qcd = 0.118
+    event.particles = [ms.LHEParticle(pdg_id=21), ms.LHEParticle(pdg_id=21)]
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        path = os.path.join(tmp_dir, "events.lhe")
+        writer = ms.LHEFileWriter(path, ms.LHEMeta())
+        writer.write(event)
+        del writer  # the destructor flushes and closes the file
+
+        with open(path) as in_file:
+            lines = in_file.read().split("\n")
+        header = lines[lines.index("<event>") + 1].split()
+
+    assert int(header[0]) == 2  # NUP
+    assert int(header[1]) == 7  # IDPRUP
+    assert float(header[2]) == approx(1.5)  # XWGTUP
+    assert float(header[3]) == approx(91.1876)  # SCALUP
+    assert float(header[4]) == approx(0.0078125)  # AQEDUP
+    assert float(header[5]) == approx(0.118)  # AQCDUP
+
+
 def test_particle_count_includes_all_resonances(events):
     # On-shell mapping guarantees t, tbar, W+ and W- are always identified.
     for event in events:


### PR DESCRIPTION
### The bug

`madspace/src/python/madspace.cpp` bound `LHEEvent.alpha_qcd` to `&LHEEvent::process_id`:

```cpp
.def_readwrite("alpha_qed", &LHEEvent::alpha_qed)
.def_readwrite("alpha_qcd", &LHEEvent::process_id)   // <- wrong member
```

The correct member is `&LHEEvent::alpha_qcd` (`double`, declared in `madspace/include/madspace/driver/lhe_output.hpp:61`). Present since the line was first written (`391f807c3`, "started implementing LHE output") — never correct.

Observed from Python before the fix:

```
>>> e = ms.LHEEvent(process_id=7, alpha_qcd=0.118)
>>> e.alpha_qcd
7
>>> e.alpha_qcd = 0.118
TypeError: incompatible function arguments ... (arg0: typing.SupportsInt)
```

The generated stub was self-contradictory too: `__init__(..., alpha_qcd: SupportsFloat)` next to `alpha_qcd -> int`. It regenerates correctly now.

### Blast radius

Nothing consumed it. `alpha_qcd` is only ever read/written through the C++ struct (`event_generator.cpp`, `lhe_output.cpp`, `io.hpp`), never through the Python attribute — no use in `madspace/tests`, MadGraph7's `mg7` templates, MadSpin, or the acceptance tests. LHE files produced by the normal `combine_to_lhe` path were and are correct, since that never touches the binding. The reachable hazard was the Python-facing path only: an `LHEEvent` built or edited from Python and handed to `LHEFileWriter`.

The two members have different types (`double` vs `int`), so the mis-binding was partly self-announcing on the setter (`TypeError` on any float) but silent on the getter — reads just returned the process id.

### Audit of the surrounding bindings

Checked all 167 `def_readwrite`/`def_readonly` bindings in `madspace.cpp` mechanically (Python name vs. bound member name, and bound class vs. enclosing `py::classh`). This was the only mismatch. Also hand-checked the `py::init` argument names and orders of the whole LHE block — `LHEHeader`, `LHEProcess`, `LHEMeta`, `LHEParticle`, `LHEEvent`, `SubprocArgs` — against their struct declarations; all correct.

### Tests

Two additions to `madspace/tests/test_lhe.py`, both failing before the fix and passing after:

- `test_event_attributes_are_bound_to_their_own_members` — every `LHEEvent` attribute reads back its own value, via the constructor and via the setters (catches any future aliasing in that block, not just this field).
- `test_event_header_line_written_to_lhe` — sets the fields one by one and checks the `NUP IDPRUP XWGTUP SCALUP AQEDUP AQCDUP` header line of the file written by `LHEFileWriter`.

They need the built extension, which is exactly what CI already does: `.github/workflows/madspace.yml` runs `pytest {project}/madspace/tests` against the cibuildwheel-built wheel. No CI changes needed.

### Suite

`pytest madspace/tests` (local, macOS arm64, Python 3.14):

- before: 4 failed, 1470 passed, 2 skipped
- after: 4 failed, 1472 passed, 2 skipped

The 4 failures are pre-existing and need `scipy` (`test_double_t.py`); `test_flow.py`/`test_mlp.py` need `torch`. Neither is installed locally, both are installed in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
