### PR TITLE
Declare virtgranny_red EXTERNAL in genps_fks.f

### DIFF
--- a/Template/NLO/SubProcesses/genps_fks.f
+++ b/Template/NLO/SubProcesses/genps_fks.f
@@ -295,7 +295,7 @@ c
      &     ,virtgranny_red,MC_sum_factor,xmbe2hatlow,xmbe2hatupp
      &     ,xmbe2inv,xmbe2inv_temp,xinv_redvirtgranny,xinv_virtgranny
       external derivative,ran2,virtgranny,xinv_redvirtgranny
-     &     ,xinv_virtgranny
+     &     ,xinv_virtgranny,virtgranny_red
 c     granny stuff
       double precision tiny,granny_m2(-1:1),step,granny_m2_red_local(
      &     -1:1)


### PR DESCRIPTION
`generate_momenta_conf_wrapper` passes `virtgranny_red` to `derivative()` as an actual argument, but declares it only as a `double precision`. Every other procedure it passes or calls — `derivative`, `ran2`, `virtgranny`, `xinv_redvirtgranny`, `xinv_virtgranny` — is in the `external` list; this one was simply missed.

Without `EXTERNAL` the name denotes a variable, so the call passes an undefined double. gfortran up to 15 inferred the intent from the function references elsewhere in the same scope (lines 434-438); **gfortran 16 does not**, and refuses to compile any NLO process directory:

```
genps_fks.f:569: Error: Procedure 'virtgranny_red' used as actual argument
but does neither have an explicit interface nor the EXTERNAL attribute
```

So on gfortran 16 every newly generated NLO run fails to build. The code was always technically wrong and happened to compile.

## Verification

Under **GNU Fortran 16.2.0**, building `genps_fks.o` with the generated makefile in a real NLO process directory:

- current file → fails with the error above
- this file → compiles clean (only pre-existing `-Walign-commons` warnings)

Also confirmed in isolation with a minimal fixed-form reproducer: passing a declared-but-not-`external` function errors with `Expected a procedure for argument`, and adding `external` fixes it.

Found while investigating a MadSpin issue on a box that had been upgraded to gcc 16; six generated run directories were hand-patched to get that work moving, and this is the same change at the template so it stops recurring. There is only one tracked copy of the file, so this covers every NLO output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)