### PR TITLE
Fix the PDF path logic (#94)

### DIFF
--- a/.github/actions/checkout_mg5/action.yml
+++ b/.github/actions/checkout_mg5/action.yml
@@ -7,7 +7,7 @@ runs:
     # setup other environment
     - run: |
         cd $GITHUB_WORKSPACE
-        cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
         cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
       shell: bash
 

--- a/.github/actions/restore-pip-cache/action.yml
+++ b/.github/actions/restore-pip-cache/action.yml
@@ -27,9 +27,9 @@ runs:
         # Use direct path because GITHUB_PATH additions don't take effect in the same step
         F2PY_BIN="$HOME/.cache/pip-packages/bin/f2py"
         if [ -x "$F2PY_BIN" ]; then
-          echo "f2py_compiler = $F2PY_BIN" >> input/mg5_configuration.txt
+          echo "f2py_compiler = $F2PY_BIN" >> input/mg7_configuration.txt
         else
           pip install --target "$HOME/.cache/pip-packages" --upgrade numpy
-          echo "f2py_compiler = $F2PY_BIN" >> input/mg5_configuration.txt
+          echo "f2py_compiler = $F2PY_BIN" >> input/mg7_configuration.txt
         fi
       shell: bash

--- a/.github/actions/restore_delphes/action.yml
+++ b/.github/actions/restore_delphes/action.yml
@@ -32,5 +32,5 @@ runs:
 
     - run: |
         cd $GITHUB_WORKSPACE
-        echo "delphes_path = $HOME/.cache/Delphes/Delphes" >> input/mg5_configuration.txt
+        echo "delphes_path = $HOME/.cache/Delphes/Delphes" >> input/mg7_configuration.txt
       shell: bash

--- a/.github/actions/restore_heptools_contur/action.yml
+++ b/.github/actions/restore_heptools_contur/action.yml
@@ -26,11 +26,11 @@ runs:
 
     - run: |
         cd $GITHUB_WORKSPACE
-        echo "hepmc3_path = /home/runner/.cache/HEPtools/hepmc3" >>  input/mg5_configuration.txt
-        echo "rivet_path = /home/runner/.cache/HEPtools/rivet" >>  input/mg5_configuration.txt
-        echo "yoda_path = /home/runner/.cache/HEPtools/yoda" >>  input/mg5_configuration.txt
-        echo "contur_path = /home/runner/.cache/HEPtools/contur" >>  input/mg5_configuration.txt
-        echo "fastjet = /home/runner/.cache/HEPtools/fastjet/bin/fastjet-config" >>  input/mg5_configuration.txt
+        echo "hepmc3_path = /home/runner/.cache/HEPtools/hepmc3" >>  input/mg7_configuration.txt
+        echo "rivet_path = /home/runner/.cache/HEPtools/rivet" >>  input/mg7_configuration.txt
+        echo "yoda_path = /home/runner/.cache/HEPtools/yoda" >>  input/mg7_configuration.txt
+        echo "contur_path = /home/runner/.cache/HEPtools/contur" >>  input/mg7_configuration.txt
+        echo "fastjet = /home/runner/.cache/HEPtools/fastjet/bin/fastjet-config" >>  input/mg7_configuration.txt
       shell: bash
 
     - name: set pythonpath for ubuntu22

--- a/.github/actions/restore_heptools_emela/action.yml
+++ b/.github/actions/restore_heptools_emela/action.yml
@@ -26,5 +26,5 @@ runs:
 
     - run: |
         cd $GITHUB_WORKSPACE
-        echo "eMELA = /home/runner/.cache/HEPtools/bin/eMELA-config" >>       input/mg5_configuration.txt
+        echo "eMELA = /home/runner/.cache/HEPtools/bin/eMELA-config" >>       input/mg7_configuration.txt
       shell: bash

--- a/.github/actions/restore_heptools_lhapdf/action.yml
+++ b/.github/actions/restore_heptools_lhapdf/action.yml
@@ -21,9 +21,9 @@ runs:
 
     - run: |
         cd $GITHUB_WORKSPACE
-        echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg5_configuration.txt
-        echo "lhapdf = /home/runner/.cache/HEPtools/bin/lhapdf-config" >>       input/mg5_configuration.txt
-        echo "lhapdf_py3 = /home/runner/.cache/HEPtools/bin/lhapdf-config" >>       input/mg5_configuration.txt
+        echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg7_configuration.txt
+        echo "lhapdf = /home/runner/.cache/HEPtools/bin/lhapdf-config" >>       input/mg7_configuration.txt
+        echo "lhapdf_py3 = /home/runner/.cache/HEPtools/bin/lhapdf-config" >>       input/mg7_configuration.txt
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/runner/.cache/HEPtools/lhapdf6_py3//lib" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/runner/.cache/HEPtools/lib" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/restore_heptools_looptools/action.yml
+++ b/.github/actions/restore_heptools_looptools/action.yml
@@ -23,6 +23,6 @@ runs:
     # this ignore cuttools/iregi cache ... ok but we should try to fix that
     - run: |
         cd $GITHUB_WORKSPACE
-        echo "ninja = /home/runner/.cache/HEPtools/ninja/lib" >>  input/mg5_configuration.txt
-        echo "collier = /home/runner/.cache/HEPtools/collier" >>  input/mg5_configuration.txt
+        echo "ninja = /home/runner/.cache/HEPtools/ninja/lib" >>  input/mg7_configuration.txt
+        echo "collier = /home/runner/.cache/HEPtools/collier" >>  input/mg7_configuration.txt
       shell: bash

--- a/.github/actions/restore_heptools_pythia8/action.yml
+++ b/.github/actions/restore_heptools_pythia8/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - run: |
         cd $GITHUB_WORKSPACE
-        echo "pythia8_path = /home/runner/.cache/HEPtools/pythia8" >>  input/mg5_configuration.txt
-        echo "hepmc_path = /home/runner/.cache/HEPtools/hepmc" >>  input/mg5_configuration.txt
-        echo " mg5amc_py8_interface_path = /home/runner/.cache/HEPtools/MG5aMC_PY8_interface" >>  input/mg5_configuration.txt
+        echo "pythia8_path = /home/runner/.cache/HEPtools/pythia8" >>  input/mg7_configuration.txt
+        echo "hepmc_path = /home/runner/.cache/HEPtools/hepmc" >>  input/mg7_configuration.txt
+        echo " mg5amc_py8_interface_path = /home/runner/.cache/HEPtools/MG5aMC_PY8_interface" >>  input/mg7_configuration.txt
       shell: bash

--- a/.github/workflows/acceptancetest.yml
+++ b/.github/workflows/acceptancetest.yml
@@ -447,8 +447,8 @@ jobs:
       - name: test one of the test test_sm_equivalence
         run: |
             cd $GITHUB_WORKSPACE
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
-            echo "f2py_compiler = $(which f2py)" >> input/mg5_configuration.txt
+            cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
+            echo "f2py_compiler = $(which f2py)" >> input/mg7_configuration.txt
             ./tests/test_manager.py test_sm_equivalence -pA -t0 -l INFO
 
   acceptancetest_69:
@@ -467,8 +467,8 @@ jobs:
       - name: test one of the test test_sm_equivalence
         run: |
             cd $GITHUB_WORKSPACE
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
-            echo "f2py_compiler = $(which f2py)" >> input/mg5_configuration.txt
+            cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
+            echo "f2py_compiler = $(which f2py)" >> input/mg7_configuration.txt
             ./tests/test_manager.py test_all -pA -t0 -l DEBUG --debug
 
 
@@ -1026,7 +1026,7 @@ jobs:
       - name: test one of the test test_polarization_top_decay
         run: |
             cd $GITHUB_WORKSPACE
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+            cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
             ./tests/test_manager.py test_polarization_top_decay -pA -t0 -l INFO
   
   acceptancetest_ewsudakov:
@@ -1161,7 +1161,7 @@ jobs:
             cd $GITHUB_WORKSPACE
             sudo pip install numpy
             which f2py
-            echo "f2py_compiler = $(which f2py)" >> input/mg5_configuration.txt
+            echo "f2py_compiler = $(which f2py)" >> input/mg7_configuration.txt
             ./tests/test_manager.py test_standalone_density_f2py -pA -t0 -l INFO
 
   acceptancetest_density_decay2:

--- a/.github/workflows/acceptancetest_madevent.yml
+++ b/.github/workflows/acceptancetest_madevent.yml
@@ -459,7 +459,7 @@ jobs:
       - name: test one of the test test_eft_running
         run: |
             cd $GITHUB_WORKSPACE
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+            cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
             echo "install RunningCoupling" > cmd
             ./bin/madgraph cmd
             ./tests/test_manager.py test_eft_running -pA -t0 -l INFO
@@ -817,7 +817,7 @@ jobs:
       - name: test flavor consistency and decay-chain symmetry factor
         run: |
             cd $GITHUB_WORKSPACE
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+            cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
             ./tests/test_manager.py test_flavor_grouping_consistency_mlm test_flavor_grouping_consistency test_decay_chain_symmetry_factor -pA -t0 -l INFO
 
 
@@ -979,7 +979,7 @@ jobs:
       - name: test one of the test test_density_mode_doublettbar
         run: |
             cd $GITHUB_WORKSPACE
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+            cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
             ./tests/test_manager.py test_density_mode_doublettbar -pA -t0 -l INFO
 
   acceptancetest_mssm_gogo:

--- a/.github/workflows/parralel.yml
+++ b/.github/workflows/parralel.yml
@@ -42,7 +42,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       # Runs a set of commands using the runners shell
@@ -64,7 +64,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       # Runs a set of commands using the runners shell
@@ -85,7 +85,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       # Runs a set of commands using the runners shell
@@ -106,7 +106,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       # Runs a set of commands using the runners shell
@@ -128,7 +128,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       # Runs a set of commands using the runners shell
@@ -150,7 +150,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       # Runs a set of commands using the runners shell
@@ -172,7 +172,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       # Runs a set of commands using the runners shell
@@ -193,7 +193,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       # Runs a set of commands using the runners shell
@@ -212,7 +212,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       - name: test test_short_cross_gauge
@@ -230,7 +230,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       - name: test test_short_gauge
@@ -248,7 +248,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       - name: test test_short_gauge_loop
@@ -274,7 +274,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       - name: test test_short_sm
@@ -291,7 +291,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       - name: test test_short_sqso
@@ -308,7 +308,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       - name: test test_short_polarization
@@ -326,7 +326,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
       - uses: ./.github/actions/restore_ufomodel
 
@@ -345,7 +345,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
       - uses: ./.github/actions/restore_ufomodel
 
@@ -364,7 +364,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       - name: test test_short_cross_sm2
@@ -382,7 +382,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
 
       - name: test test_short_cross_sm3
@@ -400,7 +400,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Reset MG5 config
-        run: cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+        run: cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
       - uses: ./.github/actions/restore-pip-cache
       - uses: ./.github/actions/restore_ufomodel
 

--- a/.github/workflows/warm_cache.yml
+++ b/.github/workflows/warm_cache.yml
@@ -169,7 +169,7 @@ jobs:
          run: |
                mkdir -p /home/runner/.cache/HEPtools
                cd $GITHUB_WORKSPACE
-               echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg5_configuration.txt
+               echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg7_configuration.txt
                cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
                echo "install lhapdf6" > cmd
                ./bin/madgraph cmd
@@ -228,7 +228,7 @@ jobs:
          run: |
                mkdir -p /home/runner/.cache/HEPtools
                cd $GITHUB_WORKSPACE
-               echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg5_configuration.txt
+               echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg7_configuration.txt
                cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
                echo "install pythia8" > cmd
                ./bin/madgraph cmd
@@ -278,7 +278,7 @@ jobs:
          run: |
                mkdir -p /home/runner/.cache/HEPtools
                cd $GITHUB_WORKSPACE
-               echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg5_configuration.txt
+               echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg7_configuration.txt
                cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
                echo "install eMELA" > cmd
                ./bin/madgraph cmd
@@ -344,7 +344,7 @@ jobs:
                python3 -m pip install Cython
                mkdir -p /home/runner/.cache/HEPtools
                cd $GITHUB_WORKSPACE
-               echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg5_configuration.txt
+               echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg7_configuration.txt
                cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
                echo "install rivet" > cmd
                echo "install contur" >> cmd
@@ -395,7 +395,7 @@ jobs:
              mkdir -p /home/runner/.cache/HEPtools/CutTools/lib
              mkdir -p /home/runner/.cache/HEPtools/IREGI/src
              cd $GITHUB_WORKSPACE
-             echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg5_configuration.txt
+             echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg7_configuration.txt
              cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
              cd vendor/IREGI/src
              make
@@ -411,7 +411,7 @@ jobs:
        run: |
              mkdir -p ~/.cache/HEPtools
              cd $GITHUB_WORKSPACE
-             echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg5_configuration.txt
+             echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg7_configuration.txt
              cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
              echo "install collier " > cmd
              echo "install ninja " >> cmd

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ tests/status
 input/default_run_card_lo.dat
 input/default_run_card_nlo.dat
 input/default_run_card_mg7.toml
-input/mg5_configuration.txt
+input/mg7_configuration.txt
 TEST_MW_*
 .vscode/
 HEPTools/*
@@ -60,7 +60,7 @@ ME5_debug
 MS_debug
 Template/LO/Source/make_opts
 additional_command
-input/mg5_configuration.txt
+input/mg7_configuration.txt
 input/default_run_card_lo.dat
 input/default_run_card_nlo.dat
 input/default_run_card_mg7.toml

--- a/INSTALL
+++ b/INSTALL
@@ -61,5 +61,5 @@ From MG5aMC, you can run a lot of post-processing script to plot, shower,
 decay, ... your generated sample. Those tools need to be installed in
 advance via the MG5aMC terminal thanks to the "install" command.
 If some of those packages are already present, you can edit the file
-./input/mg5_configuration.txt to uncomment the associated line and
+./input/mg7_configuration.txt to uncomment the associated line and
 indicate the path to the package.

--- a/Template/LO/README
+++ b/Template/LO/README
@@ -74,7 +74,7 @@ B) Running in cluster or multicore mode:
 
 In order to automatically run in cluster or multicore mode, please set
 the flag run_mode in the Cards/me5_configuration.txt file (or in the
-input/mg5_configuration.txt file before you generate your process):
+input/mg7_configuration.txt file before you generate your process):
 
 # Default Running mode 
 # 0: single machine/ 1: cluster / 2: multicore
@@ -130,7 +130,7 @@ E) How to prevent automatic opening of the crossx.html page:
 Edit the file ./Cards/me5_configuration.txt and set
 the option automatic_html_opening to `False`.
 You can also edit the MG5 configuration card
-input/mg5_configuration.txt
+input/mg7_configuration.txt
 in order to have this value on False by default for all subsequently 
 generated processes.
 
@@ -139,7 +139,7 @@ F) How to run with a LHAPDF set
 -------------------------------
 
 1) Install lhapdf on your computer
-2) If not install globally, modify the file input/mg5_configuration.txt
+2) If not install globally, modify the file input/mg7_configuration.txt
 and specify the path to the script lhpadfconfig.
 3) in the run_card use the following parameter
  'lhapdf'    = pdlabel     ! PDF set

--- a/bin/compile.py
+++ b/bin/compile.py
@@ -57,8 +57,8 @@ class Compile_MG5:
 
         # important to uclclus
         if self.overwrite_configuration:
-            files.cp(pjoin(MG5DIR,'input','.mg5_configuration_default.txt'),
-                     pjoin(MG5DIR,'input','mg5_configuration.txt'))
+            files.cp(pjoin(MG5DIR,'input','.mg7_configuration_default.txt'),
+                     pjoin(MG5DIR,'input','mg7_configuration.txt'))
             
         self.cmd = interface.MasterCmd()                
 

--- a/bin/create_release.py
+++ b/bin/create_release.py
@@ -381,9 +381,9 @@ if (rev_nb and auto_update) or MG_branch == "LTS_2":
         p = subprocess.call("git push", shell=True)
         p = subprocess.call("git push --tags", shell=True)
 
-# 1. Copy the .mg5_configuration_default.txt to it's default path
-shutil.copy(path.join(filepath, 'input','.mg5_configuration_default.txt'), 
-            path.join(filepath, 'input','mg5_configuration.txt'))
+# 1. Copy the .mg7_configuration_default.txt to it's default path
+shutil.copy(path.join(filepath, 'input','.mg7_configuration_default.txt'), 
+            path.join(filepath, 'input','mg7_configuration.txt'))
 if os.path.exists(path.join(filepath, 'input','.default_run_card_lo.dat')):
     shutil.copy(path.join(filepath, 'input','.default_run_card_lo.dat'),
             path.join(filepath, 'input','default_run_card_lo.dat'))

--- a/bin/madgraph
+++ b/bin/madgraph
@@ -105,25 +105,17 @@ else:
         
     # charge history file
     try:
-        legacy_state_dir = os.path.join(os.environ['HOME'], '.mg5')
-
-        if os.path.exists(legacy_state_dir):
-            state_dir = legacy_state_dir
+        # MG7 keeps its state to itself: nothing is read from or written into
+        # MG5_aMC's ~/.mg5.
+        state_dir = os.getenv('XDG_STATE_HOME')
+        if state_dir:
+            state_dir = os.path.join(state_dir, 'mg7')
         else:
-            state_dir = os.getenv('XDG_STATE_HOME', os.path.join(os.environ['HOME'], '.local', 'state'))
+            state_dir = os.path.join(os.environ['HOME'], '.mg7')
 
-        # MG7 keeps its own history file. An MG5_aMC install writes mg5history
-        # into this same shared state directory, so sharing the name would
-        # interleave the two command sets. Read mg5history as a one-time
-        # fallback so an existing MG5 user does not start from an empty
-        # history; writes always go to mg7history.
         history_file = os.path.join(state_dir, "mg7history")
         if os.path.exists(history_file):
             readline.read_history_file(history_file)
-        else:
-            legacy_history_file = os.path.join(state_dir, "mg5history")
-            if os.path.exists(legacy_history_file):
-                readline.read_history_file(legacy_history_file)
     except:
         pass
 
@@ -231,8 +223,7 @@ except KeyboardInterrupt:
 try:
     cmd_line.exec_cmd('quit all', printcmd=False)
     readline.set_history_length(100)
-    if not os.path.exists(state_dir):
-        os.mkdir(state_dir)
+    os.makedirs(state_dir, exist_ok=True)
     readline.write_history_file(history_file)
 except Exception as error:
     pass

--- a/input/.mg7_configuration_default.txt
+++ b/input/.mg7_configuration_default.txt
@@ -21,8 +21,8 @@
 # Current value for all options can seen by typing "display options"
 #    after either ./bin/madgraph or ./bin/madevent 
 #
-# You can place this files in ~/.mg5/mg5_configuration.txt if you have more than
-#    one version of MG5. 
+# You can place this files in ~/.mg7/mg7_configuration.txt if you have more than
+#    one version of MG7. 
 #
 ################################################################################
 

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -4368,18 +4368,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             if 'MADGRAPH_BASE' in os.environ:
                 config_path = pjoin(os.environ['MADGRAPH_BASE'], misc.CONFIG_NAME)
                 self.set_configuration(config_path=config_path, final=False)
-            if 'HOME' in os.environ:
-                legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
-
-                if os.path.exists(legacy_config_dir):
-                    config_dir = legacy_config_dir
-                else:
-                    config_dir = os.getenv('XDG_CONFIG_HOME', os.path.join(os.environ['HOME'], '.config'))
-
-                config_path = os.path.join(config_dir, 'mg5_configuration.txt')
-
-                if os.path.exists(config_path):
-                    self.set_configuration(config_path=config_path,  final=False)
+            config_path = misc.user_config_file()
+            if config_path and os.path.exists(config_path):
+                self.set_configuration(config_path=config_path, final=False)
             if amcatnlo:
                 me5_config = pjoin(self.me_dir, 'Cards', 'amcatnlo_configuration.txt')
             else:

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -4357,7 +4357,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
     ############################################################################
     def set_configuration(self, config_path=None, final=True, initdir=None, amcatnlo=False):
         """ assign all configuration variable from file
-            ./Cards/mg5_configuration.txt. assign to default if not define """
+            ./Cards/me5_configuration.txt. assign to default if not define """
 
         if not hasattr(self, 'options') or not self.options:
             self.options = dict(self.options_configuration)
@@ -4366,7 +4366,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         if not config_path:
             if 'MADGRAPH_BASE' in os.environ:
-                config_path = pjoin(os.environ['MADGRAPH_BASE'],'mg5_configuration.txt')
+                config_path = pjoin(os.environ['MADGRAPH_BASE'], misc.CONFIG_NAME)
                 self.set_configuration(config_path=config_path, final=False)
             if 'HOME' in os.environ:
                 legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
@@ -4388,7 +4388,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
             if 'mg5_path' in self.options and self.options['mg5_path']:
                 MG5DIR = self.options['mg5_path']
-                config_file = pjoin(MG5DIR, 'input', 'mg5_configuration.txt')
+                config_file = misc.install_config_file(MG5DIR)
                 self.set_configuration(config_path=config_file, final=False,initdir=MG5DIR)
             else:
                 self.options['mg5_path'] = None
@@ -5260,7 +5260,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                         stdout = subprocess.PIPE).stdout.read().decode(errors='ignore').strip()
         except OSError as error:
             if error.errno == 2:
-                raise Exception( 'lhapdf executable (%s) is not found on your system. Please install it and/or indicate the path to the correct executable in input/mg5_configuration.txt' % lhapdf_config)
+                raise Exception( 'lhapdf executable (%s) is not found on your system. Please install it and/or indicate the path to the correct executable in input/mg7_configuration.txt' % lhapdf_config)
             else:
                 raise
                 

--- a/madgraph/interface/extended_cmd.py
+++ b/madgraph/interface/extended_cmd.py
@@ -2013,7 +2013,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 base = pjoin(self.me_dir, 'Cards', 'me5_configuration.txt')
                 if len(args) == 0 and os.path.exists(base):
                     self.write_configuration(base, base, self.me_dir)
-            base = pjoin(MG5DIR, 'input', 'mg5_configuration.txt')
+            base = misc.install_config_file(MG5DIR)
             basedir = MG5DIR
             
         if len(args) == 0:

--- a/madgraph/interface/extended_cmd.py
+++ b/madgraph/interface/extended_cmd.py
@@ -1984,38 +1984,30 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         if check:
             Cmd.check_save(self, args)
             
-        # find base file for the configuration
-        legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
-
-        if os.path.exists(legacy_config_dir):
-            config_dir = legacy_config_dir
-        else:
-            config_dir = os.getenv('XDG_CONFIG_HOME', os.path.join(os.environ['HOME'], '.config'))
-
-        config_file = os.path.join(config_dir, 'mg5_configuration.txt')
-
-        if 'HOME' in os.environ and os.environ['HOME'] and os.path.exists(config_file):
-            base = config_file
-            if hasattr(self, 'me_dir'):
-                basedir = self.me_dir
-            elif not MADEVENT:
-                basedir = MG5DIR
-            else:
-                basedir = os.getcwd()
-        elif MADEVENT:
-            # launch via ./bin/madevent
-            for config_file in ['me5_configuration.txt', 'amcatnlo_configuration.txt']:
-                if os.path.exists(pjoin(self.me_dir, 'Cards', config_file)): 
-                    base = pjoin(self.me_dir, 'Cards', config_file)
-            basedir = self.me_dir
-        else:
-            if hasattr(self, 'me_dir'):
+        # find base file for the configuration. The card of the directory we
+        # run in comes first: tool paths that are relative to a process
+        # directory have no business in the shared per-user file, and writing
+        # them there is what makes another installation pick them up.
+        base, basedir = None, None
+        if getattr(self, 'me_dir', None):
+            for name in ['me5_configuration.txt', 'amcatnlo_configuration.txt']:
+                if os.path.exists(pjoin(self.me_dir, 'Cards', name)):
+                    base = pjoin(self.me_dir, 'Cards', name)
+                    basedir = self.me_dir
+                    break
+        if base is None:
+            config_file = misc.user_config_file()
+            if config_file and os.path.exists(config_file):
+                base = config_file
+                basedir = os.getcwd() if MADEVENT else MG5DIR
+        if base is None:
+            if MADEVENT:
                 base = pjoin(self.me_dir, 'Cards', 'me5_configuration.txt')
-                if len(args) == 0 and os.path.exists(base):
-                    self.write_configuration(base, base, self.me_dir)
-            base = misc.install_config_file(MG5DIR)
-            basedir = MG5DIR
-            
+                basedir = self.me_dir
+            else:
+                base = misc.install_config_file(MG5DIR)
+                basedir = MG5DIR
+
         if len(args) == 0:
             args.append(base)
         self.write_configuration(args[0], base, basedir, self.options)

--- a/madgraph/interface/madevent_interface.py
+++ b/madgraph/interface/madevent_interface.py
@@ -358,7 +358,7 @@ class HelpToCmd(object):
         logger.info('   If FILE belongs to index.html, param_card.dat, run_card.dat')
         logger.info('   the path to the last created/used directory is used')
         logger.info('   The program used to open those files can be chosen in the')
-        logger.info('   configuration file ./input/mg5_configuration.txt')   
+        logger.info('   configuration file ./input/mg7_configuration.txt')   
         
         
     def run_options_help(self, data):
@@ -1116,7 +1116,7 @@ class CheckValidForCmd(object):
                         has_path = True
             if not has_path:
                 if '--auto' in arg and self.options['mg5_path']:
-                    args.insert(1, pjoin(self.options['mg5_path'],'input','mg5_configuration.txt'))  
+                    args.insert(1, misc.install_config_file(self.options['mg5_path']))  
                 else:
                     args.insert(1, pjoin(self.me_dir,'Cards','me5_configuration.txt'))  
 

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -333,7 +333,7 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("syntax: save %s FILENAME [OPTIONS]" % "|".join(self._save_opts),'$MG:color:BLUE')
         logger.info("-- save information as file FILENAME",'$MG:BOLD')
         logger.info("   FILENAME is optional for saving 'options'.")
-        logger.info('   By default it uses ./input/mg5_configuration.txt')
+        logger.info('   By default it uses ./input/mg7_configuration.txt')
         logger.info('   If you put "global" for FILENAME it will use the global configuration')
         logger.info('   If this files exists, it is uses by all MG5 on the system but continues')
         logger.info('   to read the local options files.')
@@ -483,7 +483,7 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info('   If FILE belongs to index.html, param_card.dat, run_card.dat')
         logger.info('   the path to the last created/used directory is used')
         logger.info('   The program used to open those files can be chosen in the')
-        logger.info('   configuration file ./input/mg5_configuration.txt')
+        logger.info('   configuration file ./input/mg7_configuration.txt')
 
     def help_customize_model(self):
         logger.info("syntax: customize_model --save=NAME",'$MG:color:BLUE')
@@ -508,7 +508,7 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("   - If mode is pythia8, output all files needed to generate")
         logger.info("     the processes using Pythia 8. The files are written in")
         logger.info("     the Pythia 8 directory (default).")
-        logger.info("     NOTE: The Pythia 8 directory is set in the ./input/mg5_configuration.txt")
+        logger.info("     NOTE: The Pythia 8 directory is set in the ./input/mg7_configuration.txt")
         logger.info("   - If mode is aloha: Special syntax output:")
         logger.info("     syntax: aloha [ROUTINE] [--options]" )
         logger.info("     valid options for aloha output are:")
@@ -1650,7 +1650,7 @@ This will take effect only in a NEW terminal
                         args.insert(1, arg)
                         has_path = True
             if not has_path:
-                args.insert(1, pjoin(MG5DIR,'input','mg5_configuration.txt'))
+                args.insert(1, misc.install_config_file(MG5DIR))
 
 
     def check_set(self, args, log=True):
@@ -3348,7 +3348,7 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
         self._nlo_modes_for_completion = ['all','virt','real','LOonly']
         self._second_exporter = None
 
-        # Load the configuration file,i.e.mg5_configuration.txt
+        # Load the configuration file,i.e.mg7_configuration.txt
         self.set_configuration()
 
     def setup(self):
@@ -3397,7 +3397,7 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
         # The four gluon merging is wanted while the diagrams are generated,
         # which is below the interface, so it travels on the module. Synced
         # here rather than only in the setter, since the option can also
-        # arrive from mg5_configuration.txt.
+        # arrive from mg7_configuration.txt.
         madgraph.merge_quartic_vertices = \
                              self.options.get('merge_quartic_vertices', False)
         # an added process arrives in the generated order whatever an earlier
@@ -7721,7 +7721,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
 
     def set_configuration(self, config_path=None, final=True):
         """ assign all configuration variable from file
-            ./input/mg5_configuration.txt. assign to default if not define """
+            ./input/mg7_configuration.txt. assign to default if not define """
 
         if not self.options:
             self.options = dict(self.options_configuration)
@@ -7730,7 +7730,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
 
         if not config_path:
             if 'MADGRAPH_BASE' in os.environ:
-                config_path = pjoin(os.environ['MADGRAPH_BASE'],'mg5_configuration.txt')
+                config_path = pjoin(os.environ['MADGRAPH_BASE'], misc.CONFIG_NAME)
                 self.set_configuration(config_path, final=False)
             if 'HOME' in os.environ:
                 legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
@@ -7744,12 +7744,11 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
 
                 if os.path.exists(config_path):
                     self.set_configuration(config_path, final=False)
-            config_path = os.path.relpath(pjoin(MG5DIR,'input',
-                                                       'mg5_configuration.txt'))
+            config_path = os.path.relpath(misc.install_config_file(MG5DIR))
             return self.set_configuration(config_path, final)
 
         if not os.path.exists(config_path):
-            files.cp(pjoin(MG5DIR,'input','.mg5_configuration_default.txt'), config_path)
+            files.cp(pjoin(MG5DIR,'input',misc.CONFIG_TEMPLATE_NAME), config_path)
         if not os.path.exists(pjoin(MG5DIR,'input','default_run_card_lo.dat')) and madgraph.ReadWrite:
             files.cp(pjoin(MG5DIR,'input','.default_run_card_lo.dat'), pjoin(MG5DIR,'input','default_run_card_lo.dat'))
             files.cp(pjoin(MG5DIR,'input','.default_run_card_nlo.dat'), pjoin(MG5DIR,'input','default_run_card_nlo.dat'))
@@ -7766,7 +7765,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
             try:
                 name, value = line.split('=',1)
             except ValueError:
-                #misc.sprint('ignore line in mg5_configuration.txt: %s' % line)
+                #misc.sprint('ignore line in mg7_configuration.txt: %s' % line)
                 pass
             else:
                 name = name.strip()
@@ -8354,13 +8353,13 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             if len(args) >1 and not args[1].startswith('--') and args[1] not in self.options:
                 filepath = args[1]
             else:
-                filepath = pjoin(MG5DIR, 'input', 'mg5_configuration.txt')
-            
+                filepath = misc.install_config_file(MG5DIR)
+
             basedir = MG5DIR
             if partial_save and os.path.exists(filepath):
                 basefile = filepath
             else:
-                basefile = pjoin(MG5DIR, 'input', '.mg5_configuration_default.txt')
+                basefile = pjoin(MG5DIR, 'input', misc.CONFIG_TEMPLATE_NAME)
                 
             
 

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -1624,16 +1624,10 @@ This will take effect only in a NEW terminal
                 elif arg.startswith('--'):
                     raise self.InvalidCmd('unknow command for \'save options\'')
                 elif arg == 'global':
-                    legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
-
-                    if os.path.exists(legacy_config_dir):
-                        config_dir = legacy_config_dir
-                    else:
-                        config_dir = os.getenv('XDG_CONFIG_HOME', os.path.join(os.environ['HOME'], '.config'))
-                        if not os.path.exists(config_dir):
-                            os.makedirs(config_dir)
-
-                    config_file = os.path.join(config_dir, 'mg5_configuration.txt')
+                    config_file = misc.user_config_file(create=True)
+                    if not config_file:
+                        raise self.InvalidCmd('no home directory to save the '
+                                              'global configuration into')
                     args.remove('global')
                     args.insert(1, config_file)
 
@@ -6477,7 +6471,27 @@ This implies that with decay chains:
         line = 'all =' + ' '.join(line)
         self.do_define(line)
 
-    def advanced_install(self, tool_to_install, 
+    @staticmethod
+    def heptools_install_target(heptools_install_dir):
+        """Where 'install <tool>' puts a tool, and which configuration file
+        records the resulting path ('' meaning this installation's own).
+
+        A prefix inside this installation is private to it, so its paths belong
+        in its own configuration; only a prefix explicitly pointed at a shared
+        location is recorded per user. Writing installation-specific absolute
+        paths into the shared file is what makes another MadGraph installation
+        pick up this one's HEPTools.
+        """
+
+        prefix = heptools_install_dir or pjoin(MG5DIR, 'HEPTools')
+        if not os.path.isabs(prefix):
+            prefix = pjoin(MG5DIR, prefix)
+        prefix = os.path.realpath(prefix)
+        if os.path.commonpath([prefix, MG5DIR]) == MG5DIR:
+            return prefix, ''
+        return prefix, misc.user_config_file(create=True) or ''
+
+    def advanced_install(self, tool_to_install,
                                HepToolsInstaller_web_address=None,
                                additional_options=[]):
         """ Uses the HEPToolsInstaller.py script maintened online to install
@@ -6551,21 +6565,8 @@ This implies that with decay chains:
             compiler_options.append('--fortran_compiler=%s'%
                                                self.options['fortran_compiler'])
 
-        if  self.options['heptools_install_dir']:
-            prefix = self.options['heptools_install_dir']
-            legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
-
-            if os.path.exists(legacy_config_dir):
-                config_dir = legacy_config_dir
-            else:
-                config_dir = os.getenv('XDG_CONFIG_HOME', os.path.join(os.environ['HOME'], '.config'))
-                if not os.path.exists(config_dir):
-                    os.makedirs(config_dir)
-
-            config_file = os.path.join(config_dir, 'mg5_configuration.txt')
-        else:
-            prefix = pjoin(MG5DIR, 'HEPTools')
-            config_file = ''
+        prefix, config_file = self.heptools_install_target(
+                                       self.options['heptools_install_dir'])
 
         # Add the path of pythia8 if known and the MG5 path
         if tool=='mg5amc_py8_interface':
@@ -7732,18 +7733,9 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
             if 'MADGRAPH_BASE' in os.environ:
                 config_path = pjoin(os.environ['MADGRAPH_BASE'], misc.CONFIG_NAME)
                 self.set_configuration(config_path, final=False)
-            if 'HOME' in os.environ:
-                legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
-
-                if os.path.exists(legacy_config_dir):
-                    config_dir = legacy_config_dir
-                else:
-                    config_dir = os.getenv('XDG_STATE_HOME', os.path.join(os.environ['HOME'], '.config'))
-
-                config_path = os.path.join(config_dir, "mg5_configuration.txt")
-
-                if os.path.exists(config_path):
-                    self.set_configuration(config_path, final=False)
+            config_path = misc.user_config_file()
+            if config_path and os.path.exists(config_path):
+                self.set_configuration(config_path, final=False)
             config_path = os.path.relpath(misc.install_config_file(MG5DIR))
             return self.set_configuration(config_path, final)
 
@@ -8079,42 +8071,17 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                     heptools_dir = os.path.join(MG5DIR, heptools_dir)
                 gen_env['MADGRAPH_HEPTOOLS_DIR'] = os.path.abspath(heptools_dir)
 
-            # Point the run at the LHAPDF data directory where PDF sets live
-            # (and where a missing one can be downloaded on the fly), following:
-            #   1. $LHAPDF_DATA_PATH if the user set it;
-            #   2. the data dir of the configured lhapdf (e.g. lhapdf6 installed
-            #      via 'install lhapdf6', which lives inside HEPTools);
-            #   3. a local writable directory otherwise.
-            # The lhapdf-config executable is forwarded (MADGRAPH_LHAPDF_CONFIG)
-            # so the run can download the requested PDF set (see madevent
-            # init_beam / ensure_pdf_set).
-            lhapdf_exe = None
-            for _opt in ('lhapdf', 'lhapdf_py3'):
-                _val = self.options.get(_opt)
-                if not _val:
-                    continue
-                _exe = _val.split()[0]  # strip any '--python=' suffix
-                try:
-                    _datadir = subprocess.check_output(
-                        [_exe, '--datadir'], text=True,
-                        stderr=subprocess.DEVNULL).strip()
-                except Exception:
-                    continue
-                lhapdf_exe = _exe
-                if 'LHAPDF_DATA_PATH' not in gen_env and _datadir and os.path.isdir(_datadir):
-                    gen_env['LHAPDF_DATA_PATH'] = _datadir
-                break
-            if 'LHAPDF_DATA_PATH' not in gen_env:
-                # local fallback (inside HEPTools if configured, else MG5DIR)
-                local_pdf = os.path.join(
-                    gen_env.get('MADGRAPH_HEPTOOLS_DIR', MG5DIR), 'lhapdf_pdfsets')
-                try:
-                    os.makedirs(local_pdf, exist_ok=True)
-                    gen_env['LHAPDF_DATA_PATH'] = local_pdf
-                except OSError:
-                    pass
-            if lhapdf_exe:
-                gen_env['MADGRAPH_LHAPDF_CONFIG'] = lhapdf_exe
+            # Forward the resolved LHAPDF location. bin/generate_events
+            # resolves it the same way on its own (launch.lhapdf_paths), so
+            # this only matters for the real LHAPDF library used by the
+            # post-processing tools, which reads LHAPDF_DATA_PATH natively.
+            lhapdf = misc.resolve_lhapdf(self.options, root=MG5DIR, create=True)
+            search = lhapdf.data_paths or (
+                [lhapdf.download_path] if lhapdf.download_path else [])
+            if search:
+                gen_env['LHAPDF_DATA_PATH'] = os.pathsep.join(search)
+            if lhapdf.config:
+                gen_env['MADGRAPH_LHAPDF_CONFIG'] = lhapdf.config
 
             class ext_program:
                 @staticmethod

--- a/madgraph/interface/master_interface.py
+++ b/madgraph/interface/master_interface.py
@@ -784,7 +784,7 @@ class MasterCmdWeb(MGcmd.MadGraphCmdWeb, Switcher, LoopCmd.LoopInterfaceWeb):
     def set_configuration(self, config_path=None, final=False):
         
         """Force to use the web configuration file only"""
-        config_path = pjoin(os.environ['MADGRAPH_BASE'], 'mg5_configuration.txt')
+        config_path = pjoin(os.environ['MADGRAPH_BASE'], misc.CONFIG_NAME)
         return Switcher.set_configuration(self, config_path=config_path, final=final)
     
     def do_save(self, line, check=True, **opt):
@@ -801,7 +801,7 @@ class MasterCmdWeb(MGcmd.MadGraphCmdWeb, Switcher, LoopCmd.LoopInterfaceWeb):
             # put default options since 
             # in the web the local file is not used
             # in download the default file is more usefull
-            files.cp(pjoin(MG5DIR,'input','mg5_configuration.txt'), args[1])
+            files.cp(misc.install_config_file(MG5DIR), args[1])
             
     def do_install(self, line):
         """block all install"""

--- a/madgraph/interface/tutorial_text_nlo.py
+++ b/madgraph/interface/tutorial_text_nlo.py
@@ -31,7 +31,7 @@ b) How to create the corresponding output for MadGraph5_aMC@NLO
 c) How to run this output for computing NLO corrections
 
 If you have FastJet (v3 or later) installed on your computer and you wish
-to link it, please update the mg5_configuration file or type
+to link it, please update the mg7_configuration file or type
 MG5_aMC>set fastjet /path/to/fastjet-config
 Otherwise the basic fastjet functionalities included in FJcore (shipped
 with MadGraph5_aMC@NLO) will be used.

--- a/madgraph/iolibs/export_cpp.py
+++ b/madgraph/iolibs/export_cpp.py
@@ -3259,6 +3259,47 @@ class ProcessExporterMG7(ProcessExporterCPP):
                 )
             os.chmod(madnis_bin, 0o755)
 
+    # Recorded in Cards/me5_configuration.txt: the tools a run needs but cannot
+    # rediscover on its own. LHAPDF above all -- bin/generate_events may be
+    # driven from a shell that never sourced anything MadGraph-related.
+    _me5_config_keys = ('lhapdf', 'lhapdf_py3', 'lhapdf_py2',
+                        'heptools_install_dir')
+
+    def write_me5_configuration(self):
+        """Cards/me5_configuration.txt: read by CommonRunCmd.set_configuration
+        and by the mg7 launcher (load_mg5_options). Edit it to move the
+        directory to a machine where the tools sit elsewhere."""
+
+        lines = ['# configuration for the mg7 run time and post-processing tools',
+                 '# written at output time; edit if you move this directory',
+                 'mg5_path = %s' % MG5DIR]
+        for key in self._me5_config_keys:
+            value = self.opt.get(key)
+            if not value or str(value).strip().lower() in ('none', 'auto'):
+                continue
+            lines.append('%s = %s' % (key, self._portable_tool_value(value)))
+        try:
+            with open(pjoin(self.dir_path, 'Cards',
+                            'me5_configuration.txt'), 'w') as fsock:
+                fsock.write('\n'.join(lines) + '\n')
+        except Exception as error:
+            logger.warning('could not write me5_configuration.txt: %s', error)
+
+    @staticmethod
+    def _portable_tool_value(value):
+        """Make a configuration value usable from another working directory.
+
+        A value relative to MG5DIR ('./HEPTools') becomes absolute; a bare
+        program name ('lhapdf-config', the shipped default) is left alone,
+        since resolving it would freeze this machine's PATH into the output.
+        A trailing '--python=X.Y' filter is preserved -- the readers know it.
+        """
+
+        exe, sep, flags = str(value).strip().partition(' ')
+        if not os.path.isabs(exe) and (os.sep in exe or exe.startswith('.')):
+            exe = os.path.realpath(pjoin(MG5DIR, exe))
+        return exe + sep + flags
+
     def get_merged_info(self):
         merged_subproc_info = []
         for subprocesses in self.merged_subprocesses.values():
@@ -3363,16 +3404,7 @@ class ProcessExporterMG7(ProcessExporterCPP):
         # process-dependent defaults (mirrors the LO run_card.dat logic).
         self.create_run_card(matrix_elements, history)
 
-        # Cards/me5_configuration.txt: read by CommonRunCmd.set_configuration.
-        # Point it at the MG5 install so tool paths (pythia8, etc.) and the
-        # cluster/run-mode settings resolve from the central configuration.
-        try:
-            with open(pjoin(self.dir_path, 'Cards',
-                            'me5_configuration.txt'), 'w') as fsock:
-                fsock.write('# configuration for the mg7 post-processing tools\n'
-                            'mg5_path = %s\n' % MG5DIR)
-        except Exception as error:
-            logger.warning('could not write me5_configuration.txt: %s', error)
+        self.write_me5_configuration()
 
         # MadAnalysis5 default analysis cards, tailored to this process. This
         # must run *before* history.write() below: writing the proc_card cleans

--- a/madgraph/iolibs/export_fks.py
+++ b/madgraph/iolibs/export_fks.py
@@ -849,7 +849,7 @@ class ProcessExporterFortranFKS(loop_exporters.LoopProcessExporterFortranSA):
         if res != 0:
             logger.info('The value for lhapdf in the current configuration does not ' + \
                         'correspond to a valid executable.\nPlease set it correctly either in ' + \
-                        'input/mg5_configuration or with "set lhapdf /path/to/lhapdf-config" ' + \
+                        'input/mg7_configuration or with "set lhapdf /path/to/lhapdf-config" ' + \
                         'and regenrate the process. \nTo avoid regeneration, edit the ' + \
                         ('%s/Cards/amcatnlo_configuration.txt file.\n' % self.dir_path ) + \
                         'Note that you can still compile and run aMC@NLO with the built-in PDFs\n')

--- a/madgraph/iolibs/template_files/mg7/launch.py
+++ b/madgraph/iolibs/template_files/mg7/launch.py
@@ -2170,7 +2170,7 @@ def load_mg5_options() -> dict:
         'lhapdf': None, 'timeout': 0,
         'mg5amc_py8_interface_path': None, 'heptools_install_dir': None,
     }
-    config_files = [os.path.join(mg5dir, 'input', 'mg5_configuration.txt')]
+    config_files = [misc.install_config_file(mg5dir)]
     home = os.environ.get('HOME')
     if home:
         config_files.append(os.path.join(home, '.mg5', 'mg5_configuration.txt'))

--- a/madgraph/iolibs/template_files/mg7/launch.py
+++ b/madgraph/iolibs/template_files/mg7/launch.py
@@ -49,20 +49,6 @@ if not (_INSTALL_DIR / "madspace").is_dir():
 if str(_INSTALL_DIR) not in sys.path:
     sys.path.insert(0, str(_INSTALL_DIR))
 
-if "LHAPDF_DATA_PATH" in os.environ:
-    PDF_PATH = os.environ["LHAPDF_DATA_PATH"]
-else:
-    try:
-        import lhapdf
-        lhapdf.setVerbosity(0)
-        PDF_PATH = lhapdf.paths()[0]
-    except ImportError:
-        # Do not abort at import time: lhapdf is only needed when a PDF grid is
-        # actually loaded (see PdfGrid/AlphaSGrid below). Leave PDF_PATH unset
-        # so that code paths which do not require an external PDF still work;
-        # the missing-lhapdf error is raised lazily at the point of use.
-        PDF_PATH = None
-
 import madspace as ms
 from models.check_param_card import ParamCard
 from madgraph.various.banner import RunCardMG7
@@ -463,31 +449,59 @@ class MadgraphProcess:
             if key != "order_by"
         ]
 
-    def ensure_pdf_set(self, pdf_set: str) -> None:
-        """Make sure the requested LHAPDF set is available, downloading it if
-        needed. The destination follows LHAPDF_DATA_PATH, otherwise the data
-        dir of the configured lhapdf (e.g. lhapdf6 in HEPTools), otherwise a
-        local directory -- and PDF_PATH is pointed at it so madspace uses it.
-        Both LHAPDF_DATA_PATH and MADGRAPH_LHAPDF_CONFIG are provided by
-        do_launch; nothing is downloaded when the set is already present."""
-        global PDF_PATH
-        data_path = os.environ.get("LHAPDF_DATA_PATH") or PDF_PATH
-        if data_path and os.path.isdir(os.path.join(data_path, pdf_set)):
-            PDF_PATH = data_path
-            return
-        lhapdf_config = os.environ.get("MADGRAPH_LHAPDF_CONFIG")
-        if not lhapdf_config:
-            return  # can't download; the missing-PDF error is raised below
-        if not data_path:
-            data_path = os.path.join(os.getcwd(), "lhapdf_pdfsets")
+    def ensure_pdf_set(self, pdf_set: str) -> misc.LhapdfPaths:
+        """Make sure the requested LHAPDF set is available, downloading it into
+        the first writable PDF directory if needed, and return the (possibly
+        updated) LHAPDF resolution. Nothing is downloaded when the set is
+        already present."""
+        paths = lhapdf_paths()
+        if paths.find_set(pdf_set):
+            return paths
+        if not paths.config:
+            logger.debug("no usable lhapdf-config: cannot download %s", pdf_set)
+            return paths
+        if not paths.download_path:
+            logger.debug("no writable PDF directory: cannot download %s", pdf_set)
+            return paths
         try:
             from madgraph.interface.common_run_interface import CommonRunCmd
-            os.makedirs(data_path, exist_ok=True)
-            logger.info("PDF set %s not found; downloading into %s", pdf_set, data_path)
-            CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, data_path, pdf_set)
-            PDF_PATH = data_path
+            os.makedirs(paths.download_path, exist_ok=True)
+            logger.info("PDF set %s not found; downloading into %s",
+                        pdf_set, paths.download_path)
+            CommonRunCmd.install_lhapdf_pdfset_static(
+                paths.config, paths.download_path, pdf_set)
         except Exception as err:
             logger.warning("Could not download PDF set %s: %s", pdf_set, err)
+            return paths
+        global _LHAPDF
+        _LHAPDF = paths.with_data_path(paths.download_path)
+        return _LHAPDF
+
+    def _no_pdf_message(self, pdf_set: str) -> str:
+        """Explain a missing PDF set in terms of the settings that fix it."""
+        searched = os.pathsep.join(self.lhapdf.data_paths) or \
+            "(no PDF set directory could be located)"
+        if self.lhapdf.config:
+            found = "using lhapdf-config: %s" % self.lhapdf.config
+        else:
+            found = ("no usable lhapdf-config was found, so the set could not "
+                     "be downloaded automatically")
+        return (
+            "LHAPDF set %r, requested by [beam] pdf in Cards/run_card.toml, "
+            "was not found.\n"
+            "  searched: %s\n"
+            "  %s\n"
+            "Fix this in one of the following ways:\n"
+            "  * install LHAPDF for this MadGraph:  MG7> install lhapdf6\n"
+            "  * point MadGraph at an existing one:\n"
+            "        MG7> set lhapdf /path/to/lhapdf-config\n"
+            "        MG7> save options\n"
+            "  * or set it for this directory only, by adding\n"
+            "        lhapdf = /path/to/lhapdf-config\n"
+            "    to %s\n"
+            "  * or set $LHAPDF_DATA_PATH to a directory containing %r."
+            % (pdf_set, searched, found,
+               os.path.join("Cards", "me5_configuration.txt"), pdf_set))
 
     def init_beam(self) -> None:
         beam_args = self.run_card["beam"]
@@ -530,6 +544,8 @@ class MadgraphProcess:
                 fact_scale2=self.decaying_mass,
             )
             self.pdf_grid = None
+            self.lhapdf = None
+            self.pdf_dir = None
             self.alphas_grid = ms.AlphaSGrid(self.write_fixed_alphas_info())
             for context in self.contexts:
                 self.alphas_grid.initialize_globals(context)
@@ -537,11 +553,12 @@ class MadgraphProcess:
             return
 
         pdf_set = beam_args["pdf"]
-        self.ensure_pdf_set(pdf_set)
-        if PDF_PATH is None:
-            raise RuntimeError("Can't load lhapdf module. Please set LHAPDF_DATA_PATH manually")
-        self.pdf_grid = ms.PdfGrid(os.path.join(PDF_PATH, pdf_set, f"{pdf_set}_0000.dat"))
-        self.alphas_grid = ms.AlphaSGrid(os.path.join(PDF_PATH, pdf_set, f"{pdf_set}.info"))
+        self.lhapdf = self.ensure_pdf_set(pdf_set)
+        self.pdf_dir = self.lhapdf.find_set(pdf_set)
+        if self.pdf_dir is None:
+            raise RuntimeError(self._no_pdf_message(pdf_set))
+        self.pdf_grid = ms.PdfGrid(os.path.join(self.pdf_dir, pdf_set, f"{pdf_set}_0000.dat"))
+        self.alphas_grid = ms.AlphaSGrid(os.path.join(self.pdf_dir, pdf_set, f"{pdf_set}.info"))
         for context in self.contexts:
             self.pdf_grid.initialize_globals(context)
             self.alphas_grid.initialize_globals(context)
@@ -1062,10 +1079,10 @@ class MadgraphProcess:
     def _lhapdf_id(self):
         """Central LHAPDF id of the beam PDF set (read from its .info SetIndex),
         or -1 for a leptonic beam (no PDF)."""
-        if self.leptonic:
+        if self.leptonic or not self.pdf_dir:
             return -1
         pdf_set = self.run_card["beam"]["pdf"]
-        info = os.path.join(PDF_PATH or "", pdf_set, "%s.info" % pdf_set)
+        info = os.path.join(self.pdf_dir, pdf_set, "%s.info" % pdf_set)
         try:
             for line in open(info):
                 if line.strip().startswith("SetIndex:"):
@@ -2155,29 +2172,42 @@ class MadgraphSubprocess:
         )
 
 
+_ROOTED_OPTIONS = ('lhapdf', 'lhapdf_py3', 'lhapdf_py2', 'heptools_install_dir')
+
 def load_mg5_options() -> dict:
-    """Read the tool paths from the MG5aMC configuration so the launcher knows
-    which optional programs (Pythia8/Delphes/MadSpin/reweight/analysis) are
-    available.  Relative *_path entries are resolved against the MG5aMC root."""
+    """Read the tool paths from the MadGraph configuration, so the launcher
+    knows where LHAPDF and the optional programs (Pythia8/Delphes/MadSpin/
+    reweight/analysis) live.
+
+    Files are read least- to most-specific, each overriding the previous, which
+    is the same layering CommonRunCmd.set_configuration uses: the card inside
+    this process directory has the last word, then this installation, then the
+    per-user file. Relative values are resolved against the root of the file
+    they came from.
+    """
 
     import madgraph
     mg5dir = os.path.dirname(os.path.dirname(os.path.abspath(madgraph.__file__)))
+    me_dir = os.getcwd()
 
     options = {
         'pythia-pgs_path': None, 'pythia8_path': None, 'madanalysis_path': None,
         'madanalysis5_path': None, 'exrootanalysis_path': None, 'delphes_path': None,
         'rivet_path': None, 'contur_path': None, 'f2py_compiler': None,
-        'lhapdf': None, 'timeout': 0,
+        'lhapdf': None, 'lhapdf_py3': None, 'lhapdf_py2': None, 'timeout': 0,
         'mg5amc_py8_interface_path': None, 'heptools_install_dir': None,
     }
-    config_files = [misc.install_config_file(mg5dir)]
-    home = os.environ.get('HOME')
-    if home:
-        config_files.append(os.path.join(home, '.mg5', 'mg5_configuration.txt'))
-        config_files.append(os.path.join(
-            os.environ.get('XDG_CONFIG_HOME', os.path.join(home, '.config')),
-            'mg5_configuration.txt'))
-    for cfg in config_files:
+    config_files = []
+    if os.environ.get('MADGRAPH_BASE'):
+        config_files.append((os.path.join(os.environ['MADGRAPH_BASE'],
+                                          misc.CONFIG_NAME), mg5dir))
+    user_config = misc.user_config_file()
+    if user_config:
+        config_files.append((user_config, mg5dir))
+    config_files.append((misc.install_config_file(mg5dir), mg5dir))
+    config_files.append((os.path.join(me_dir, 'Cards', 'me5_configuration.txt'),
+                         me_dir))
+    for cfg, root in config_files:
         if not os.path.exists(cfg):
             continue
         with open(cfg) as fsock:
@@ -2188,11 +2218,35 @@ def load_mg5_options() -> dict:
                 name, value = (x.strip() for x in line.split('=', 1))
                 if name not in options or value in ('', 'None'):
                     continue
-                if name.endswith('_path') and value.startswith('.'):
-                    value = os.path.join(mg5dir, value)
+                if (name.endswith('_path') or name in _ROOTED_OPTIONS) and \
+                        not os.path.isabs(value) and \
+                        (os.sep in value or value.startswith('.')):
+                    value = os.path.normpath(os.path.join(root, value))
                 options[name] = value
     options['mg5_path'] = mg5dir  # enables MadSpin/reweight
     return options
+
+
+_LHAPDF = None
+
+def lhapdf_paths(refresh: bool = False) -> misc.LhapdfPaths:
+    """The LHAPDF installation this run should use, resolved once.
+
+    Uses the same helper as the 'launch' command, so driving a process
+    directory straight through bin/generate_events behaves identically to
+    launching it from MadGraph.
+    """
+
+    global _LHAPDF
+    if _LHAPDF is None or refresh:
+        _LHAPDF = misc.resolve_lhapdf(load_mg5_options())
+        # Export what we found: the real LHAPDF library, systematics and the
+        # MadSpin/reweight subprocesses read these from the environment.
+        if _LHAPDF.data_paths:
+            os.environ["LHAPDF_DATA_PATH"] = os.pathsep.join(_LHAPDF.data_paths)
+        if _LHAPDF.config:
+            os.environ["MADGRAPH_LHAPDF_CONFIG"] = _LHAPDF.config
+    return _LHAPDF
 
 
 def build_selector_cmd():
@@ -2623,19 +2677,9 @@ def _add_time_of_flight(lhe_path, threshold, param_card_path, log):
 
 
 def _lhapdf_config_path():
-    """Best-effort path to lhapdf-config so systematics can import the python
-    lhapdf module (required to compute PDF/scale variations)."""
-    cfg = os.environ.get("MADGRAPH_LHAPDF_CONFIG")
-    if cfg and os.path.exists(cfg):
-        return cfg
-    if PDF_PATH:
-        # PDF_PATH is <prefix>/share/LHAPDF -> <prefix>/bin/lhapdf-config
-        cand = os.path.join(os.path.dirname(os.path.dirname(PDF_PATH)),
-                            "bin", "lhapdf-config")
-        if os.path.exists(cand):
-            return cand
-    import shutil
-    return shutil.which("lhapdf-config")
+    """Path to lhapdf-config so systematics can import the python lhapdf
+    module (required to compute PDF/scale variations)."""
+    return lhapdf_paths().config
 
 
 def _run_systematics(lhe_path, cfg, log):

--- a/madgraph/loop/loop_exporters.py
+++ b/madgraph/loop/loop_exporters.py
@@ -2032,7 +2032,7 @@ class LoopProcessOptimizedExporterFortranSA(LoopProcessExporterFortranSA):
                 (not os.path.isfile(pjoin(libpath,libname))):
                     # WARNING ONLY appears when the libpath is a wrong specific path.
                     logger.warning("The %s reduction library could not be found"%tir_name\
-                                   +" with PATH:%s specified in mg5_configuration.txt."%libpath\
+                                   +" with PATH:%s specified in mg7_configuration.txt."%libpath\
                                    +" It will not be available.")
                 self.tir_available_dict[tir_name]=False
                 return ""
@@ -2056,7 +2056,7 @@ class LoopProcessOptimizedExporterFortranSA(LoopProcessExporterFortranSA):
             if (not isinstance(libpath,str)) or (not os.path.exists(libpath)):
                 # WARNING ONLY appears when the libpath is a wrong specific path.
                 logger.warning("The %s reduction library could not be found"%tir_name\
-                                   +" with PATH:%s specified in mg5_configuration.txt."%libpath\
+                                   +" with PATH:%s specified in mg7_configuration.txt."%libpath\
                                    +" It will not be available.")
                 self.tir_available_dict[tir_name]=False
                 return ""

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -63,6 +63,40 @@ def install_config_file(root):
 
     return pjoin(root, 'input', CONFIG_NAME)
 
+def user_config_dir(create=False):
+    """MadGraph7's per-user configuration directory.
+
+    MG5aMC's ~/.mg5 is deliberately never consulted: a config file shared
+    between installations is what makes one of them write absolute paths into
+    another one's HEPTools folder. Returns None without HOME or XDG_CONFIG_HOME.
+    """
+
+    xdg = os.environ.get('XDG_CONFIG_HOME')
+    if xdg:
+        path = pjoin(xdg, 'mg7')
+    elif os.environ.get('HOME'):
+        path = pjoin(os.environ['HOME'], '.mg7')
+    else:
+        return None
+    if create:
+        try:
+            os.makedirs(path, exist_ok=True)
+        except OSError as error:
+            logger.warning('could not create %s: %s', path, error)
+            return None
+    return path
+
+def user_config_file(create=False):
+    """MadGraph7's per-user configuration file, or None if it has no home."""
+
+    config_dir = user_config_dir(create=create)
+    return pjoin(config_dir, CONFIG_NAME) if config_dir else None
+
+def mg_root():
+    """The root of this MadGraph installation, deduced from this file."""
+
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 #===============================================================================
 # parse_info_str
 #===============================================================================
@@ -2395,6 +2429,148 @@ def from_plugin_import(plugin_path, target_type, keyname=None, warning=False,
     
     
     
+
+#===============================================================================
+# LHAPDF locations
+#===============================================================================
+class LhapdfPaths(collections.namedtuple('LhapdfPaths',
+                                    ['config', 'data_paths', 'download_path'])):
+    """Where LHAPDF lives for one run: the lhapdf-config executable, the
+    directories to search for PDF sets, and the one a missing set may be
+    downloaded into. Any field may be None or empty."""
+
+    def find_set(self, pdf_set):
+        """The first data path holding <pdf_set>/, or None."""
+
+        for base in self.data_paths:
+            if os.path.isdir(pjoin(base, pdf_set)):
+                return base
+        return None
+
+    def with_data_path(self, path):
+        """A copy with *path* first in the search list (used after a download)."""
+
+        return self._replace(
+            data_paths=[path] + [p for p in self.data_paths if p != path])
+
+
+def _tool_executable(value, root):
+    """Turn a configuration value into a usable executable path, or None.
+
+    Accepts an absolute path, a path relative to the MadGraph root
+    ('./HEPTools/...'), and a bare program name looked up on PATH
+    ('lhapdf-config', the shipped default). A trailing '--python=X.Y' is a
+    filter for the 'set' command, not part of the path, so it is dropped.
+    """
+
+    if not value:
+        return None
+    exe = str(value).split()[0].strip('"\'')
+    if exe.lower() in ('none', 'auto'):
+        return None
+    if not os.path.isabs(exe) and (os.sep in exe or exe.startswith('.')):
+        return which(os.path.normpath(pjoin(root, exe))) or which(exe)
+    return which(exe)
+
+
+_lhapdf_datadirs_cache = {}
+def _lhapdf_datadirs(exe):
+    """The PDF-set directories a lhapdf-config reports, in its own order.
+    '--datadir' is the LHAPDF 6 spelling, '--pdfsets-path' the LHAPDF 5 one."""
+
+    if exe not in _lhapdf_datadirs_cache:
+        dirs = []
+        for flag in ('--datadir', '--pdfsets-path'):
+            try:
+                out = subprocess.check_output([exe, flag],
+                                              stderr=subprocess.DEVNULL)
+            except (OSError, subprocess.CalledProcessError):
+                continue
+            out = out.decode(errors='ignore').strip()
+            if out:
+                dirs = [p for p in out.split(os.pathsep) if p]
+                break
+        _lhapdf_datadirs_cache[exe] = dirs
+    return _lhapdf_datadirs_cache[exe]
+
+
+def _writable_dir(path):
+    """True if *path* is a writable directory or can be created as one."""
+
+    probe = path
+    while probe and not os.path.isdir(probe):
+        parent = os.path.dirname(probe)
+        if parent == probe:
+            return False
+        probe = parent
+    return os.access(probe, os.W_OK)
+
+
+def resolve_lhapdf(options=None, root=None, use_env=True, create=False):
+    """Locate LHAPDF for a run and return a LhapdfPaths.
+
+    Both the 'launch' command and a standalone bin/generate_events resolve
+    through here, so they cannot disagree about where the PDF sets live.
+    Never raises: a missing or broken LHAPDF just yields empty fields.
+
+    ``options``  an MG5aMC option mapping; 'lhapdf', 'lhapdf_py3',
+                 'lhapdf_py2', 'heptools_install_dir' and 'mg5_path' are read
+    ``root``     what a relative option value is resolved against
+    ``use_env``  honour $MADGRAPH_LHAPDF_CONFIG and $LHAPDF_DATA_PATH
+    ``create``   create the download directory (only needed before a download)
+    """
+
+    options = options or {}
+    root = root or options.get('mg5_path') or mg_root()
+
+    candidates = []
+    if use_env:
+        candidates.append(os.environ.get('MADGRAPH_LHAPDF_CONFIG'))
+    candidates += [options.get(key)
+                   for key in ('lhapdf', 'lhapdf_py3', 'lhapdf_py2')]
+    candidates.append('lhapdf-config')
+
+    # Accept the first candidate that actually answers a data-directory query;
+    # remember the first one that merely exists in case none of them answers.
+    config, data_dirs, fallback, seen = None, [], None, set()
+    for value in candidates:
+        exe = _tool_executable(value, root)
+        if not exe or exe in seen:
+            continue
+        seen.add(exe)
+        fallback = fallback or exe
+        dirs = _lhapdf_datadirs(exe)
+        if dirs:
+            config, data_dirs = exe, dirs
+            break
+    config = config or fallback
+
+    heptools = options.get('heptools_install_dir') or pjoin('.', 'HEPTools')
+    if not os.path.isabs(heptools):
+        heptools = pjoin(root, heptools)
+
+    search = []
+    if use_env and os.environ.get('LHAPDF_DATA_PATH'):
+        search += os.environ['LHAPDF_DATA_PATH'].split(os.pathsep)
+    search += data_dirs
+    search.append(pjoin(heptools, 'lhapdf_pdfsets'))
+    search.append(pjoin(root, 'lhapdf_pdfsets'))
+    search = [os.path.abspath(p) for p in search]
+
+    data_paths = []
+    for path in search:
+        if path not in data_paths and os.path.isdir(path):
+            data_paths.append(path)
+
+    download_path = next((p for p in search if _writable_dir(p)), None)
+    if download_path and create:
+        try:
+            os.makedirs(download_path, exist_ok=True)
+        except OSError:
+            download_path = None
+
+    return LhapdfPaths(config, data_paths, download_path)
+
 
 python_lhapdf=None
 def import_python_lhapdf(lhapdfconfig):

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -51,7 +51,18 @@ logger = logging.getLogger('cmdprint.ext_program')
 logger_stderr = logging.getLogger('madevent.misc')
 pjoin = os.path.join
 misc = locals
-   
+
+#===============================================================================
+# configuration file locations
+#===============================================================================
+CONFIG_NAME = 'mg7_configuration.txt'
+CONFIG_TEMPLATE_NAME = '.mg7_configuration_default.txt'
+
+def install_config_file(root):
+    """The configuration file of the MadGraph installation rooted at *root*."""
+
+    return pjoin(root, 'input', CONFIG_NAME)
+
 #===============================================================================
 # parse_info_str
 #===============================================================================
@@ -1508,11 +1519,11 @@ class open_file(object):
         for p in possibility:
             if which(p):
                 logger.info('Using default %s \"%s\". ' % (program, p) + \
-                             'Set another one in ./input/mg5_configuration.txt')
+                             'Set another one in ./input/mg7_configuration.txt')
                 return p
         
         logger.info('No valid %s found. ' % program + \
-                                   'Please set in ./input/mg5_configuration.txt')
+                                   'Please set in ./input/mg7_configuration.txt')
         return None
         
         
@@ -1534,7 +1545,7 @@ class open_file(object):
                 _thread.start_new_thread(subprocess.call,(arguments,))
         else:
             logger.warning('Not able to open file %s since no program configured.' % file_path + \
-                                'Please set one in ./input/mg5_configuration.txt')
+                                'Please set one in ./input/mg7_configuration.txt')
 
     def open_mac_program(self, program, file_path):
         """ open a text with the text editor """

--- a/madmatrix/contrib/acceptance_tests/create_acceptance_from_file.py
+++ b/madmatrix/contrib/acceptance_tests/create_acceptance_from_file.py
@@ -104,7 +104,7 @@ template_one_cicd="""
         run: |
             cd $GITHUB_WORKSPACE
             cd MG5aMC/mg5amcnlo/
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+            cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
             cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
             if [ -f tests/cudacpp_acceptance_tests ]; then echo 'ERROR! tests/cudacpp_acceptance_tests already exists'; exit 1; fi # should never happen
             ln -sf ../../MG5aMC_PLUGIN/CUDACPP_OUTPUT/acceptance_tests tests/cudacpp_acceptance_tests # workaround for 'relative position not supported'

--- a/madmatrix/contrib/ci/workflows/madgraph_launch_test.yml
+++ b/madmatrix/contrib/ci/workflows/madgraph_launch_test.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE
             cd MG5aMC/mg5amcnlo/
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+            cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
             cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
             if [ -f tests/cudacpp_acceptance_tests ]; then echo 'ERROR! tests/cudacpp_acceptance_tests already exists'; exit 1; fi # should never happen
             ln -sf ../../MG5aMC_PLUGIN/CUDACPP_OUTPUT/acceptance_tests tests/cudacpp_acceptance_tests # workaround for 'relative position not supported'
@@ -73,7 +73,7 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE
             cd MG5aMC/mg5amcnlo/
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+            cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
             cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
             if [ -f tests/cudacpp_acceptance_tests ]; then echo 'ERROR! tests/cudacpp_acceptance_tests already exists'; exit 1; fi # should never happen
             ln -sf ../../MG5aMC_PLUGIN/CUDACPP_OUTPUT/acceptance_tests tests/cudacpp_acceptance_tests # workaround for 'relative position not supported'
@@ -96,7 +96,7 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE
             cd MG5aMC/mg5amcnlo/
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+            cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
             cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
             if [ -f tests/cudacpp_acceptance_tests ]; then echo 'ERROR! tests/cudacpp_acceptance_tests already exists'; exit 1; fi # should never happen
             ln -sf ../../MG5aMC_PLUGIN/CUDACPP_OUTPUT/acceptance_tests tests/cudacpp_acceptance_tests # workaround for 'relative position not supported'
@@ -119,7 +119,7 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE
             cd MG5aMC/mg5amcnlo/
-            cp input/.mg5_configuration_default.txt input/mg5_configuration.txt
+            cp input/.mg7_configuration_default.txt input/mg7_configuration.txt
             cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
             if [ -f tests/cudacpp_acceptance_tests ]; then echo 'ERROR! tests/cudacpp_acceptance_tests already exists'; exit 1; fi # should never happen
             ln -sf ../../MG5aMC_PLUGIN/CUDACPP_OUTPUT/acceptance_tests tests/cudacpp_acceptance_tests # workaround for 'relative position not supported'

--- a/madmatrix/contrib/codegen/generateAndCompare.sh
+++ b/madmatrix/contrib/codegen/generateAndCompare.sh
@@ -518,7 +518,7 @@ function cleanup_MG5AMC_HOME()
   # Remove MG5aMC fragments from previous runs
   rm -f ${MG5AMC_HOME}/py.py
   rm -f ${MG5AMC_HOME}/Template/LO/Source/make_opts
-  rm -f ${MG5AMC_HOME}/input/mg5_configuration.txt
+  rm -f ${MG5AMC_HOME}/input/mg7_configuration.txt
   rm -f ${MG5AMC_HOME}/models/sm/py3_model.pkl
   # Remove any *~ files in MG5AMC_HOME
   rm -rf $(find ${MG5AMC_HOME} -name '*~')

--- a/madspace/install.py
+++ b/madspace/install.py
@@ -298,16 +298,17 @@ def _cmake_version_ok(path, minimum=CMAKE_MIN_VERSION) -> bool:
 
 
 def _heptools_dir_from_config() -> str | None:
-    """Read heptools_install_dir from the MG5 configuration files (same
-    locations MG5 itself uses), so the value is available even when the
-    installer is run directly rather than launched from MG5."""
-    home = os.environ.get("HOME") or os.path.expanduser("~")
-    candidates = []
-    if home:
-        candidates.append(os.path.join(home, ".mg5", "mg5_configuration.txt"))
-        xdg = os.environ.get("XDG_CONFIG_HOME", os.path.join(home, ".config"))
-        candidates.append(os.path.join(xdg, "mg5_configuration.txt"))
-    candidates.append(str(SCRIPT_DIR.parent / "input" / "mg7_configuration.txt"))
+    """Read heptools_install_dir from the MadGraph configuration files (same
+    locations MadGraph itself uses -- see misc.user_config_file), so the value
+    is available even when the installer is run directly rather than launched
+    from MadGraph. This installation's own config wins over the per-user one."""
+    candidates = [str(SCRIPT_DIR.parent / "input" / "mg7_configuration.txt")]
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    home = os.environ.get("HOME")
+    if xdg:
+        candidates.append(os.path.join(xdg, "mg7", "mg7_configuration.txt"))
+    elif home:
+        candidates.append(os.path.join(home, ".mg7", "mg7_configuration.txt"))
     for cfg in candidates:
         try:
             with open(cfg) as f:

--- a/madspace/install.py
+++ b/madspace/install.py
@@ -307,7 +307,7 @@ def _heptools_dir_from_config() -> str | None:
         candidates.append(os.path.join(home, ".mg5", "mg5_configuration.txt"))
         xdg = os.environ.get("XDG_CONFIG_HOME", os.path.join(home, ".config"))
         candidates.append(os.path.join(xdg, "mg5_configuration.txt"))
-    candidates.append(str(SCRIPT_DIR.parent / "input" / "mg5_configuration.txt"))
+    candidates.append(str(SCRIPT_DIR.parent / "input" / "mg7_configuration.txt"))
     for cfg in candidates:
         try:
             with open(cfg) as f:

--- a/tests/acceptance_tests/test_check_xsec_processes_mg7.py
+++ b/tests/acceptance_tests/test_check_xsec_processes_mg7.py
@@ -71,6 +71,7 @@ import traceback
 import unittest
 
 import madgraph.interface.master_interface as MGCmd
+import madgraph.various.misc as misc
 
 pjoin = os.path.join
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -80,7 +81,7 @@ _REFERENCE = pjoin(_HERE, 'check_xsec_processes_reference.json')
 # into every run_card.toml (see _edit_run_card) instead of relying on the
 # template default, so that changing the default PDF of the mg7 run_card does
 # not silently invalidate all ~40 reference values. It is also the set
-# _mg7_datadir_or_skip requires to be installed.
+# _require_mg7_runtime requires to be installed.
 _REFERENCE_PDF = 'NNPDF23_lo_as_0130_qed'
 
 # Environment-tunable knobs (see module docstring). Kept as module globals so
@@ -112,10 +113,13 @@ def _tail(path, n=60):
         return ''
 
 
-def _mg7_datadir_or_skip(test):
-    """Return an LHAPDF data dir that contains the ``_REFERENCE_PDF`` set, or
-    ``skipTest`` (on *test*) when the mg7 runtime stack (madspace + LHAPDF +
-    the PDF set the references were generated with) is unavailable."""
+def _require_mg7_runtime(test):
+    """``skipTest`` (on *test*) when the mg7 runtime stack -- madspace, LHAPDF
+    and the PDF set the references were generated with -- is unavailable.
+
+    Only a skip gate: the run itself must locate LHAPDF from the configuration
+    the way a user's ``bin/generate_events`` does, with no environment help.
+    """
     try:
         import madspace
         has_mg7 = hasattr(madspace, 'ChannelEventGenerator')
@@ -124,21 +128,9 @@ def _mg7_datadir_or_skip(test):
     if not has_mg7:
         test.skipTest('mg7 runtime stack (madspace) unavailable')
 
-    candidates = []
-    if os.environ.get('LHAPDF_DATA_PATH'):
-        candidates.extend(os.environ['LHAPDF_DATA_PATH'].split(os.pathsep))
-    try:
-        out = subprocess.check_output(['lhapdf-config', '--datadir'],
-                                      stderr=subprocess.DEVNULL).decode().strip()
-        if out:
-            candidates.append(out)
-    except Exception:
-        pass
-    for d in candidates:
-        if d and os.path.isdir(d) and glob.glob(pjoin(d, '%s*' % _REFERENCE_PDF)):
-            return d
-    test.skipTest('%s LHAPDF data not found (set $LHAPDF_DATA_PATH)'
-                  % _REFERENCE_PDF)
+    if not misc.resolve_lhapdf().find_set(_REFERENCE_PDF):
+        test.skipTest('%s LHAPDF data not found (set the lhapdf option or '
+                      '$LHAPDF_DATA_PATH)' % _REFERENCE_PDF)
 
 
 def _edit_run_card(toml_path, events, disable_jet_cuts):
@@ -151,7 +143,7 @@ def _edit_run_card(toml_path, events, disable_jet_cuts):
     pins the configuration back to the one the references were generated with.
     They are load-bearing: drop them and every reference value below goes
     stale. The PDF pin in particular decouples the references from the
-    template default -- ``_mg7_datadir_or_skip`` already guarantees the pinned
+    template default -- ``_require_mg7_runtime`` already guarantees the pinned
     set is the one present on disk."""
     t = open(toml_path).read()
     t = t.replace('fixed_ren_scale = false', 'fixed_ren_scale = true')
@@ -226,7 +218,7 @@ class CheckXsecProcessesMG7Test(unittest.TestCase):
             raise
 
     def _run_and_check(self, entry, defines, section):
-        datadir = _mg7_datadir_or_skip(self)
+        _require_mg7_runtime(self)
 
         run_dir = pjoin(self.path, entry['id'])
         mg = MGCmd.MasterCmd()
@@ -240,13 +232,11 @@ class CheckXsecProcessesMG7Test(unittest.TestCase):
         toml = pjoin(run_dir, 'Cards', 'run_card.toml')
         _edit_run_card(toml, _EVENTS, entry.get('disable_jet_cuts', False))
 
-        env = dict(os.environ)
-        env['LHAPDF_DATA_PATH'] = datadir
         log = pjoin(run_dir, 'mg7_gen.log')
         with open(log, 'w') as logfh:
             ret = subprocess.call(
                 [sys.executable, pjoin(run_dir, 'bin', 'generate_events'), '-f'],
-                cwd=run_dir, env=env, stdout=logfh, stderr=subprocess.STDOUT)
+                cwd=run_dir, stdout=logfh, stderr=subprocess.STDOUT)
         if ret != 0:
             message = ('mg7 generate_events failed (exit %d)\n\n%s'
                        % (ret, _tail(log)))

--- a/tests/acceptance_tests/test_cmd.py
+++ b/tests/acceptance_tests/test_cmd.py
@@ -163,7 +163,7 @@ class TestCmdShell1(unittest.TestCase):
         """check that configuration file is at default value"""
         self.maxDiff=None
         self.cmd.options = {} #reset to None
-        config = self.cmd.set_configuration(MG5DIR+'/input/.mg5_configuration_default.txt', final=False)
+        config = self.cmd.set_configuration(MG5DIR+'/input/.mg7_configuration_default.txt', final=False)
         config =dict(config)
         del config['stdout_level']
 #        for key in config.keys():

--- a/tests/acceptance_tests/test_cmd_madevent.py
+++ b/tests/acceptance_tests/test_cmd_madevent.py
@@ -3664,7 +3664,7 @@ set draw_rivet_plots True
         """Return the configured delphes_path from the MG5 configuration, or
         None when Delphes is not configured (used to skip the parallel-Delphes
         acceptance test on setups without Delphes/ROOT)."""
-        config = pjoin(MG5DIR, 'input', 'mg5_configuration.txt')
+        config = pjoin(MG5DIR, 'input', 'mg7_configuration.txt')
         if not os.path.exists(config):
             return None
         for line in open(config):

--- a/tests/parallel_tests/madevent_comparator.py
+++ b/tests/parallel_tests/madevent_comparator.py
@@ -581,6 +581,11 @@ class MG5Runner(MadEventRunner):
         return output
 
 
+# Default PDF of the mg7 run_card.toml, pinned into the MG5 side too (see
+# _patch_run_card_toml / the 'set lhaid' below); both runners need it on disk.
+_MG7_REFERENCE_PDF = 'NNPDF40MC_lo_as_01180'
+
+
 class MG7Runner(MG5Runner):
     """Runner object for the MadGraph7 default ('mg7') exporter.
 
@@ -602,31 +607,13 @@ class MG7Runner(MG5Runner):
 
     @staticmethod
     def resolve_lhapdf_data_path(lhapdf_config=None):
-        """Return a usable LHAPDF data dir, or None.
+        """A PDF-set directory holding the reference set, or None.
 
-        Tries, in order: the ``LHAPDF_DATA_PATH`` env var, the explicitly given
-        ``lhapdf-config`` (e.g. the one MG5 is configured with), and finally a
-        ``lhapdf-config`` found on PATH. A candidate is only accepted if the
-        directory exists and is non-empty (the PATH lhapdf-config sometimes
-        points at an empty share dir).
+        Only used to decide whether this runner can run: bin/generate_events
+        resolves LHAPDF from the configuration itself (see misc.resolve_lhapdf).
         """
-        if os.environ.get('LHAPDF_DATA_PATH'):
-            return os.environ['LHAPDF_DATA_PATH']
-        candidates = []
-        if lhapdf_config and lhapdf_config not in ('lhapdf-config', None):
-            candidates.append(lhapdf_config)
-        on_path = misc.which('lhapdf-config')
-        if on_path:
-            candidates.append(on_path)
-        for lc in candidates:
-            try:
-                datadir = subprocess.check_output(
-                    [lc, '--datadir']).decode().strip()
-            except Exception:
-                continue
-            if datadir and os.path.isdir(datadir) and os.listdir(datadir):
-                return datadir
-        return None
+        options = {'lhapdf': lhapdf_config} if lhapdf_config else {}
+        return misc.resolve_lhapdf(options).find_set(_MG7_REFERENCE_PDF)
 
     @classmethod
     def is_available(cls):
@@ -684,18 +671,9 @@ class MG7Runner(MG5Runner):
         # but ships with fixed_(ren|fact)_scale=true, so flip those off.
         self._patch_run_card_toml(os.path.join(dir_name, 'Cards', 'run_card.toml'))
 
-        # Drive the mg7 survey directly (bin/generate_events), with a resolved
-        # LHAPDF data path so hadronic PDFs load without the python lhapdf
-        # module. Prefer the lhapdf-config MG5 is configured with.
-        env = dict(os.environ)
-        mg5_lhapdf = None
-        try:
-            mg5_lhapdf = cmd.options.get('lhapdf')
-        except Exception:
-            mg5_lhapdf = None
-        datadir = self.resolve_lhapdf_data_path(mg5_lhapdf)
-        if datadir:
-            env['LHAPDF_DATA_PATH'] = datadir
+        # Drive the mg7 survey directly (bin/generate_events). It resolves
+        # LHAPDF from Cards/me5_configuration.txt on its own, so no LHAPDF
+        # environment is handed down here.
         # Run the full pipeline (survey + integration): the aggregated,
         # converged cross-section ends up in process.mean of info.json. The
         # survey-only estimate is far too biased to use here.
@@ -703,7 +681,7 @@ class MG7Runner(MG5Runner):
         log_path = os.path.join(dir_name, 'mg7_survey.log')
         with open(log_path, 'w') as logf:
             ret = subprocess.call([sys.executable, gen, '-f'],
-                                  cwd=dir_name, env=env,
+                                  cwd=dir_name,
                                   stdout=logf, stderr=subprocess.STDOUT)
         if ret != 0:
             raise self.MERunnerException(

--- a/tests/unit_tests/interface/test_cmd.py
+++ b/tests/unit_tests/interface/test_cmd.py
@@ -28,6 +28,9 @@ import tests.parallel_tests.test_aloha as test_aloha
 
 import tempfile
 pjoin = os.path.join
+MG5DIR = madgraph.MG5DIR
+
+
 class TestValidCmd(unittest.TestCase):
     """ check if the ValidCmd works correctly """
     
@@ -360,6 +363,31 @@ class TestExtendedCmd(unittest.TestCase):
         self.assertEqual(main.child, None)
         #ret = main.do_quit('')
         #self.assertEqual(ret, True)        
+
+class TestHepToolsInstallTarget(unittest.TestCase):
+    """'install <tool>' must record its paths in this installation's own
+    configuration, unless HEPTools genuinely lives somewhere shared. Writing
+    installation-specific absolute paths into the per-user file is what made
+    one MadGraph download PDF sets into another one's HEPTools (issue #94)."""
+
+    def target(self, heptools_install_dir):
+        import madgraph.interface.madgraph_interface as mg_cmd
+        return mg_cmd.MadGraphCmd.heptools_install_target(heptools_install_dir)
+
+    def test_default_stays_in_the_installation(self):
+        """The default './HEPTools' is inside MG5DIR, so its paths are private
+        to this installation -- this is the branch that used to be dead."""
+        for value in ['./HEPTools', None, '', os.path.join(MG5DIR, 'HEPTools')]:
+            prefix, config_file = self.target(value)
+            self.assertEqual(prefix, os.path.join(MG5DIR, 'HEPTools'))
+            self.assertEqual(config_file, '')
+
+    def test_external_prefix_uses_the_user_config(self):
+        prefix, config_file = self.target(tempfile.gettempdir())
+        self.assertEqual(prefix, os.path.realpath(tempfile.gettempdir()))
+        self.assertEqual(config_file, misc.user_config_file())
+        self.assertNotIn('.mg5', config_file)
+
 
 class TestMadSpinFCT_in_interface(unittest.TestCase):
     """ check if the ValidCmd works correctly """

--- a/tests/unit_tests/various/test_cmd.py
+++ b/tests/unit_tests/various/test_cmd.py
@@ -63,12 +63,12 @@ class TestInstall(unittest.TestCase):
         #perform this test only for .bzr repository
         if not os.path.exists(pjoin(MG5DIR, '.bzr')):
             return
-        if not os.path.exists(pjoin(MG5DIR, 'input','mg5_configuration.txt')):
+        if not os.path.exists(pjoin(MG5DIR, 'input','mg7_configuration.txt')):
             return        
         
-        text1 = open(pjoin(MG5DIR,'input','.mg5_configuration_default.txt')).read()
-        text2 = open(pjoin(MG5DIR,'input','mg5_configuration.txt')).read()
-        warning = """WARNING: Your file mg5_configuration.txt and .mg5_configuration_default.txt
+        text1 = open(pjoin(MG5DIR,'input','.mg7_configuration_default.txt')).read()
+        text2 = open(pjoin(MG5DIR,'input','mg7_configuration.txt')).read()
+        warning = """WARNING: Your file mg7_configuration.txt and .mg7_configuration_default.txt
         are different. This probably fine but please check it before any release."""
         if text1 != text2:
             print(warning)

--- a/tests/unit_tests/various/test_lhapdf_resolve.py
+++ b/tests/unit_tests/various/test_lhapdf_resolve.py
@@ -1,0 +1,241 @@
+################################################################################
+#
+# Copyright (c) 2009 The MadGraph5_aMC@NLO Development team and Contributors
+#
+# This file is a part of the MadGraph5_aMC@NLO project, an application which
+# automatically generates Feynman diagrams and matrix elements for arbitrary
+# high-energy processes in the Standard Model and beyond.
+#
+# It is subject to the MadGraph5_aMC@NLO license which should accompany this
+# distribution.
+#
+# For more information, visit madgraph.phys.ucl.ac.be and amcatnlo.web.cern.ch
+#
+################################################################################
+"""Test the configuration-file locations and the LHAPDF path resolution."""
+
+from __future__ import absolute_import
+import os
+import shutil
+import stat
+import tempfile
+import unittest
+
+import madgraph.various.misc as misc
+
+pjoin = os.path.join
+
+
+class TestUserConfigLocation(unittest.TestCase):
+    """MadGraph7 must keep its per-user configuration to itself: a file shared
+    with an MG5aMC installation is what issue #94 is about."""
+
+    def setUp(self):
+        self.saved = {key: os.environ.get(key)
+                      for key in ('HOME', 'XDG_CONFIG_HOME')}
+
+    def tearDown(self):
+        for key, value in self.saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_xdg_config_home_wins(self):
+        os.environ['HOME'] = '/home/someone'
+        os.environ['XDG_CONFIG_HOME'] = '/xdg'
+        self.assertEqual(misc.user_config_dir(), pjoin('/xdg', 'mg7'))
+        self.assertEqual(misc.user_config_file(),
+                         pjoin('/xdg', 'mg7', 'mg7_configuration.txt'))
+
+    def test_home_fallback(self):
+        os.environ['HOME'] = '/home/someone'
+        os.environ.pop('XDG_CONFIG_HOME', None)
+        self.assertEqual(misc.user_config_dir(), pjoin('/home/someone', '.mg7'))
+        self.assertEqual(misc.user_config_file(),
+                         pjoin('/home/someone', '.mg7', 'mg7_configuration.txt'))
+
+    def test_never_mg5(self):
+        """No location MadGraph7 uses may live under MG5aMC's ~/.mg5."""
+        os.environ['HOME'] = '/home/someone'
+        os.environ.pop('XDG_CONFIG_HOME', None)
+        self.assertNotIn('.mg5', misc.user_config_file())
+        self.assertNotIn('mg5_configuration', misc.user_config_file())
+        self.assertNotIn('mg5_configuration', misc.install_config_file('/mg'))
+
+    def test_no_home(self):
+        os.environ.pop('HOME', None)
+        os.environ.pop('XDG_CONFIG_HOME', None)
+        self.assertIsNone(misc.user_config_dir())
+        self.assertIsNone(misc.user_config_file())
+
+
+class TestResolveLhapdf(unittest.TestCase):
+    """misc.resolve_lhapdf is the single place both 'launch' and a standalone
+    bin/generate_events use to locate LHAPDF, so it carries all the awkward
+    cases: relative option values, a '--python=' filter, a path list, and a
+    broken or absent lhapdf-config."""
+
+    # what a lhapdf-config answers, keyed by the flag it supports
+    SCRIPT = ('#!/bin/sh\n'
+              'case "$1" in\n'
+              '  %(flag)s) echo "%(datadir)s" ;;\n'
+              '  --version) echo 6.5.4 ;;\n'
+              '  *) exit 1 ;;\n'
+              'esac\n')
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='mg7_lhapdf_test')
+        self.root = pjoin(self.tmpdir, 'MG')
+        self.datadir = pjoin(self.tmpdir, 'lha6', 'share', 'LHAPDF')
+        os.makedirs(pjoin(self.datadir, 'MYSET'))
+        os.makedirs(pjoin(self.root, 'input'))
+        self.exe = self.write_config('lha6', self.datadir)
+        self.saved = {key: os.environ.get(key)
+                      for key in ('LHAPDF_DATA_PATH', 'MADGRAPH_LHAPDF_CONFIG',
+                                  'PATH', 'HOME', 'XDG_CONFIG_HOME')}
+        os.environ.pop('LHAPDF_DATA_PATH', None)
+        os.environ.pop('MADGRAPH_LHAPDF_CONFIG', None)
+        # the resolver caches per executable path, and every test writes its
+        # own, but a stale entry from another test module would still leak in
+        misc._lhapdf_datadirs_cache.clear()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        for key, value in self.saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        misc._lhapdf_datadirs_cache.clear()
+
+    def write_config(self, name, datadir, flag='--datadir'):
+        """Write a fake lhapdf-config under <tmpdir>/<name>/bin and return it."""
+        bindir = pjoin(self.tmpdir, name, 'bin')
+        if not os.path.isdir(bindir):
+            os.makedirs(bindir)
+        exe = pjoin(bindir, 'lhapdf-config')
+        with open(exe, 'w') as fsock:
+            fsock.write(self.SCRIPT % {'flag': flag, 'datadir': datadir})
+        os.chmod(exe, os.stat(exe).st_mode | stat.S_IEXEC)
+        return exe
+
+    def resolve(self, **options):
+        return misc.resolve_lhapdf(options, root=self.root)
+
+    def test_absolute_lhapdf(self):
+        paths = self.resolve(lhapdf=self.exe)
+        self.assertEqual(paths.config, self.exe)
+        self.assertEqual(paths.data_paths, [self.datadir])
+        self.assertEqual(paths.find_set('MYSET'), self.datadir)
+        self.assertIsNone(paths.find_set('OTHERSET'))
+
+    def test_python_filter_is_not_part_of_the_path(self):
+        paths = self.resolve(lhapdf='%s --python=3.11' % self.exe)
+        self.assertEqual(paths.config, self.exe)
+        self.assertEqual(paths.data_paths, [self.datadir])
+
+    def test_relative_value_roots_at_the_install(self):
+        """'./HEPTools/...' means relative to the MadGraph root, not to cwd."""
+        exe = self.write_config(pjoin('MG', 'HEPTools', 'lhapdf6'), self.datadir)
+        relative = os.path.join('.', 'HEPTools', 'lhapdf6', 'bin', 'lhapdf-config')
+        paths = self.resolve(lhapdf=relative)
+        self.assertEqual(paths.config, exe)
+        self.assertEqual(paths.data_paths, [self.datadir])
+
+    def test_bare_name_from_path(self):
+        os.environ['PATH'] = os.path.dirname(self.exe)
+        paths = self.resolve(lhapdf='lhapdf-config')
+        self.assertEqual(paths.config, self.exe)
+
+    def test_missing_executable_does_not_raise(self):
+        os.environ['PATH'] = pjoin(self.tmpdir, 'empty')
+        paths = self.resolve(lhapdf=pjoin(self.tmpdir, 'nope', 'lhapdf-config'))
+        self.assertIsNone(paths.config)
+        self.assertEqual(paths.data_paths, [])
+        self.assertEqual(paths.download_path,
+                         pjoin(self.root, 'HEPTools', 'lhapdf_pdfsets'))
+
+    def test_no_lhapdf_at_all(self):
+        os.environ['PATH'] = pjoin(self.tmpdir, 'empty')
+        paths = self.resolve()
+        self.assertIsNone(paths.config)
+        self.assertEqual(paths.data_paths, [])
+
+    def test_lhapdf5_pdfsets_path(self):
+        exe = self.write_config('lha5', self.datadir, flag='--pdfsets-path')
+        paths = self.resolve(lhapdf=exe)
+        self.assertEqual(paths.config, exe)
+        self.assertEqual(paths.data_paths, [self.datadir])
+
+    def test_datadir_list_is_split(self):
+        """A path list must be split; joining it into a filename is the bug
+        that made a multi-entry LHAPDF_DATA_PATH silently unusable."""
+        other = pjoin(self.tmpdir, 'other')
+        os.makedirs(other)
+        exe = self.write_config('lhamulti',
+                                os.pathsep.join([other, self.datadir]))
+        paths = self.resolve(lhapdf=exe)
+        self.assertEqual(paths.data_paths, [other, self.datadir])
+        self.assertEqual(paths.find_set('MYSET'), self.datadir)
+
+    def test_env_data_path_comes_first(self):
+        other = pjoin(self.tmpdir, 'other')
+        os.makedirs(pjoin(other, 'MYSET'))
+        os.environ['LHAPDF_DATA_PATH'] = os.pathsep.join([other, self.datadir])
+        paths = misc.resolve_lhapdf({'lhapdf': self.exe}, root=self.root)
+        self.assertEqual(paths.data_paths[0], other)
+        self.assertEqual(paths.find_set('MYSET'), other)
+        # ... and use_env=False ignores the environment entirely
+        paths = misc.resolve_lhapdf({'lhapdf': self.exe}, root=self.root,
+                                    use_env=False)
+        self.assertEqual(paths.data_paths, [self.datadir])
+
+    def test_env_config_wins_over_options(self):
+        other = pjoin(self.tmpdir, 'other')
+        os.makedirs(other)
+        exe = self.write_config('lhaenv', other)
+        os.environ['MADGRAPH_LHAPDF_CONFIG'] = exe
+        paths = misc.resolve_lhapdf({'lhapdf': self.exe}, root=self.root)
+        self.assertEqual(paths.config, exe)
+
+    def test_lhapdf_py3_fallback(self):
+        """set2_lhapdf leaves 'lhapdf' at its default when a --python= filter
+        does not match the running interpreter, so lhapdf_py3 must be tried."""
+        os.environ['PATH'] = pjoin(self.tmpdir, 'empty')
+        paths = self.resolve(lhapdf=pjoin(self.tmpdir, 'nope', 'lhapdf-config'),
+                             lhapdf_py3=self.exe)
+        self.assertEqual(paths.config, self.exe)
+        self.assertEqual(paths.data_paths, [self.datadir])
+
+    def test_none_and_auto_are_not_paths(self):
+        os.environ['PATH'] = pjoin(self.tmpdir, 'empty')
+        self.assertIsNone(self.resolve(lhapdf='None').config)
+        self.assertIsNone(self.resolve(lhapdf='auto').config)
+
+    def test_heptools_fallback_when_datadir_is_read_only(self):
+        if os.geteuid() == 0:
+            self.skipTest('root can write to a read-only directory')
+        mode = os.stat(self.datadir).st_mode
+        os.chmod(self.datadir, stat.S_IRUSR | stat.S_IXUSR)
+        try:
+            paths = self.resolve(lhapdf=self.exe)
+            self.assertEqual(paths.download_path,
+                             pjoin(self.root, 'HEPTools', 'lhapdf_pdfsets'))
+        finally:
+            os.chmod(self.datadir, mode)
+
+    def test_create_makes_the_download_directory(self):
+        os.environ['PATH'] = pjoin(self.tmpdir, 'empty')
+        target = pjoin(self.root, 'HEPTools', 'lhapdf_pdfsets')
+        paths = misc.resolve_lhapdf({}, root=self.root)
+        self.assertEqual(paths.download_path, target)
+        self.assertFalse(os.path.isdir(target))
+        paths = misc.resolve_lhapdf({}, root=self.root, create=True)
+        self.assertTrue(os.path.isdir(target))
+
+    def test_with_data_path_promotes_a_directory(self):
+        paths = self.resolve(lhapdf=self.exe)
+        promoted = paths.with_data_path('/somewhere')
+        self.assertEqual(promoted.data_paths[0], '/somewhere')
+        self.assertEqual(promoted.config, paths.config)

--- a/vendor/SudGen/README_grid_clust
+++ b/vendor/SudGen/README_grid_clust
@@ -70,9 +70,9 @@
 ==================================================
 
 0. Make sure that correct information about the PY8 path is stored in
-   input/mg5_configuration.txt, which will be used to fill makefile.inc.
+   input/mg7_configuration.txt, which will be used to fill makefile.inc.
    It is possible to run pythia_path.py to retrieve information from
-   the input/mg5_configuration.txt.
+   the input/mg7_configuration.txt.
 
 1. Run "make gridsudgen_clust".
 

--- a/vendor/SudGen/pythia_path.py
+++ b/vendor/SudGen/pythia_path.py
@@ -4,9 +4,14 @@ from pathlib import Path
 
 pjoin=os.path.join
 
-# Check the configuration file in ~/.mg5/mg5_configuration.txt
-home = str(Path.home())
-conf_file=pjoin(home,'.mg5','mg5_configuration.txt')
+pythia8_path=None
+
+# Check the per-user configuration file (see misc.user_config_file)
+xdg=os.environ.get('XDG_CONFIG_HOME')
+if xdg:
+    conf_file=pjoin(xdg,'mg7','mg7_configuration.txt')
+else:
+    conf_file=pjoin(str(Path.home()),'.mg7','mg7_configuration.txt')
 try:
     with open(conf_file) as f:
         data=f.readlines()

--- a/vendor/SudGen/pythia_path.py
+++ b/vendor/SudGen/pythia_path.py
@@ -16,9 +16,9 @@ try:
 except OSError:
     pass
 
-# Check the configuration file in ~/.mg5/mg5_configuration.txt
+# Check the configuration file in input/mg7_configuration.txt
 curr_path=os.getcwd()
-conf_file=pjoin(curr_path,'..','..','input','mg5_configuration.txt')
+conf_file=pjoin(curr_path,'..','..','input','mg7_configuration.txt')
 try:
     with open(conf_file) as f:
         data=f.readlines()
@@ -29,7 +29,7 @@ except OSError:
     pass
 
 if not pythia8_path:
-    print('Pythia8 path not found in input/mg5_configuration.txt file. Cannot compile SudGen.')
+    print('Pythia8 path not found in input/mg7_configuration.txt file. Cannot compile SudGen.')
 else:
     makefile_inc=pjoin(curr_path,'makefile.inc')
     try:


### PR DESCRIPTION
Fixes #94.

## The two bugs

**`bin/generate_events` could not find LHAPDF on its own.**

```
RuntimeError: Can't load lhapdf module. Please set LHAPDF_DATA_PATH manually
```

All the discovery lived in the caller: `do_launch` probed the configured `lhapdf-config` and injected `LHAPDF_DATA_PATH` / `MADGRAPH_LHAPDF_CONFIG` into the subprocess environment, and its final fallback *always* set the former — which is exactly why a CLI `launch` worked and re-launching the same directory did not. The standalone script sets no environment, `Cards/me5_configuration.txt` recorded only `mg5_path`, so `launch.py` was left with a bare `import lhapdf`.

**PDF sets were downloaded into another installation's `HEPTools`.**

`heptools_install_dir` defaults to the truthy `'./HEPTools'`, so `advanced_install` always took the branch that saves tool paths into the *per-user* config — as absolute paths inside whichever installation ran `install`. Every other installation read them back and, since the paths exist on disk, kept them. Hence `rm -rf ~/.mg5` working around it.

## What changed

- **One resolver.** `misc.resolve_lhapdf` is now the single place LHAPDF is located, used by both `do_launch` and the standalone launcher, so they cannot disagree. It returns the `lhapdf-config`, an ordered list of PDF-set directories, and the one a missing set may be downloaded into. It splits path lists on `os.pathsep` (feeding a multi-entry `LHAPDF_DATA_PATH` to `os.path.join` silently produced a bogus path), roots a relative option value at the installation rather than at cwd, and drops a `--python=` filter.
- **`launch.py` resolves its own paths** and exports what it finds, so systematics and the MadSpin/reweight subprocesses keep reading the environment. Side effect: the LHE banner's `lhaid` is now correct for a standalone run instead of `0`. The error message names the option and the file to edit.
- **A process directory records what it was built against.** The mg7 exporter writes `lhapdf`/`lhapdf_py3`/`heptools_install_dir` into `Cards/me5_configuration.txt`, and `load_mg5_options` reads that card *last* — process directory, then installation, then per-user, matching `CommonRunCmd.set_configuration`. Previously the per-user file overrode the installation's own.
- **`install <tool>` records paths per installation** unless `heptools_install_dir` points somewhere genuinely shared, and `Cmd.do_save` prefers a process directory's card over the per-user file.
- **MG7 keeps its configuration to itself.** The per-user location is `$XDG_CONFIG_HOME/mg7` or `~/.mg7`; MG5aMC's `~/.mg5` is never read or written. The first commit renames the in-tree file to `input/mg7_configuration.txt` to match.

## Commits

1. `chore:` rename the installation config to `mg7_configuration.txt` — mechanical.
2. `fix:` the PDF path logic.

## Verification

- 19 new unit tests in `tests/unit_tests/various/test_lhapdf_resolve.py` cover the resolver (relative values, `--python=` suffix, colon-separated `--datadir`, LHAPDF 5 vs 6, `lhapdf_py3` fallback, a broken or absent `lhapdf-config`, read-only data dir, env precedence) and the per-user location. Plus the `install` target choice in `tests/unit_tests/interface/test_cmd.py`.
- End to end with **no** `LHAPDF_DATA_PATH` and no `MADGRAPH_LHAPDF_CONFIG` in the environment: `output` a `p p > e+ e-` directory, then `cd` into it and run `./bin/generate_events -f` — exits 0, systematics included, and the banner carries `lhaid = 338500`. The CLI `launch` path was re-checked and still works.
- The manual `env['LHAPDF_DATA_PATH']` workarounds in `test_check_xsec_processes_mg7.py` and `madevent_comparator.py` are removed, so those tests now exercise the real config-driven path; the LHAPDF probe there is reduced to a skip gate.

## Note for reviewers

Anyone keeping global settings in `~/.mg5/mg5_configuration.txt` (or `~/.config/mg5_configuration.txt`) will find MG7 no longer reads them — that is the intended separation. There is no compatibility shim: at alpha stage an installation just re-seeds `input/mg7_configuration.txt` from the template on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)