### PR TITLE
Remove remaining uses of the six module

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -3341,14 +3341,11 @@ class MadSpinInterface(extended_cmd.Cmd):
         """Environment for run.sh / gridrun subprocesses. The gridpack scripts
         start with ``#!/usr/bin/env python3``, which otherwise resolves via PATH
         to whatever ``python3`` comes first -- often NOT the interpreter running
-        MadSpin, and thus one missing modules that gridrun needs (e.g. ``six``,
-        whose absence gridrun treats as fatal). Guarantee the same interpreter by
-        putting a ``python3`` -> sys.executable shim first on PATH. Also expose
-        ``six`` explicitly if this interpreter has it, in case it lives outside
-        the default site-packages."""
+        MadSpin. Guarantee the same interpreter by putting a ``python3`` ->
+        sys.executable shim first on PATH."""
         env = os.environ.copy()
-        # 1. python3 shim so `env python3` == the MadSpin interpreter, regardless
-        #    of whether dirname(sys.executable) even contains a bare `python3`.
+        # python3 shim so `env python3` == the MadSpin interpreter, regardless
+        # of whether dirname(sys.executable) even contains a bare `python3`.
         if not getattr(self, '_py3_shim_dir', None):
             import tempfile
             import atexit
@@ -3364,14 +3361,6 @@ class MadSpinInterface(extended_cmd.Cmd):
                 os.chmod(link, 0o755)
             self._py3_shim_dir = shim
         env['PATH'] = self._py3_shim_dir + os.pathsep + env.get('PATH', '')
-        # 2. belt-and-suspenders: if we can import six here, make sure the
-        #    subprocess can find it too.
-        try:
-            import six as _six
-            sixdir = os.path.dirname(os.path.abspath(_six.__file__))
-            env['PYTHONPATH'] = sixdir + os.pathsep + env.get('PYTHONPATH', '')
-        except Exception:
-            pass
         return env
 
     def _run_gridpack(self, cmd, cwd):

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -6004,9 +6004,8 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             print("no help available") 
           
         if banner:                      
-            logger.info('*** END HELP ***', '$MG:BOLD')    
-        #six.moves.input('press enter to quit the help')
-        return card       
+            logger.info('*** END HELP ***', '$MG:BOLD')
+        return card
 #     except Exception, error:
 #         if __debug__:
 #             import traceback

--- a/madgraph/madweight/change_tf.py
+++ b/madgraph/madweight/change_tf.py
@@ -748,10 +748,3 @@ if(__name__=="__main__"):
         made_make=0
     os.chdir('./Source/MadWeight/transfer_function')
     create_TF_main(name,made_make,MW_dir)
-    
-##    file=six.input("file: ")
-##    ff=open(file,'r')
-##    gg=open(file+'_70.f','w')
-##    text=ff.read()
-##    text=MW_fct.put_in_fortran_format(text)
-##    gg.writelines(text)

--- a/madmatrix/model_handling.py
+++ b/madmatrix/model_handling.py
@@ -25,7 +25,7 @@ from aloha import unitary_gauge
 
 from collections import defaultdict
 from fractions import Fraction
-from six import StringIO
+from io import StringIO
 
 # FD gauge check
 fd_gauge = (unitary_gauge == 3)

--- a/tests/input_files/fourfermion_UFO/object_library.py
+++ b/tests/input_files/fourfermion_UFO/object_library.py
@@ -9,7 +9,6 @@
 
 from __future__ import absolute_import
 import cmath
-import six
 
 
 class UFOBaseClass(object):
@@ -129,7 +128,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in six.iteritems(self.__dict__):
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:

--- a/tests/input_files/fourfermion_UFO/write_param_card.py
+++ b/tests/input_files/fourfermion_UFO/write_param_card.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-from six.moves import range
 __date__ = "22 Sept 2011"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 

--- a/tests/input_files/full_sm_UFO/object_library.py
+++ b/tests/input_files/full_sm_UFO/object_library.py
@@ -9,7 +9,6 @@
 
 from __future__ import absolute_import
 import cmath
-import six
 
 
 class FRBaseClass(object):
@@ -91,7 +90,7 @@ class Particle(FRBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in six.iteritems(self.__dict__):
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:

--- a/tests/input_files/loop_MSSM/object_library.py
+++ b/tests/input_files/loop_MSSM/object_library.py
@@ -10,7 +10,6 @@
 from __future__ import absolute_import
 import cmath
 import re
-import six
 
 class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
@@ -135,7 +134,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in six.iteritems(self.__dict__):
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:

--- a/tests/input_files/loop_MSSM/write_param_card.py
+++ b/tests/input_files/loop_MSSM/write_param_card.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-from six.moves import range
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 


### PR DESCRIPTION
We don't support Python 2.7, so it serves no purpose.