### PR TITLE
MadSpin: read mg7's decay pools as .npy again, and stop splitting them

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -512,6 +512,12 @@ class MadSpinOptions(banner.ConfigFile):
         if value not in ["crash", 'average', 'max', 'first']:
             raise Exception("value %s not supported for this parameter identical_in_prod_and_decay")
 
+# Name mg7's numpy decay pool is left under inside a run/refill directory.
+# Module level rather than a class attribute: several of the methods that use it
+# are borrowed function-by-function by objects that are not MadSpinInterface
+# instances (the unit-test stubs).
+_NPY_POOL_NAME = 'events.npy'
+
 # Per-particle columns of mg7's "lhe_npy" event file, in the order they map
 # onto lhe_parser.Particle's attributes below.
 _NPY_PARTICLE_FIELDS = ('pdg_id', 'status_code', 'mother1', 'mother2',
@@ -533,6 +539,18 @@ class NpyDecayPool(object):
     Exposes the part of lhe_parser.EventFile that the decay loop uses -- being
     iterable, and carrying the channel's cross section -- so it drops into
     evt_decayfile in place of an EventFile.
+
+    ``offset``/``stride`` give one parallel unweighting worker its own disjoint
+    view of a shared pool: worker ``offset`` of ``stride`` reads the rows at
+    positions offset, offset+stride, ... and nothing else. This is the whole
+    reason a numpy pool needs no splitting. The array is memory-mapped and
+    randomly addressable, so skipping the other workers' events costs index
+    arithmetic and nothing more; ``_StridedEvents`` over LHE text has to
+    ``next()`` past them, i.e. parse the entire pool to read 1/N of it, which is
+    what the round-robin split existed to avoid. Here there is nothing to avoid
+    and nothing to split: every worker mmaps the same file and touches only its
+    own rows. ``len()`` is this worker's stripe, so the owner undersize
+    (_LimitedEvents) needs no event count off the disk either.
     """
 
     # Rows converted from numpy to python scalars per batch. Small enough that
@@ -540,14 +558,18 @@ class NpyDecayPool(object):
     # large enough that the per-call overhead disappears.
     CHUNK = 4096
 
-    def __init__(self, path, cross):
+    def __init__(self, path, cross, offset=0, stride=1):
         import numpy
 
         self.name = path
         self.cross = cross
         # Memory-mapped: a pool is tens of MB and is read once, front to back.
         self._records = numpy.load(path, mmap_mode='r')
-        self._count = len(self._records)
+        self._total = len(self._records)
+        self._offset = int(offset)
+        self._stride = max(1, int(stride))
+        # rows of THIS worker's stripe: offset, offset+stride, ... < total
+        self._count = max(0, -(-(self._total - self._offset) // self._stride))
         self._index = 0
         self._chunk = []
         self._chunk_index = 0
@@ -576,8 +598,12 @@ class NpyDecayPool(object):
                 raise StopIteration
             # One vectorised conversion per chunk. Reading numpy scalars one
             # field at a time instead costs more than parsing the LHE text did.
+            # Slicing with the stride skips straight over the other workers'
+            # rows -- the mmap is never even touched for them.
             end = min(self._index + self.CHUNK, self._count)
-            self._chunk = self._records[self._index:end].tolist()
+            first = self._offset + self._index * self._stride
+            last = self._offset + (end - 1) * self._stride + 1
+            self._chunk = self._records[first:last:self._stride].tolist()
             self._chunk_index = 0
             self._index = end
         row = self._chunk[self._chunk_index]
@@ -2735,33 +2761,36 @@ class MadSpinInterface(extended_cmd.Cmd):
     def generate_events_mg7(self, decay_dir, nb_event, run_name='run_01'):
         """Run the mg7 (madmatrix/madspace) generator in ``decay_dir``.
 
-        Returns ``(event_file, partial_width)``. The partial width is read back
-        from the LHE <init> block, which for a 1 -> n process carries a width in
+        Returns ``(event_file, partial_width)``. The partial width comes out of
+        the run's ``info.json``, which for a 1 -> n process reports a width in
         GeV rather than a cross section in pb.
 
-        The pool is left in the layout the parallel unweighting expects of any
-        backend -- one LHE file per worker, under ``Events/<run_name>/`` -- so
-        that mg7 goes down exactly the same paths madevent does. See below for
-        why LHE rather than the (faster to read) numpy event file.
+        The pool is a single ``Events/<run_name>/events.npy``. Every worker of
+        the parallel unweighting mmaps it and reads its own stripe by index
+        (see :class:`NpyDecayPool`), so there is nothing to split and no
+        per-worker file to write.
         """
         run_card_path = pjoin(decay_dir, 'Cards', 'run_card.toml')
         run_card = banner.RunCardMG7(run_card_path)
         run_card['generation']['events'] = int(nb_event)
-        # LHE, not mg7's numpy event file, even though the numpy one is ~4 us an
-        # event cheaper to read (~5% of a run; measured 1.05x end to end).
+        # mg7's numpy event file, not LHE: the pool is read straight back into
+        # MadSpin, so the text round trip is pure overhead (~4 us an event) and
+        # a strided reader over it costs nothing, where a strided reader over
+        # LHE has to parse every other worker's events to get past them.
         #
-        # A decay pool has to survive being handed to another process BY PATH
-        # ALONE: once across the per-particle generation fork (_reader_paths /
-        # _reader_from_paths), and again from a channel's refill owner to every
-        # waiter, which opens its slice by path and has no other channel back to
-        # the generator. What travels with the path has to include the channel's
-        # partial width -- it is what picks a channel among a pdg's and what
-        # sets the branching ratio. An LHE file carries it in its <init> block,
-        # so it is self-describing and any reader can be rebuilt from the path.
-        # A .npy has no banner: the width would have to become a sidecar file in
-        # the owner->waiter publish contract, i.e. an extension of the one
-        # protocol surface where a publish/open race can live. Not worth 5%.
-        run_card['run']['output_format'] = 'lhe'
+        # The objection this reverses was that a decay pool has to survive being
+        # handed to another process BY PATH ALONE -- across the per-particle
+        # generation fork, and from a channel's refill owner to its waiters --
+        # carrying the channel's partial width with it, which an LHE <init>
+        # block does and a .npy does not. It does not need to. The fork already
+        # marshals the width explicitly beside the paths (_generate_decay_entry
+        # writes it into its JSON, _generate_decays hands it back to
+        # _reader_from_paths), and a refill does not need it published at all: a
+        # channel's partial width does not change from one generation of its
+        # pool to the next, so the reader being replaced already has it and
+        # _worker_refill passes it on. Nothing is added to the owner->waiter
+        # publish contract, which stays exactly the one ms_refill.gen marker.
+        run_card['run']['output_format'] = 'lhe_npy'
         run_card.write(run_card_path)
         with open(pjoin(decay_dir, 'Cards', 'param_card.dat'), 'w') as fsock:
             fsock.write(self.banner['slha'])
@@ -2790,70 +2819,50 @@ class MadSpinInterface(extended_cmd.Cmd):
                 'the mg7 decay generator produced no run directory in %s' % events_dir)
         run_dir = new_runs[-1]
 
-        for name in ('events.lhe', 'events.lhe.gz'):
-            events_path = pjoin(run_dir, name)
-            if os.path.exists(events_path):
-                break
-        else:
+        events_path = pjoin(run_dir, _NPY_POOL_NAME)
+        if not os.path.exists(events_path):
             raise self.InvalidCmd(
-                'the mg7 decay generator produced no LHE file in %s' % run_dir)
+                'the mg7 decay generator produced no events.npy in %s' % run_dir)
 
-        # Timing breakdown, best effort: the launcher reports how long the
-        # integration itself took, and the rest of the subprocess wall time is
-        # interpreter start-up plus the one-off matrix-element compile, which is
-        # what dominates a decay directory. Unlike the width -- which now comes
-        # out of the LHE banner -- this is only for the benchmark report, so a
-        # missing or malformed info.json must not fail the run.
+        # The numpy event file carries no banner, so the partial width comes
+        # from the run's info.json -- along with the timing breakdown, which is
+        # best effort (the launcher reports how long the integration itself
+        # took; the rest of the subprocess wall time is interpreter start-up
+        # plus the one-off matrix-element compile).
+        info_path = pjoin(run_dir, 'info.json')
         try:
-            with open(pjoin(run_dir, 'info.json')) as fsock:
-                run_times = json.load(fsock).get('run_times', {})
-        except (OSError, ValueError, AttributeError):
-            run_times = {}
+            with open(info_path) as fsock:
+                info = json.load(fsock)
+        except (OSError, ValueError) as error:
+            raise self.InvalidCmd(
+                'could not read the mg7 result from %s: %s' % (info_path, error))
+        try:
+            width = float(info['process']['mean'])
+        except (KeyError, TypeError, ValueError) as error:
+            raise self.InvalidCmd(
+                'no partial width in %s: %s' % (info_path, error))
+        run_times = info.get('run_times', {})
         if isinstance(run_times, dict):
             self._add_phase('decay_mg7_integrate',
                             sum(stage.get('wall_time_sec', 0.)
                                 for stage in run_times.values()
                                 if isinstance(stage, dict)))
 
-        pool = lhe_parser.EventFile(events_path)
-        # <init> of a 1 -> n process carries a width in GeV, not a cross section
-        width = pool.cross
-
-        # Deal the pool out into one file per unweighting worker, at the paths
-        # the rest of MadSpin already expects any backend to use -- the same
-        # ones madevent reaches through the run_card's ``nb_unweight_output``.
-        # Two things fall out of writing them THERE rather than anywhere else:
-        # a worker opens its own file instead of striding the whole pool (which
-        # costs it a full parse of every other worker's events), and on a refill
-        # these paths *are* _refill_pool_paths, so _generate_refill_pool finds
-        # sources == targets and does no further work. Left uncompressed: they
-        # are read back immediately and gzip is pure overhead here.
-        nb_split = self._decay_pool_split()
-        if nb_split <= 1:
-            pool.seek(0)
-            return pool, width
-        pool.close()
-        targets = lhe_parser.EventFile.unweight_output_paths(
-            pjoin(decay_dir, 'Events', run_name, 'unweighted_events.lhe'),
-            nb_split)
-        target_dir = os.path.dirname(targets[0])
-        if not os.path.isdir(target_dir):
-            os.makedirs(target_dir)
-        with self._phase('decay_mg7_split'):
-            self._split_pool_round_robin([events_path], targets)
-        # Between them the slices hold every event of the source -- the split
-        # reads it to the end or raises -- so keeping the source doubles what a
-        # pool costs on disk: another 241 MB per channel on the 100k benchmark,
-        # and a refill adds a generation rather than replacing one. Nothing
-        # reads it after this point (each slice carries its own banner, and the
-        # run directory keeps info.json and the generation log), so drop it once
-        # every slice is actually there.
-        if all(os.path.exists(path) for path in targets):
-            try:
-                os.remove(events_path)
-            except OSError:
-                pass
-        return _ChainedEvents(targets), width
+        # Move the pool to the canonical ``Events/<run_name>/events.npy``. mg7
+        # names its own run directory (run_01, run_02, ...) and MadSpin does not
+        # get to choose it, but every other part of MadSpin addresses a pool by
+        # run_name: for a refill that path IS _refill_pool_paths, so
+        # _generate_refill_pool finds the backend has already written the
+        # canonical layout and does no further work. A rename, not a copy --
+        # same directory tree, so it is atomic and costs nothing whatever the
+        # pool weighs.
+        target_dir = pjoin(decay_dir, 'Events', run_name)
+        target = pjoin(target_dir, _NPY_POOL_NAME)
+        if os.path.realpath(target) != os.path.realpath(events_path):
+            if not os.path.isdir(target_dir):
+                os.makedirs(target_dir)
+            os.replace(events_path, target)
+        return NpyDecayPool(target, width), width
 
     # File in which a decay directory records the partial width that was
     # measured when it was built. Only the gridpack (ms_dir) path needs it: the
@@ -3178,10 +3187,10 @@ class MadSpinInterface(extended_cmd.Cmd):
                 # Two things still send the decay generation back to Fortran
                 # madevent. Neither is the parallel unweighting: that used to
                 # demote mg7 whenever nb_core > 1, i.e. on any multicore box,
-                # because the refill path splits and reopens a pool as LHE files
-                # and mg7 was writing numpy. mg7 writes LHE now (see
-                # generate_events_mg7), in the per-worker layout, so there is
-                # nothing left to conflict with and that demotion is gone.
+                # because the refill path could only split and reopen a pool as
+                # LHE files. It reads mg7's numpy pool directly now -- every
+                # worker strides the one mmap (NpyDecayPool), so there is
+                # nothing to split and that demotion is gone.
                 if use_gridpack:
                     # gridpack (ms_dir) drives the decay directory through
                     # run.sh, and the mg7 output provides no run.sh.
@@ -4610,19 +4619,29 @@ class MadSpinInterface(extended_cmd.Cmd):
         return pjoin(decay_dir, 'Events', 'ms_refill_%d' % gen)
 
     def _refill_pool_paths(self, decay_dir, gen):
-        """Every per-worker slice of the refill pool ``gen``, in worker order.
-        This layout is the contract between the owner (which puts the files
-        there, see :meth:`_generate_refill_pool`) and the waiters (which open
-        their own one and nothing else)."""
-        base = pjoin(self._refill_pool_dir(decay_dir, gen),
-                     'unweighted_events.lhe')
+        """The file(s) of refill pool ``gen``. This layout is the contract
+        between the owner (which puts them there, see
+        :meth:`_generate_refill_pool`) and the waiters.
+
+        Two layouts, told apart by what is on disk rather than by anything
+        published beside it. mg7's numpy pool is ONE file that every worker
+        mmaps and strides by index (:class:`NpyDecayPool`), so there is nothing
+        to split; every other backend writes LHE text, which a worker cannot
+        stride for free, so it gets one file per worker. Probing is race-free:
+        a waiter only ever calls this once ``ms_refill.gen`` says the whole
+        generation is on disk."""
+        pool_dir = self._refill_pool_dir(decay_dir, gen)
+        npy = pjoin(pool_dir, _NPY_POOL_NAME)
+        if os.path.exists(npy):
+            return [npy]
+        base = pjoin(pool_dir, 'unweighted_events.lhe')
         return lhe_parser.EventFile.unweight_output_paths(
             base, self._shard_nb_core)
 
     def _refill_pool_path(self, decay_dir, gen):
-        """This worker's own file of the refill pool ``gen``. The refill hands
-        each worker one file, so a worker never reads (nor even parses) the
-        events that belong to the others."""
+        """The file of refill pool ``gen`` this worker reads. Either its own LHE
+        slice, or -- for a numpy pool -- the single shared file it will stride;
+        either way it never reads (nor even parses) another worker's events."""
         paths = self._refill_pool_paths(decay_dir, gen)
         path = paths[self._shard_tag] if len(paths) > 1 else paths[0]
         if not os.path.exists(path):
@@ -4631,9 +4650,23 @@ class MadSpinInterface(extended_cmd.Cmd):
         return path
 
     @staticmethod
-    def _count_lhe_events(path):
-        """Number of ``<event`` records in an LHE file (plain or gzip). Used to
-        size the owner's ~10% shortfall -- a cheap line scan, no parsing."""
+    def _count_pool_events(path):
+        """Number of events in a decay pool file, whatever format it is in.
+        Used to size the owner's ~10% shortfall.
+
+        Dispatches on the suffix, and that dispatch is the point of the method.
+        The LHE branch is a line scan for ``<event``, and a numpy pool contains
+        no such text: run over one it counted zero, the owner's slice was capped
+        at zero events, and it refilled on its very first draw -- forever. That
+        failure wears the costume of a refill-loop bug, not of a file-format
+        one, which is why it gets a named method with a test rather than an
+        inline scan at each call site."""
+        if path.endswith('.npy'):
+            try:
+                import numpy
+                return len(numpy.load(path, mmap_mode='r'))
+            except (IOError, OSError, ValueError):
+                return 0
         try:
             if path.endswith('.gz'):
                 import gzip
@@ -4664,15 +4697,33 @@ class MadSpinInterface(extended_cmd.Cmd):
             idx = 0
         return idx % max(1, int(self._shard_nb_core))
 
-    def _open_refill_slice(self, decay_dir, gen, owner):
+    def _open_refill_slice(self, decay_dir, gen, owner, cross=None):
         """This worker's reader over refill pool ``gen``; the owner's slice is
-        cut ~10% short (see _LimitedEvents) so the owner runs out first."""
+        cut ~10% short (see _LimitedEvents) so the owner runs out first.
+
+        ``cross`` is the channel's partial width, and only a numpy pool needs it
+        handed in: an LHE slice carries it in its own <init> block, a .npy does
+        not. It is NOT published beside the pool -- a channel's width does not
+        change from one generation to the next, so the caller simply passes on
+        the one the reader it is replacing already had, and the owner->waiter
+        contract on disk stays the single ms_refill.gen marker."""
         path = self._refill_pool_path(decay_dir, gen)
-        reader = lhe_parser.EventFile(path)
+        if path.endswith('.npy'):
+            # one shared, memory-mapped pool: this worker takes its stripe by
+            # index, so no split had to happen and none of the other workers'
+            # events are read
+            reader = NpyDecayPool(path, cross,
+                                  offset=self._shard_tag or 0,
+                                  stride=self._shard_nb_core)
+            n = len(reader)
+        else:
+            reader = lhe_parser.EventFile(path)
+            n = None
         if self._shard_tag == owner:
             frac = float(getattr(self, '_owner_undersize', 0.10) or 0.0)
             if frac > 0:
-                n = self._count_lhe_events(path)
+                if n is None:
+                    n = self._count_pool_events(path)
                 reader = _LimitedEvents(reader,
                                         int(math.floor((1.0 - frac) * n)))
         return reader
@@ -4686,7 +4737,17 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         Worker i therefore ends up with the events at positions i, i+N, ... of
         the pool -- exactly the stripe it would otherwise pick out itself, minus
-        having to parse the other workers' events to get there."""
+        having to parse the other workers' events to get there.
+
+        LHE only, deliberately. A numpy pool needs no split at all (every worker
+        strides the mmap for free, see :class:`NpyDecayPool`), and handing one to
+        the LHE parser raises ``UnicodeDecodeError: byte 0x93`` -- the first byte
+        of the \\x93NUMPY magic -- from three frames down. Say so here instead."""
+        for src in sources:
+            if src.endswith('.npy'):
+                raise Exception(
+                    "MadSpin: %s is a numpy decay pool and must not be split; "
+                    "every worker reads its own stripe of it directly." % src)
         first = lhe_parser.EventFile(sources[0])
         banner = first.banner
         first.close()
@@ -4736,11 +4797,14 @@ class MadSpinInterface(extended_cmd.Cmd):
         COMPLETE at the per-worker paths of :meth:`_refill_pool_paths`. Returns
         those paths. Publishing ``gen`` is only allowed once this has returned.
 
-        Two generation backends land here and they do not agree on where they
+        Three generation backends land here and they do not agree on where they
         write. The plain madevent one honours ``run_name`` and splits the
-        unweighting one file per worker, i.e. it writes the canonical layout
-        itself. The gridpack one (any ``ms_dir`` run) goes through run.sh, which
-        knows nothing of either: it always writes a single
+        unweighting one file per worker; the mg7 one leaves a single
+        ``events.npy`` under the same ``run_name``. Both, that is, write the
+        canonical layout themselves, and are recognised by it -- whatever the
+        backend left inside ``Events/ms_refill_<gen>`` IS the pool, so nothing
+        further happens. The gridpack one (any ``ms_dir`` run) goes through
+        run.sh, which knows nothing of either: it always writes a single
         ``<decay_dir>/events.lhe.gz`` -- straight on top of the pool the other
         workers are still reading. So on that backend, move the pool aside for
         the duration, split what run.sh produced into the per-worker files, and
@@ -4749,7 +4813,6 @@ class MadSpinInterface(extended_cmd.Cmd):
         their inode -- and this whole routine runs under the channel's exclusive
         refill lock."""
         decay_dir = self._decay_dir(self.path_me, pdg, decay_file_nb)
-        targets = self._refill_pool_paths(decay_dir, gen)
         pool = pjoin(decay_dir, 'events.lhe.gz')
         stash = pool + '.mspool'
         # mirrors ``use_gridpack`` in generate_events
@@ -4766,7 +4829,19 @@ class MadSpinInterface(extended_cmd.Cmd):
                 reader.close()
             except Exception:
                 pass
-            if sources != targets:
+            # Did the backend write the canonical layout itself? Ask where the
+            # files it produced actually are, rather than guessing the layout
+            # first and comparing: the two self-writing backends produce
+            # different file sets in that directory (madevent one LHE per
+            # worker, mg7 a single events.npy) and only the generation knows
+            # which. Anything landing anywhere else has to be materialised as
+            # the per-worker LHE slices.
+            final_dir = os.path.realpath(self._refill_pool_dir(decay_dir, gen))
+            if sources and all(os.path.realpath(os.path.dirname(p)) == final_dir
+                               for p in sources):
+                targets = sources
+            else:
+                targets = self._refill_pool_paths(decay_dir, gen)
                 self._materialise_refill_pool(sources, targets, decay_dir, gen)
         finally:
             if protect:
@@ -4965,9 +5040,16 @@ class MadSpinInterface(extended_cmd.Cmd):
             cur = st[1]
         return False
 
-    def _worker_refill(self, pdg, decay_file_nb, needed):
+    def _worker_refill(self, pdg, decay_file_nb, needed, cross=None):
         """Owner-based decay-event refill for the forked workers. Returns the
         reader this worker should continue from.
+
+        ``cross`` is the partial width of the channel being refilled, taken by
+        the caller off the reader that just ran dry. Only a numpy pool needs it
+        (an LHE slice carries its own <init> block), and a channel's width is
+        the same for every generation of its pool, so passing the old reader's
+        on is exact -- and keeps the width off the owner->waiter publish
+        contract, which stays the one ms_refill.gen marker it always was.
 
         Each channel has one deterministic OWNER worker (:meth:`_channel_owner`).
         In normal operation only the owner (re)generates that channel's pool;
@@ -4998,7 +5080,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             finally:
                 self._set_status('R')
             self._pool_gen[key] = target_gen
-            return self._open_refill_slice(decay_dir, target_gen, owner)
+            return self._open_refill_slice(decay_dir, target_gen, owner, cross)
 
         # Not my channel: wait for the owner, advertising who I wait for so the
         # deadlock detection can see me. A cycle back to myself has to persist a
@@ -5054,7 +5136,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         finally:
             self._set_status('R')
         self._pool_gen[key] = target_gen
-        return self._open_refill_slice(decay_dir, target_gen, owner)
+        return self._open_refill_slice(decay_dir, target_gen, owner, cross)
 
     def _unweight_range(self, prod_source, evt_decayfile, output_lhe, ctx):
         """Decay + accept/reject over every production event in ``prod_source``,
@@ -6599,37 +6681,49 @@ class MadSpinInterface(extended_cmd.Cmd):
     def _reopen_decay_pool(self, evt_decayfile, shard_id, nb_core):
         """Return this worker's private view of the decay pools.
 
-        The unweighting already wrote one file per worker
-        (``nb_unweight_output``), so a worker simply opens *its* file: no two
-        workers ever read the same event and none of them has to scan the whole
-        pool. If the pool happens to be a single file (e.g. it was produced
-        before this was in place) fall back to striding it, which is correct but
-        makes every worker parse everything."""
+        Three ways to get one, in decreasing order of how much they cost.
+
+        A numpy pool (mg7) is a single memory-mapped array, so the worker takes
+        its stripe by index: nothing is split, nothing of the other workers'
+        events is read, and the stripe's length is known exactly.
+
+        An LHE pool that the unweighting already wrote one file per worker
+        (``nb_unweight_output``) means the worker simply opens *its* file: again
+        no two workers read the same event and none scans the whole pool.
+
+        A single LHE file (e.g. produced before that was in place) has to be
+        strided, which is correct but makes every worker parse everything."""
         local = {}
         for pdg, channels in evt_decayfile.items():
             local[pdg] = {}
             for file_nb, evtfile in channels.items():
                 paths = getattr(evtfile, 'paths', None)
-                own_file = bool(paths and len(paths) == nb_core)
-                if own_file:
+                if isinstance(evtfile, NpyDecayPool):
+                    reader = NpyDecayPool(evtfile.name, evtfile.cross,
+                                          offset=shard_id, stride=nb_core)
+                    # this worker's own rows, counted without touching the disk
+                    n = len(reader)
+                elif paths and len(paths) == nb_core:
                     reader = lhe_parser.EventFile(paths[shard_id])
+                    n = self._count_pool_events(paths[shard_id])
                 elif paths:
                     # split, but not into exactly nb_core files: stride the WHOLE
                     # chained pool. ``evtfile.name`` is only its first file, so
                     # striding that would strand every other file's events.
                     reader = _StridedEvents(_ChainedEvents(paths), shard_id, nb_core)
+                    n = None
                 else:
                     fresh = lhe_parser.EventFile(evtfile.name)
                     reader = _StridedEvents(fresh, shard_id, nb_core)
+                    n = None
                 # The worker that OWNS this channel reads its slice ~10% short so
                 # it runs out (and, being the sole generator, regenerates) before
                 # the others do -- keeping their wait for the refill minimal.
-                # Only meaningful on the own-file fast path where the count of
-                # this worker's slice is well defined.
-                if own_file and self._channel_owner(pdg, file_nb) == shard_id:
+                # Only meaningful where the count of this worker's own events is
+                # well defined, i.e. not on the strided fallbacks.
+                if n is not None and self._channel_owner(pdg, file_nb) == shard_id:
                     frac = float(getattr(self, '_owner_undersize', 0.10) or 0.0)
                     if frac > 0:
-                        n = self._count_lhe_events(paths[shard_id])
                         reader = _LimitedEvents(reader,
                                                 int(math.floor((1.0 - frac) * n)))
                 local[pdg][file_nb] = reader
@@ -7044,7 +7138,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                         evt_decayfile[particle.pdg][decay_file_nb] = \
                             self._worker_refill(
                                 particle.pdg, decay_file_nb,
-                                needed * self._shard_nb_core)
+                                needed * self._shard_nb_core,
+                                decay_file.cross)
                     else:
                         # serial: _regenerate_events already returns the reader
                         # over the events it produced

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -10273,7 +10273,7 @@ class TestRefillPoolIsCompleteBeforeItIsPublished(unittest.TestCase):
             # are plain functions, and a plain function in a class body would
             # be handed a ``self`` they do not take
             _refill_pool_dir = staticmethod(interface._refill_pool_dir)
-            _count_lhe_events = staticmethod(interface._count_lhe_events)
+            _count_pool_events = staticmethod(interface._count_pool_events)
             _published_gen = staticmethod(interface._published_gen)
             _publish_gen = staticmethod(interface._publish_gen)
             _decay_dir = staticmethod(interface._decay_dir)
@@ -11523,28 +11523,38 @@ class TestMg7IsOnlyDemotedForGridpack(unittest.TestCase):
             shutil.rmtree(tmp, ignore_errors=True)
 
 
-class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
-    """mg7 emits LHE, and MadSpin deals it out into one file per unweighting
-    worker at the canonical ``Events/<run_name>/unweighted_events_<i>.lhe``.
+class TestMg7WritesANumpyPoolEveryWorkerStrides(unittest.TestCase):
+    """mg7 writes its decay pool as one ``events.npy`` and nothing splits it.
 
-    Both halves matter. LHE because a pool has to be reconstructible from a
-    path alone -- across the generation fork and, on a refill, from the channel
-    owner to every waiter -- and only LHE carries the channel's partial width
-    with it, in its <init> block. The per-worker split because a worker that is
-    handed a single file has to STRIDE it (_StridedEvents calls next() on every
-    other worker's events too), i.e. parse the whole pool to read 1/N of it.
+    The pool is memory-mapped and randomly addressable, so worker i of N reads
+    the rows at positions i, i+N, ... by index arithmetic: no per-worker file to
+    write, no other worker's events to parse past. That is the whole difference
+    from LHE text, where a worker handed a single file has to ``next()`` its way
+    over everybody else's events and the pool therefore has to be dealt out into
+    one file per worker first.
 
-    And writing them at those particular paths is what makes a refill free:
-    ``_refill_pool_paths`` is the same layout under the same ``run_name``, so
-    ``_generate_refill_pool`` finds sources == targets and does no further
-    work -- the same branch madevent lands in.
+    The objection this reverses was that only LHE carries the channel's partial
+    width with it (in its <init> block), so a .npy pool could not survive being
+    handed to another process by path alone. It survives both hops without
+    anything being published beside it: the generation fork already marshals the
+    width explicitly with the paths, and a refill hands on the width the reader
+    it replaces already had -- a channel's width does not change from one
+    generation of its pool to the next. See
+    TestMg7NumpyPoolCrossesTheGenerationFork and
+    TestNumpyRefillPoolCarriesItsWidthWithoutASidecar.
+
+    The pool still lands under ``Events/<run_name>/`` -- mg7 names its own run
+    directory and MadSpin renames it there -- because for a refill that path IS
+    ``_refill_pool_paths``, so ``_generate_refill_pool`` sees the backend has
+    written the canonical layout and does nothing further.
     """
 
     NB_EVENT = 24
+    WIDTH = 1.4586029
 
     def setUp(self):
         import tempfile
-        self.tmpdir = tempfile.mkdtemp(prefix='ms_mg7lhe_')
+        self.tmpdir = tempfile.mkdtemp(prefix='ms_mg7npy_')
         self.decay_dir = pjoin(self.tmpdir, 'decay_6_0')
         os.makedirs(pjoin(self.decay_dir, 'Cards'))
         os.makedirs(pjoin(self.decay_dir, 'bin'))
@@ -11555,17 +11565,20 @@ class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    WIDTH = 1.4586029
-
     def _write_launcher(self):
         """A stand-in for ``bin/generate_events``: makes its own run directory
-        (mg7 names it, MadSpin does not) and writes an LHE pool there, with the
-        partial width in the <init> block exactly as combine_to_lhe does."""
+        (mg7 names it, MadSpin does not) and writes a numpy pool plus the
+        info.json that reports the partial width, exactly as
+        combine_to_lhe_npy and the launcher do."""
+        fields = list(interface_madspin._NPY_PARTICLE_FIELDS)
         lines = [
             '#!/usr/bin/env python3',
-            'import os',
+            'import os, json, numpy',
             'WIDTH = @WIDTH@',
             'NB = @NB@',
+            'FIELDS = %r' % (fields,),
+            'INTEGRAL = ("pdg_id", "status_code", "mother1", "mother2",',
+            '            "color", "anti_color")',
             'run = None',
             'for i in range(1, 100):',
             '    cand = os.path.join("Events", "run_%02d" % i)',
@@ -11573,22 +11586,31 @@ class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
             '        run = cand',
             '        break',
             'os.makedirs(run)',
-            'f = open(os.path.join(run, "events.lhe"), "w")',
-            'f.write(\'<LesHouchesEvents version="3.0">\\n<header></header>\\n<init>\\n\')',
-            'f.write(" 2212 2212 6.5e+03 6.5e+03 0 0 247000 247000 -4 1\\n")',
-            'f.write(" %.7e 1.2908000e-03 %.7e 1\\n" % (WIDTH, WIDTH))',
-            'f.write("</init>\\n")',
-            'for i in range(NB):',
-            '    f.write("<event>\\n")',
-            '    f.write(" 3 1 +1.0e+00 1.73e+02 7.5467711e-03 1.178e-01\\n")',
-            '    f.write("  6 -1 0 0 501 0 0. 0. 0. 1.73e+02 1.73e+02 0. 9.\\n")',
-            '    f.write("  5 1 1 1 501 0 0. 0. %d. 8.65e+01 8.65e+01 0. 9.\\n" % i)',
-            '    f.write(" 24 1 1 1 0 0 0. 0. 0. 8.65e+01 8.65e+01 0. 9.\\n")',
-            '    f.write("</event>\\n")',
-            'f.write("</LesHouchesEvents>\\n")',
-            'f.close()',
+            'dtype = [("weight", "f8"), ("scale", "f8"),',
+            '         ("alpha_qed", "f8"), ("alpha_qcd", "f8")]',
+            'for i in range(1, 4):',
+            '    for f in FIELDS:',
+            '        dtype.append(("part%d_%s" % (i, f),',
+            '                      "i4" if f in INTEGRAL else "f8"))',
+            'rec = numpy.zeros(NB, dtype=dtype)',
+            'rec["weight"] = 1.0',
+            'rec["part1_pdg_id"] = 6',
+            'rec["part1_status_code"] = -1',
+            'rec["part1_energy"] = 173.0',
+            'rec["part1_mass"] = 173.0',
+            'for i, pdg in ((2, 5), (3, 24)):',
+            '    rec["part%d_pdg_id" % i] = pdg',
+            '    rec["part%d_status_code" % i] = 1',
+            '    rec["part%d_mother1" % i] = 1',
+            '    rec["part%d_mother2" % i] = 1',
+            '    rec["part%d_energy" % i] = 86.5',
+            # a per-event fingerprint, so the stripes can be checked to
+            # partition the pool
+            'rec["part2_pz"] = numpy.arange(NB, dtype="f8")',
+            'numpy.save(os.path.join(run, "events.npy"), rec)',
             'info = open(os.path.join(run, "info.json"), "w")',
-            'info.write(\'{"run_times": {"integrate": {"wall_time_sec": 2.5}}}\')',
+            'json.dump({"process": {"mean": WIDTH},',
+            '           "run_times": {"integrate": {"wall_time_sec": 2.5}}}, info)',
             'info.close()',
         ]
         script = '\n'.join(lines) \
@@ -11599,7 +11621,7 @@ class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
             fsock.write(script + '\n')
         os.chmod(path, 0o755)
 
-    def _stub(self, nb_split):
+    def _stub(self, nb_core):
         interface = interface_madspin.MadSpinInterface
 
         class Stub(object):
@@ -11607,119 +11629,325 @@ class TestMg7WritesThePoolWhereTheParallelPathLooksForIt(unittest.TestCase):
             _add_phase = interface._add_phase
             _phase = interface._phase
             InvalidCmd = interface.InvalidCmd
-            _split_pool_round_robin = staticmethod(
-                interface._split_pool_round_robin)
             _refill_pool_dir = staticmethod(interface._refill_pool_dir)
             _refill_pool_paths = interface._refill_pool_paths
+            _reopen_decay_pool = interface._reopen_decay_pool
+            _channel_owner = interface._channel_owner
+            _count_pool_events = staticmethod(interface._count_pool_events)
 
             def _decay_pool_split(self):
-                return nb_split
+                return nb_core
 
         stub = Stub()
         stub.banner = {'slha': '# param card\n'}
-        stub._shard_nb_core = nb_split
+        stub._shard_nb_core = nb_core
+        stub._channel_keys = [(6, 0)]
+        stub._owner_undersize = 0.0
         return stub
 
-    def _tags(self, path):
-        """The pz of the b in every event of a file -- a per-event fingerprint,
-        so the slices can be checked to partition the pool."""
-        out = []
-        reader = lhe_parser.EventFile(path)
-        for event in reader:
-            out.append(int(event[1].pz))
-        reader.close()
-        return out
+    @staticmethod
+    def _tags(reader):
+        """The pz of the b in every event the reader yields."""
+        return [int(event[1].pz) for event in reader]
 
     # ---------------------------------------------------------------- format
 
-    def test_the_run_card_asks_for_lhe(self):
+    def test_the_run_card_asks_for_the_numpy_event_file(self):
         self._stub(1).generate_events_mg7(self.decay_dir, self.NB_EVENT)
         card = banner.RunCardMG7(pjoin(self.decay_dir, 'Cards', 'run_card.toml'))
-        self.assertEqual(card['run']['output_format'], 'lhe')
+        self.assertEqual(card['run']['output_format'], 'lhe_npy')
 
-    def test_the_partial_width_comes_out_of_the_init_block(self):
-        """The whole reason for LHE: the width travels with the file, so any
-        reader rebuilt from the path alone still has it."""
+    def test_the_partial_width_comes_out_of_info_json(self):
+        """A .npy has no <init> block, so the width comes from the run result
+        the launcher writes -- and it has to arrive, or the branching ratio of
+        the whole run silently collapses."""
         pool, width = self._stub(1).generate_events_mg7(self.decay_dir,
                                                         self.NB_EVENT)
         self.assertAlmostEqual(width, self.WIDTH, places=6)
         self.assertAlmostEqual(pool.cross, self.WIDTH, places=6)
+        self.assertIsInstance(pool, interface_madspin.NpyDecayPool)
 
-    def test_a_serial_run_gets_the_single_file_unsplit(self):
-        pool, _ = self._stub(1).generate_events_mg7(self.decay_dir,
-                                                    self.NB_EVENT)
-        self.assertEqual(len(self._tags(pool.name)), self.NB_EVENT)
+    def test_a_missing_width_is_refused_rather_than_read_as_zero(self):
+        """Without the <init> block there is no second place to find the width,
+        so a run whose info.json does not report one must fail loudly: a width
+        silently read as zero collapses the branching ratio of the whole run."""
+        with open(pjoin(self.decay_dir, 'bin', 'generate_events'), 'a') as fsock:
+            fsock.write('open(os.path.join(run, "info.json"), "w")'
+                        '.write(\'{"run_times": {}}\')\n')
+        self.assertRaises(Exception, self._stub(1).generate_events_mg7,
+                          self.decay_dir, self.NB_EVENT)
+
+    # ------------------------------------------------------------ the layout
+
+    def test_the_pool_is_one_file_whatever_the_core_count(self):
+        """No split, so no per-worker files and nothing to clean up after."""
+        pool, _ = self._stub(18).generate_events_mg7(self.decay_dir,
+                                                     self.NB_EVENT)
         self.assertFalse(hasattr(pool, 'paths'))
-
-    # ----------------------------------------------------------- the layout
-
-    def test_the_pool_is_split_one_file_per_worker(self):
-        pool, width = self._stub(4).generate_events_mg7(self.decay_dir,
-                                                        self.NB_EVENT)
-        self.assertEqual(len(pool.paths), 4)
-        for i, path in enumerate(pool.paths):
-            self.assertEqual(os.path.basename(path),
-                             'unweighted_events_%d.lhe' % i)
-            self.assertEqual(os.path.dirname(path),
-                             pjoin(self.decay_dir, 'Events', 'run_01'))
-        self.assertAlmostEqual(width, self.WIDTH, places=6)
-
-    def test_the_slices_partition_the_pool_round_robin(self):
-        """No event seen twice, none lost, and worker i gets positions
-        i, i+N, ... -- the stripe it would have strided out for itself."""
-        pool, _ = self._stub(4).generate_events_mg7(self.decay_dir,
-                                                    self.NB_EVENT)
-        seen = []
-        for i, path in enumerate(pool.paths):
-            tags = self._tags(path)
-            self.assertEqual(tags, list(range(i, self.NB_EVENT, 4)))
-            seen.extend(tags)
-        self.assertEqual(sorted(seen), list(range(self.NB_EVENT)))
-
-    def test_every_slice_carries_the_width(self):
-        """A worker opens one slice by path and reads .cross off it; the banner
-        has to be on each of them, not only the first."""
-        pool, _ = self._stub(4).generate_events_mg7(self.decay_dir,
-                                                    self.NB_EVENT)
-        for path in pool.paths:
-            reader = lhe_parser.EventFile(path)
-            self.assertAlmostEqual(reader.cross, self.WIDTH, places=6)
-            reader.close()
-
-    # ------------------------------------------------------------ the refill
-
-    def test_the_unsplit_pool_is_not_kept_beside_the_slices(self):
-        """The slices between them hold every event of what mg7 wrote, so
-        keeping mg7's own file too doubles the disk a pool costs -- and a refill
-        adds a generation rather than replacing one."""
-        pool, _ = self._stub(4).generate_events_mg7(self.decay_dir,
-                                                    self.NB_EVENT)
         run_dir = pjoin(self.decay_dir, 'Events', 'run_01')
-        self.assertFalse(os.path.exists(pjoin(run_dir, 'events.lhe')))
-        self.assertTrue(os.path.exists(pjoin(run_dir, 'info.json')))
-        seen = []
-        for path in pool.paths:
-            seen.extend(self._tags(path))
-        self.assertEqual(sorted(seen), list(range(self.NB_EVENT)))
+        self.assertEqual(sorted(os.listdir(run_dir)),
+                         ['events.npy', 'info.json'])
+        self.assertEqual(len(pool), self.NB_EVENT)
 
-    def test_a_serial_run_keeps_the_file_it_was_handed(self):
-        """Nothing is split there, so nothing may be removed either."""
-        pool, _ = self._stub(1).generate_events_mg7(self.decay_dir,
-                                                    self.NB_EVENT)
-        self.assertTrue(os.path.exists(pool.name))
-
-    def test_a_refill_lands_exactly_on_the_paths_the_waiters_open(self):
-        """The payoff of writing under ``Events/<run_name>/``: for a refill,
-        run_name is ms_refill_<gen> and those paths ARE _refill_pool_paths, so
-        _generate_refill_pool sees sources == targets and skips the whole
-        materialise/split step."""
+    def test_the_pool_lands_under_the_run_name_madspin_asked_for(self):
+        """mg7 names its own run directory; MadSpin renames the pool to the one
+        the rest of the code addresses it by."""
         stub = self._stub(4)
         pool, _ = stub.generate_events_mg7(self.decay_dir, self.NB_EVENT,
                                            run_name='ms_refill_1')
-        self.assertEqual(pool.paths,
+        self.assertEqual(pool.name,
+                         pjoin(self.decay_dir, 'Events', 'ms_refill_1',
+                               'events.npy'))
+        self.assertTrue(os.path.exists(pool.name))
+
+    def test_a_refill_lands_exactly_on_the_path_the_waiters_open(self):
+        """The payoff of the rename: for a refill, run_name is ms_refill_<gen>
+        and that path IS _refill_pool_paths, so _generate_refill_pool sees the
+        backend has written the canonical layout and does no further work."""
+        stub = self._stub(4)
+        pool, _ = stub.generate_events_mg7(self.decay_dir, self.NB_EVENT,
+                                           run_name='ms_refill_1')
+        self.assertEqual([pool.name],
                          stub._refill_pool_paths(self.decay_dir, 1))
-        for path in pool.paths:
-            self.assertTrue(os.path.exists(path), path)
+
+    # ----------------------------------------------------------- the striding
+
+    def test_every_worker_gets_a_disjoint_stripe_of_the_one_pool(self):
+        """Worker i reads positions i, i+N, ... -- the same partition the
+        round-robin split used to have to write out as files."""
+        stub = self._stub(4)
+        pool, _ = stub.generate_events_mg7(self.decay_dir, self.NB_EVENT)
+        seen = []
+        for shard in range(4):
+            local = stub._reopen_decay_pool({6: {0: pool}}, shard, 4)
+            tags = self._tags(local[6][0])
+            self.assertEqual(tags, list(range(shard, self.NB_EVENT, 4)))
+            seen.extend(tags)
+        self.assertEqual(sorted(seen), list(range(self.NB_EVENT)))
+
+    def test_every_stripe_carries_the_width(self):
+        """A worker reads .cross off its own reader to weight the channel
+        choice, so the width has to survive being re-sliced."""
+        stub = self._stub(4)
+        pool, _ = stub.generate_events_mg7(self.decay_dir, self.NB_EVENT)
+        for shard in range(4):
+            local = stub._reopen_decay_pool({6: {0: pool}}, shard, 4)
+            self.assertAlmostEqual(local[6][0].cross, self.WIDTH, places=6)
+
+    def test_a_stripe_that_does_not_divide_the_pool_evenly_is_still_exact(self):
+        """26 events over 4 workers: two workers get 7, two get 6, and between
+        them they hold every event once."""
+        stub = self._stub(4)
+        pool, _ = stub.generate_events_mg7(self.decay_dir, self.NB_EVENT)
+        path = pool.name
+        seen = []
+        for shard in range(5):
+            reader = interface_madspin.NpyDecayPool(path, 1.0, offset=shard,
+                                                    stride=5)
+            tags = self._tags(reader)
+            self.assertEqual(len(reader), len(tags))
+            self.assertEqual(tags, list(range(shard, self.NB_EVENT, 5)))
+            seen.extend(tags)
+        self.assertEqual(sorted(seen), list(range(self.NB_EVENT)))
+
+    def test_a_stripe_past_the_end_of_the_pool_is_simply_empty(self):
+        """More workers than events: the extra ones get nothing, and say so
+        through len() as well as by raising StopIteration at once."""
+        stub = self._stub(1)
+        pool, _ = stub.generate_events_mg7(self.decay_dir, self.NB_EVENT)
+        reader = interface_madspin.NpyDecayPool(pool.name, 1.0,
+                                                offset=self.NB_EVENT + 3,
+                                                stride=self.NB_EVENT + 8)
+        self.assertEqual(len(reader), 0)
+        self.assertEqual(list(reader), [])
+
+    def test_the_stripe_crosses_the_chunk_boundary_intact(self):
+        """The chunked conversion has to keep the stride across refills of the
+        chunk, not restart the arithmetic at every boundary."""
+        stub = self._stub(1)
+        pool, _ = stub.generate_events_mg7(self.decay_dir, self.NB_EVENT)
+        reader = interface_madspin.NpyDecayPool(pool.name, 1.0, offset=1,
+                                                stride=3)
+        reader.CHUNK = 2
+        self.assertEqual(self._tags(reader), list(range(1, self.NB_EVENT, 3)))
+
+
+class TestTheOwnerUndersizeCanCountANumpyPool(unittest.TestCase):
+    """``_count_pool_events`` sizes the ~10% shortfall that makes a channel's
+    OWNER worker run its slice out -- and so regenerate the pool -- before the
+    workers waiting on it do.
+
+    It counted ``<event`` records by scanning the file as text. A numpy pool
+    contains no such text, so it counted zero, the owner's slice was capped at
+    zero events, and the owner refilled on its very first draw and then again
+    on the next one, forever. Nothing raises: it presents as a refill loop, not
+    as a file-format error, which is why it is worth a test of its own.
+    """
+
+    NB_EVENT = 40
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix='ms_count_')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    @staticmethod
+    def _npy_dtype():
+        """The event-level columns mg7's lhe_npy file always carries."""
+        return [('weight', 'f8'), ('scale', 'f8'),
+                ('alpha_qed', 'f8'), ('alpha_qcd', 'f8')]
+
+    def _npy(self, nb_event=None):
+        import numpy
+        nb_event = self.NB_EVENT if nb_event is None else nb_event
+        path = pjoin(self.tmpdir, 'events.npy')
+        numpy.save(path, numpy.zeros(nb_event, dtype=self._npy_dtype()))
+        return path
+
+    def _lhe(self, nb_event):
+        path = pjoin(self.tmpdir, 'pool.lhe')
+        with open(path, 'w') as fsock:
+            fsock.write('<LesHouchesEvents version="3.0">\n<init>\n</init>\n')
+            for _ in range(nb_event):
+                fsock.write('<event>\n 0 0\n</event>\n')
+            fsock.write('</LesHouchesEvents>\n')
+        return path
+
+    def test_a_numpy_pool_is_counted_not_read_as_zero(self):
+        """The regression proper."""
+        count = interface_madspin.MadSpinInterface._count_pool_events(self._npy())
+        self.assertEqual(count, self.NB_EVENT)
+
+    def test_an_lhe_pool_is_still_counted_by_its_event_records(self):
+        count = interface_madspin.MadSpinInterface._count_pool_events(
+            self._lhe(17))
+        self.assertEqual(count, 17)
+
+    def test_the_owner_slice_of_a_numpy_pool_is_shorter_than_a_waiters(self):
+        """What the silent zero actually broke: the owner has to get ~90% of
+        its stripe, not 0% of it."""
+        interface = interface_madspin.MadSpinInterface
+        path = self._npy()
+
+        class Stub(object):
+            _open_refill_slice = interface._open_refill_slice
+            _refill_pool_path = interface._refill_pool_path
+            _refill_pool_paths = interface._refill_pool_paths
+            _refill_pool_dir = staticmethod(interface._refill_pool_dir)
+            _count_pool_events = staticmethod(interface._count_pool_events)
+
+        decay_dir = pjoin(self.tmpdir, 'decay_6_0')
+        os.makedirs(interface._refill_pool_dir(decay_dir, 1))
+        shutil.move(path, pjoin(interface._refill_pool_dir(decay_dir, 1),
+                                'events.npy'))
+
+        lengths = {}
+        for shard in range(4):
+            stub = Stub()
+            stub._shard_tag = shard
+            stub._shard_nb_core = 4
+            stub._owner_undersize = 0.10
+            reader = stub._open_refill_slice(decay_dir, 1, owner=0, cross=1.5)
+            lengths[shard] = len(list(reader))
+        self.assertEqual(lengths[0], int(math.floor(0.90 * 10)))
+        self.assertEqual(lengths[1], 10)
+        self.assertLess(lengths[0], lengths[1])
+
+
+class TestNumpyRefillPoolCarriesItsWidthWithoutASidecar(unittest.TestCase):
+    """The second hop a decay pool has to survive: a channel's refill OWNER
+    generates a pool and every waiter opens it by path alone.
+
+    The claim that this needed LHE was that ``_open_refill_slice`` builds an
+    ``EventFile``, which reads the channel's partial width out of the <init>
+    block -- and the decay loop does read ``.cross`` back off that reader, to
+    weight the choice between a pdg's channels. So the width is genuinely used
+    here; it simply does not have to be published beside the pool. A channel's
+    partial width is the same for every generation of its pool, so the reader
+    that just ran dry already has it and ``_worker_refill`` passes it on. The
+    owner->waiter contract on disk stays the single ms_refill.gen marker.
+    """
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix='ms_npyrefill_')
+        self.decay_dir = pjoin(self.tmpdir, 'decay_6_0')
+        interface = interface_madspin.MadSpinInterface
+        pool_dir = interface._refill_pool_dir(self.decay_dir, 1)
+        os.makedirs(pool_dir)
+        import numpy
+        numpy.save(pjoin(pool_dir, 'events.npy'),
+                   numpy.zeros(8, dtype=[('weight', 'f8'), ('scale', 'f8'),
+                                         ('alpha_qed', 'f8'),
+                                         ('alpha_qcd', 'f8')]))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _worker(self, shard):
+        interface = interface_madspin.MadSpinInterface
+
+        class Stub(object):
+            _open_refill_slice = interface._open_refill_slice
+            _refill_pool_path = interface._refill_pool_path
+            _refill_pool_paths = interface._refill_pool_paths
+            _refill_pool_dir = staticmethod(interface._refill_pool_dir)
+            _count_pool_events = staticmethod(interface._count_pool_events)
+
+        stub = Stub()
+        stub._shard_tag = shard
+        stub._shard_nb_core = 4
+        stub._owner_undersize = 0.0
+        return stub
+
+    def test_nothing_is_published_beside_the_pool(self):
+        """The point of the whole exercise: the refill directory holds the pool
+        and nothing else -- no width sidecar, no second marker for a
+        publish/open race to live in."""
+        pool_dir = interface_madspin.MadSpinInterface._refill_pool_dir(
+            self.decay_dir, 1)
+        self.assertEqual(os.listdir(pool_dir), ['events.npy'])
+
+    def test_the_waiter_gets_the_width_it_was_handed(self):
+        reader = self._worker(2)._open_refill_slice(self.decay_dir, 1, owner=0,
+                                                    cross=1.4602897691)
+        self.assertAlmostEqual(reader.cross, 1.4602897691, places=9)
+
+    def test_the_refill_slices_partition_the_pool(self):
+        seen = []
+        for shard in range(4):
+            reader = self._worker(shard)._open_refill_slice(
+                self.decay_dir, 1, owner=None, cross=1.0)
+            seen.append(len(list(reader)))
+        self.assertEqual(seen, [2, 2, 2, 2])
+
+
+class TestANumpyPoolIsNeverHandedToTheLheSplitter(unittest.TestCase):
+    """``_split_pool_round_robin`` is LHE-only. Handed a .npy it used to raise
+    ``UnicodeDecodeError: byte 0x93`` -- the first byte of the \\x93NUMPY magic
+    read as utf-8 -- from three frames inside the LHE parser, which says
+    nothing about what actually went wrong."""
+
+    def test_it_refuses_a_numpy_source_by_name(self):
+        import tempfile
+        import numpy
+        tmpdir = tempfile.mkdtemp(prefix='ms_nosplit_')
+        try:
+            path = pjoin(tmpdir, 'events.npy')
+            numpy.save(path, numpy.zeros(4, dtype=[('weight', 'f8'),
+                                                   ('scale', 'f8')]))
+            interface = interface_madspin.MadSpinInterface
+            try:
+                interface._split_pool_round_robin(
+                    [path], [pjoin(tmpdir, 'a.lhe'), pjoin(tmpdir, 'b.lhe')])
+            except Exception as error:
+                self.assertIn('numpy decay pool', str(error))
+            else:
+                self.fail('a numpy pool was accepted by the LHE splitter')
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 class TestDecayGeneratorIsAnOptionAtAll(unittest.TestCase):


### PR DESCRIPTION
Reinstates `output_format = lhe_npy` for `decay_generator = mg7`, which T145 dropped in favour of LHE.

## The objection was wrong, and no sidecar is added

T145's reason for LHE was that a pool has to survive being handed to another process **by path alone** carrying the channel's partial width, which an LHE `<init>` block does and a `.npy` does not -- and that supplying it for a `.npy` would mean a width sidecar in the owner->waiter publish contract, "the one protocol surface where a publish/open race can live".

Both hops were checked directly:

1. **generation fork to parent.** Already carries the width explicitly: `_generate_decay_entry` writes `{'files', 'width', 'channel_widths'}` into its JSON and `_generate_decays` hands it back to `_reader_from_paths` as `cross`. Predates this change.
2. **refill owner to waiters.** Nothing has to be published. Note the width here is *not* unused, as was suggested: `get_decay_from_file` weights the choice between a pdg's channels by `channels[key].cross`, and after a refill the reader it reads that off **is** the refill slice. But a channel's partial width does not change between generations of its pool, so the reader that just ran dry already has it and `_worker_refill` passes it on in process. `ms_refill.gen` stays the only thing on disk a waiter looks at.

## The .npy removes the split rather than optimising it

A numpy pool is memory-mapped and randomly addressable, so worker *i* of *N* takes rows *i, i+N, ...* by index arithmetic. No per-worker file to write, no other worker's events to parse past. `_StridedEvents` over LHE text has to `next()` over them, which is precisely why the pool had to be dealt out into one file per worker first.

**This makes PR #86 unnecessary.** #86 taught madspace's `combine_to_lhe` to write N LHE files from C++ so MadSpin would not have to split one; its own author measured 0.34 s / 10k and 1.11 s / 100k and judged that not worth a compiled dependency. With `.npy` there is no split at all, so there is nothing left for a multi-file writer to optimise -- and none is needed for `.npy` either.

## The three call sites

| blocker | real? | what was done |
|---|---|---|
| `_open_refill_slice` builds `EventFile(path)` directly | yes | dispatches on suffix; takes the channel's width from its caller |
| `_count_lhe_events` returns 0 on a `.npy` | yes, and the nastiest | renamed `_count_pool_events`, dispatches, has a test. The silent zero capped the owner's slice at zero events so it refilled on its first draw for ever -- it presents as a refill loop, not a type error |
| `_split_pool_round_robin` on npy sources | moot | never reached for a numpy pool; now says so instead of raising `UnicodeDecodeError` three frames inside the LHE parser |

`_refill_pool_paths` tells the layouts apart by what the backend actually left in the refill directory rather than by a flag. `_StridedEvents` and `_LimitedEvents` were re-checked on an `NpyDecayPool` and do still work unchanged (T144's measurement holds), but native striding replaces the former.

## Measured

`ttbar_full`, PA, seed 42, 18 cores, warm, back to back, same production sample. mg7/LHE is `554d8e981` itself, so this is the same tree either side of the format.

| | madevent | mg7/LHE | mg7/.npy | npy vs LHE |
|---|---|---|---|---|
| 10 000 | 35.13 s | 20.45 s | **19.69 s** | -3.7% |
| 100 000 | 89.08 s | 38.10 s | **35.74 s** | -6.2% |

Medians of 3 (10k) and 6 (100k). One 100k pass was slow for all three backends (madevent's `me_generation` went 9.6 to 15.1 s in the same pass); dropping it gives 38.10 to 35.38 s, -7.1%. Spread otherwise 0.4 s at 10k, 0.7 s at 100k.

By phase at 100k: `decay_mg7_split` 1.1 s to 0, `decay_mg7_launch` 14.2 to 12.6 s (madspace writes binary instead of formatting text), `decay_loop` 15.4 to 14.7 s.

Price: peak RSS 259 to 308 MiB at 100k, and a `.npy` pool is ~35% larger on disk (every event padded to the longest). Both transient.

Physics agrees -- BR within 0.2% of madevent's 0.917999 throughout.

## Refill exercised deliberately

The benchmark triggers no refill at either size, so it was forced: with `MADSPIN_OWNER_UNDERSIZE=0.9` the 10k run drove 14+ generations through `_worker_refill` / `_owner_generate` / `_open_refill_slice`, and every `Events/ms_refill_<gen>` came back holding exactly one `events.npy` and nothing beside it. BR 0.917343, cross section 462.667 pb.

## Tests

MadSpin unit suite 570 to **579**, all green. The LHE-pool test class is replaced by npy equivalents, plus new classes for the strided reader, the `_count_pool_events` silent zero, the refill width hop, and the splitter guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
