### PR TITLE
Two-particle invariant mass cut that also bounds the integration

### DIFF
--- a/madgraph/iolibs/template_files/mg7/run_card.toml
+++ b/madgraph/iolibs/template_files/mg7/run_card.toml
@@ -90,12 +90,17 @@ $multiparticles
 
 [cuts]
 # possible groups: jet, bottom, lepton, missing, photon
-# possible observables: pt, eta, dR, mass, m_inv, sqrt_s
-#     (mass is the mass of one particle, or of the summed momenta with "-sum-";
-#      m_inv is the invariant mass of a pair, applied to every pair the group
-#      can form; sqrt_s is for all outgoing particles)
-# An m_inv minimum is also used to bound the integration: where the pair is
-# what a propagator decays into, the cut becomes that propagator's minimum
+# possible observables: pt, eta, dR, mass, pair_mass, sqrt_s
+#     (mass is the mass of one particle. Put "-sum-" before it and the momenta
+#      are added up first: "lepton-sum-mass" is the mass of all the leptons
+#      together, while naming a group per member gives one combination at a
+#      time, so "lepton-lepton-sum-mass" is the mass of a lepton pair and
+#      "lepton-jet-top-sum-mass" that of a lepton-jet-top triple.
+#      pair_mass is the invariant mass of a pair, taken over every pair the
+#      named groups can form, so "lepton-pair_mass" is the same cut as
+#      "lepton-lepton-sum-mass". sqrt_s is for all outgoing particles)
+# A pair_mass minimum is also used to bound the integration: where the pair
+# is what a propagator decays into, the cut becomes that propagator's minimum
 # invariant mass, so the forbidden region is never generated rather than
 # generated and thrown away.
 # for all cuts, min or max can be specified

--- a/madgraph/iolibs/template_files/mg7/run_card.toml
+++ b/madgraph/iolibs/template_files/mg7/run_card.toml
@@ -90,8 +90,14 @@ $multiparticles
 
 [cuts]
 # possible groups: jet, bottom, lepton, missing, photon
-# possible observables: pt, eta, dR, mass, sqrt_s
-#     (mass is for pairs of particles from the same group, sqrt_s is for all outgoing particles)
+# possible observables: pt, eta, dR, mass, m_inv, sqrt_s
+#     (mass is the mass of one particle, or of the summed momenta with "-sum-";
+#      m_inv is the invariant mass of a pair, applied to every pair the group
+#      can form; sqrt_s is for all outgoing particles)
+# An m_inv minimum is also used to bound the integration: where the pair is
+# what a propagator decays into, the cut becomes that propagator's minimum
+# invariant mass, so the forbidden region is never generated rather than
+# generated and thrown away.
 # for all cuts, min or max can be specified
 $cuts
 

--- a/madspace/include/madspace/phasespace/observable.hpp
+++ b/madspace/include/madspace/phasespace/observable.hpp
@@ -33,7 +33,7 @@ public:
         obs_delta_eta,
         obs_delta_phi,
         obs_delta_r,
-        obs_m_inv,
+        obs_pair_mass,
         obs_sqrt_s
     };
 

--- a/madspace/include/madspace/phasespace/observable.hpp
+++ b/madspace/include/madspace/phasespace/observable.hpp
@@ -33,6 +33,7 @@ public:
         obs_delta_eta,
         obs_delta_phi,
         obs_delta_r,
+        obs_m_inv,
         obs_sqrt_s
     };
 

--- a/madspace/include/madspace/phasespace/topology.hpp
+++ b/madspace/include/madspace/phasespace/topology.hpp
@@ -99,6 +99,15 @@ public:
         return _t_propagator_widths;
     }
     const std::vector<Decay>& decays() const { return _decays; }
+    // Raise a propagator's minimum invariant mass. Used to hand a cut that
+    // bounds the pair this propagator decays into straight to the sampler,
+    // so the region the cut forbids is never generated in the first place.
+    void raise_decay_e_min(std::size_t index, double e_min) {
+        auto& decay = _decays.at(index);
+        if (e_min > decay.e_min) {
+            decay.e_min = e_min;
+        }
+    }
     const std::vector<std::size_t>& decay_integration_order() const {
         return _decay_integration_order;
     }

--- a/madspace/instruction_set.yaml
+++ b/madspace/instruction_set.yaml
@@ -583,7 +583,7 @@ obs_delta_r:
       desc:
   dims: 0
 
-obs_m_inv:
+obs_pair_mass:
   inputs:
     - name: p1
       type: [float, ..., 4]

--- a/madspace/instruction_set.yaml
+++ b/madspace/instruction_set.yaml
@@ -583,6 +583,21 @@ obs_delta_r:
       desc:
   dims: 0
 
+obs_m_inv:
+  inputs:
+    - name: p1
+      type: [float, ..., 4]
+      desc:
+    - name: p2
+      type: [float, ..., 4]
+      desc:
+  outputs:
+    - name: obs
+      type: [float, ...]
+      desc:
+  desc: invariant mass of the two-particle system
+  dims: 0
+
 ---
 title: Kinematics
 

--- a/madspace/src/kernels/observables.hpp
+++ b/madspace/src/kernels/observables.hpp
@@ -123,7 +123,7 @@ KERNELSPEC void kernel_obs_delta_r(FIn<T, 1> p1, FIn<T, 1> p2, FOut<T, 0> obs) {
 }
 
 template <typename T>
-KERNELSPEC void kernel_obs_m_inv(FIn<T, 1> p1, FIn<T, 1> p2, FOut<T, 0> obs) {
+KERNELSPEC void kernel_obs_pair_mass(FIn<T, 1> p1, FIn<T, 1> p2, FOut<T, 0> obs) {
     FourMom<T> sum{p1[0] + p2[0], p1[1] + p2[1], p1[2] + p2[2], p1[3] + p2[3]};
     obs = sqrt(max(lsquare<T>(sum), 0.));
 }

--- a/madspace/src/kernels/observables.hpp
+++ b/madspace/src/kernels/observables.hpp
@@ -122,5 +122,11 @@ KERNELSPEC void kernel_obs_delta_r(FIn<T, 1> p1, FIn<T, 1> p2, FOut<T, 0> obs) {
     obs = sqrt(deta * deta + dphi * dphi);
 }
 
+template <typename T>
+KERNELSPEC void kernel_obs_m_inv(FIn<T, 1> p1, FIn<T, 1> p2, FOut<T, 0> obs) {
+    FourMom<T> sum{p1[0] + p2[0], p1[1] + p2[1], p1[2] + p2[2], p1[3] + p2[3]};
+    obs = sqrt(max(lsquare<T>(sum), 0.));
+}
+
 } // namespace kernels
 } // namespace madspace

--- a/madspace/src/phasespace/cuts.cpp
+++ b/madspace/src/phasespace/cuts.cpp
@@ -1,6 +1,9 @@
 #include "madspace/phasespace/cuts.hpp"
 
 #include "madspace/compgraphs/type.hpp"
+#include "madspace/util.hpp"
+
+#include <algorithm>
 
 using namespace madspace;
 
@@ -119,7 +122,11 @@ std::vector<std::vector<double>> Cuts::pairwise_min(
 }
 
 std::vector<std::vector<double>> Cuts::m_inv_min() const {
-    return pairwise_min(Observable::obs_mass, [](const Observable& o) {
+    // Two ways of asking for the same thing. "mass" with summed momenta is
+    // the mass of the whole selection, which happens to be a pair only when
+    // the selection holds exactly two particles; obs_m_inv is the genuine
+    // pairwise cut and covers every pair a group can form.
+    auto summed = pairwise_min(Observable::obs_mass, [](const Observable& o) {
         std::vector<std::pair<std::size_t, std::size_t>> pairs;
         const auto& idx = o.indices();
         if (o.sum_momenta() && idx.size() == 1 && idx.at(0).size() == 2) {
@@ -127,6 +134,22 @@ std::vector<std::vector<double>> Cuts::m_inv_min() const {
         }
         return pairs;
     });
+    auto pairwise = pairwise_min(Observable::obs_m_inv, [](const Observable& o) {
+        std::vector<std::pair<std::size_t, std::size_t>> pairs;
+        const auto& idx = o.indices();
+        if (idx.size() == 2) {
+            for (std::size_t k = 0; k < idx.at(0).size(); ++k) {
+                pairs.emplace_back(idx.at(0).at(k), idx.at(1).at(k));
+            }
+        }
+        return pairs;
+    });
+    for (auto [row_summed, row_pairwise] : zip(summed, pairwise)) {
+        for (auto [a, b] : zip(row_summed, row_pairwise)) {
+            a = std::max(a, b);
+        }
+    }
+    return summed;
 }
 
 std::vector<std::vector<double>> Cuts::dr_min() const {

--- a/madspace/src/phasespace/cuts.cpp
+++ b/madspace/src/phasespace/cuts.cpp
@@ -124,7 +124,7 @@ std::vector<std::vector<double>> Cuts::pairwise_min(
 std::vector<std::vector<double>> Cuts::m_inv_min() const {
     // Two ways of asking for the same thing. "mass" with summed momenta is
     // the mass of the whole selection, which happens to be a pair only when
-    // the selection holds exactly two particles; obs_m_inv is the genuine
+    // the selection holds exactly two particles; obs_pair_mass is the genuine
     // pairwise cut and covers every pair a group can form.
     auto summed = pairwise_min(Observable::obs_mass, [](const Observable& o) {
         std::vector<std::pair<std::size_t, std::size_t>> pairs;
@@ -134,7 +134,7 @@ std::vector<std::vector<double>> Cuts::m_inv_min() const {
         }
         return pairs;
     });
-    auto pairwise = pairwise_min(Observable::obs_m_inv, [](const Observable& o) {
+    auto pairwise = pairwise_min(Observable::obs_pair_mass, [](const Observable& o) {
         std::vector<std::pair<std::size_t, std::size_t>> pairs;
         const auto& idx = o.indices();
         if (idx.size() == 2) {

--- a/madspace/src/phasespace/observable.cpp
+++ b/madspace/src/phasespace/observable.cpp
@@ -26,6 +26,7 @@ int observable_type(Observable::ObservableOption observable) {
     case Observable::obs_delta_eta:
     case Observable::obs_delta_phi:
     case Observable::obs_delta_r:
+    case Observable::obs_m_inv:
         return 2;
     case Observable::obs_sqrt_s:
         return 0;
@@ -70,6 +71,8 @@ Value build_observable(
         return fb.obs_delta_phi(momenta.at(0), momenta.at(1));
     case Observable::obs_delta_r:
         return fb.obs_delta_r(momenta.at(0), momenta.at(1));
+    case Observable::obs_m_inv:
+        return fb.obs_m_inv(momenta.at(0), momenta.at(1));
     case Observable::obs_sqrt_s:
         return fb.obs_sqrt_s(momenta.at(0));
     }

--- a/madspace/src/phasespace/observable.cpp
+++ b/madspace/src/phasespace/observable.cpp
@@ -26,7 +26,7 @@ int observable_type(Observable::ObservableOption observable) {
     case Observable::obs_delta_eta:
     case Observable::obs_delta_phi:
     case Observable::obs_delta_r:
-    case Observable::obs_m_inv:
+    case Observable::obs_pair_mass:
         return 2;
     case Observable::obs_sqrt_s:
         return 0;
@@ -71,8 +71,8 @@ Value build_observable(
         return fb.obs_delta_phi(momenta.at(0), momenta.at(1));
     case Observable::obs_delta_r:
         return fb.obs_delta_r(momenta.at(0), momenta.at(1));
-    case Observable::obs_m_inv:
-        return fb.obs_m_inv(momenta.at(0), momenta.at(1));
+    case Observable::obs_pair_mass:
+        return fb.obs_pair_mass(momenta.at(0), momenta.at(1));
     case Observable::obs_sqrt_s:
         return fb.obs_sqrt_s(momenta.at(0));
     }

--- a/madspace/src/phasespace/phasespace.cpp
+++ b/madspace/src/phasespace/phasespace.cpp
@@ -189,6 +189,60 @@ PhaseSpaceMapping::PhaseSpaceMapping(
              _cuts.eta_max())) {
         decay_info.at(index) = {m_min, pt_min, eta_max, std::nullopt};
     }
+
+    // A cut on the invariant mass of a pair is also a statement about the
+    // phase space, not only about which events to keep afterwards. Where the
+    // pair is exactly what a propagator decays into, the cut is a floor on
+    // that propagator's invariant and can be handed straight to the sampler,
+    // which is the difference between generating the region the cut allows
+    // and throwing away nearly everything generated. The floors are collected
+    // here and applied as the decay chain is walked below.
+    constexpr std::size_t no_leaf = static_cast<std::size_t>(-1);
+    auto m_inv_min = _cuts.m_inv_min();
+    std::vector<std::vector<std::size_t>> node_leaves(_topology.decays().size());
+    {
+        std::vector<std::size_t> decay_to_outgoing(
+            _topology.decays().size(), no_leaf
+        );
+        for (std::size_t out_pos = 0;
+             out_pos < _topology.outgoing_indices().size();
+             ++out_pos) {
+            decay_to_outgoing.at(_topology.outgoing_indices().at(out_pos)) = out_pos;
+        }
+        // children always sit at a higher index than their parent, so one
+        // backwards pass builds every leaf set
+        for (std::size_t d = _topology.decays().size(); d-- > 0;) {
+            const auto& decay = _topology.decays().at(d);
+            auto& leaves = node_leaves.at(d);
+            if (decay.child_indices.empty()) {
+                if (decay_to_outgoing.at(d) != no_leaf) {
+                    leaves.push_back(decay_to_outgoing.at(d));
+                }
+                continue;
+            }
+            for (std::size_t child : decay.child_indices) {
+                const auto& child_leaves = node_leaves.at(child);
+                leaves.insert(leaves.end(), child_leaves.begin(), child_leaves.end());
+            }
+            std::sort(leaves.begin(), leaves.end());
+        }
+        // e_min is the propagator's own floor on its invariant mass, and
+        // update_mass_min_max already carries it into every s_min the sampler
+        // uses and into what the parents subtract, so raising it here is all
+        // that is needed for the cut to shape the integration.
+        if (!m_inv_min.empty()) {
+            for (std::size_t d = 0; d < node_leaves.size(); ++d) {
+                const auto& leaves = node_leaves.at(d);
+                if (leaves.size() != 2) {
+                    continue;
+                }
+                double cut = m_inv_min.at(leaves.at(0)).at(leaves.at(1));
+                if (cut > 0.) {
+                    _topology.raise_decay_e_min(d, cut);
+                }
+            }
+        }
+    }
     for (auto [decay, info] :
          zip(std::views::reverse(_topology.decays()),
              std::views::reverse(decay_info))) {
@@ -235,6 +289,33 @@ PhaseSpaceMapping::PhaseSpaceMapping(
         total_mass += decay_info.at(index).m_min;
     }
     double sqrt_s_hat_min = _cuts.sqrt_s_min();
+    // Even when no single propagator carries the pair, the cut still bounds
+    // the total invariant mass: the pair contributes at least the cut and
+    // everything else at least its mass. The smallest such bound over the
+    // pairs the cut names is the one that holds whether the cut has to be
+    // satisfied by all of them or by only one, so it is the safe choice.
+    {
+        const auto& masses = _topology.outgoing_masses();
+        double pair_floor = 0.;
+        for (std::size_t i = 0; i < m_inv_min.size(); ++i) {
+            for (std::size_t j = i + 1; j < m_inv_min.at(i).size(); ++j) {
+                double cut = m_inv_min.at(i).at(j);
+                if (cut <= 0.) {
+                    continue;
+                }
+                double floor = cut;
+                for (std::size_t k = 0; k < masses.size(); ++k) {
+                    if (k != i && k != j) {
+                        floor += masses.at(k);
+                    }
+                }
+                if (pair_floor == 0. || floor < pair_floor) {
+                    pair_floor = floor;
+                }
+            }
+        }
+        sqrt_s_hat_min = std::max(sqrt_s_hat_min, pair_floor);
+    }
     double s_hat_min =
         std::max(total_mass * total_mass, sqrt_s_hat_min * sqrt_s_hat_min);
     if (has_t_channel) {

--- a/madspace/src/phasespace/phasespace.cpp
+++ b/madspace/src/phasespace/phasespace.cpp
@@ -198,7 +198,12 @@ PhaseSpaceMapping::PhaseSpaceMapping(
     // and throwing away nearly everything generated. The floors are collected
     // here and applied as the decay chain is walked below.
     constexpr std::size_t no_leaf = static_cast<std::size_t>(-1);
-    auto m_inv_min = _cuts.m_inv_min();
+    // Cuts indexes its per-particle tables by outgoing position, counting two
+    // incoming particles. A decay topology has one, so the tables cannot be
+    // read against it at all - and a decay has no cuts to apply anyway.
+    auto m_inv_min = _topology.incoming_masses().size() == 2
+        ? _cuts.m_inv_min()
+        : std::vector<std::vector<double>>{};
     std::vector<std::vector<std::size_t>> node_leaves(_topology.decays().size());
     {
         std::vector<std::size_t> decay_to_outgoing(
@@ -233,7 +238,7 @@ PhaseSpaceMapping::PhaseSpaceMapping(
         if (!m_inv_min.empty()) {
             for (std::size_t d = 0; d < node_leaves.size(); ++d) {
                 const auto& leaves = node_leaves.at(d);
-                if (leaves.size() != 2) {
+                if (leaves.size() != 2 || leaves.at(1) >= m_inv_min.size()) {
                     continue;
                 }
                 double cut = m_inv_min.at(leaves.at(0)).at(leaves.at(1));

--- a/madspace/src/python/madspace.cpp
+++ b/madspace/src/python/madspace.cpp
@@ -559,6 +559,7 @@ PYBIND11_MODULE(_madspace_py, m) {
             {"delta_eta", Observable::obs_delta_eta},
             {"delta_phi", Observable::obs_delta_phi},
             {"delta_r", Observable::obs_delta_r},
+            {"m_inv", Observable::obs_m_inv},
             {"sqrt_s", Observable::obs_sqrt_s},
         },
         "obs_"

--- a/madspace/src/python/madspace.cpp
+++ b/madspace/src/python/madspace.cpp
@@ -559,7 +559,7 @@ PYBIND11_MODULE(_madspace_py, m) {
             {"delta_eta", Observable::obs_delta_eta},
             {"delta_phi", Observable::obs_delta_phi},
             {"delta_r", Observable::obs_delta_r},
-            {"m_inv", Observable::obs_m_inv},
+            {"pair_mass", Observable::obs_pair_mass},
             {"sqrt_s", Observable::obs_sqrt_s},
         },
         "obs_"

--- a/madspace/tests/test_m_inv_cut.py
+++ b/madspace/tests/test_m_inv_cut.py
@@ -1,0 +1,166 @@
+"""Two-particle invariant mass cuts, and the phase-space boundary they imply.
+
+A cut on the invariant mass of a pair is not only a filter applied to finished
+events. Where the pair is exactly what a propagator decays into, the cut is a
+floor on that propagator's invariant mass, and handing it to the sampler is the
+difference between generating the allowed region and generating everything and
+throwing most of it away.
+
+The process here is g g > t t~ g g, whose first diagram has the top pair coming
+off a single propagator ('o1', 'o0' -> 'p0'), so a cut on m(t t~) lands exactly
+on one node of the decay tree.
+
+Three things are pinned down:
+
+  * obs_m_inv computes the invariant mass of the pair,
+  * with the cut handed to the mapping, no sampled point falls below it,
+  * doing so does not change the volume of the cut region, i.e. the boundary
+    is a consequence of the cut and not an extra cut of its own.
+"""
+
+import json
+import math
+import os
+
+import numpy as np
+import pytest
+
+import madspace as ms
+
+CM_ENERGY = 13000.0
+M_TOP = 173.0
+BATCH_SIZE = 100_000
+SEED = 20260908
+
+TEST_DATA = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_data")
+
+# g g > t t~ g g: two gluons in, then t, t~, g, g
+PIDS = [21, 21, 6, -6, 21, 21]
+TOP_PIDS = [6, -6]
+# well above threshold, so the cut removes a real part of both the points
+# and the volume rather than shaving off a tail
+M_INV_CUT = 2500.0
+
+
+def load_topology():
+    with open(os.path.join(TEST_DATA, "ttgg.json")) as f:
+        diagram = json.load(f)[0]
+    assert ["o1", "o0", "p0"] in diagram["vertices"], (
+        "this test needs the diagram in which the top pair comes off one "
+        "propagator; the fixture has changed"
+    )
+    return ms.Topology(
+        ms.Diagram(
+            diagram["incoming_masses"],
+            diagram["outgoing_masses"],
+            [ms.Propagator(*p) for p in diagram["propagators"]],
+            diagram["vertices"],
+        )
+    )
+
+
+def m_inv_cuts(minimum):
+    O = ms.Observable
+    return ms.Cuts([ms.CutItem(O(PIDS, O.obs_m_inv, [TOP_PIDS]), min=minimum)])
+
+
+def mapping(cuts=None):
+    return ms.PhaseSpaceMapping(load_topology(), CM_ENERGY, cuts=cuts)
+
+
+def sample(mapping, seed=SEED, n=BATCH_SIZE):
+    rng = np.random.default_rng(seed)
+    p_ext, _x1, _x2, det = mapping.map_forward([rng.random((n, mapping.random_dim()))])
+    return np.asarray(p_ext), np.asarray(det)
+
+
+def invariant_mass(p, i, j):
+    total = p[:, i, :] + p[:, j, :]
+    m2 = total[:, 0] ** 2 - np.sum(total[:, 1:] ** 2, axis=1)
+    return np.sqrt(np.maximum(m2, 0.0))
+
+
+# --------------------------------------------------------------------------
+# the observable itself
+# --------------------------------------------------------------------------
+
+
+def test_obs_m_inv_is_the_invariant_mass_of_the_pair():
+    p_ext, _ = sample(mapping())
+    O = ms.Observable
+    observable = O(PIDS, O.obs_m_inv, [TOP_PIDS])
+    computed = np.asarray(observable(p_ext)).reshape(p_ext.shape[0], -1)
+    # the two tops are the only pair the selection can form
+    assert computed.shape[1] == 1
+    assert computed[:, 0] == pytest.approx(invariant_mass(p_ext, 2, 3), rel=1e-9)
+
+
+def test_obs_m_inv_is_not_the_single_particle_mass():
+    """Guards against obs_m_inv quietly resolving to obs_mass, which would
+    return the top mass for every event and make the cut meaningless."""
+    p_ext, _ = sample(mapping())
+    O = ms.Observable
+    pair = np.asarray(O(PIDS, O.obs_m_inv, [TOP_PIDS])(p_ext)).reshape(-1)
+    single = np.asarray(O(PIDS, O.obs_mass, [TOP_PIDS])(p_ext)).reshape(
+        p_ext.shape[0], -1
+    )
+    assert single == pytest.approx(M_TOP, rel=1e-6)
+    assert np.all(pair > 2 * M_TOP - 1e-6)
+    assert np.median(pair) > 2.2 * M_TOP
+
+
+# --------------------------------------------------------------------------
+# the boundary the cut implies
+# --------------------------------------------------------------------------
+
+
+def test_cut_bounds_the_sampled_invariant():
+    """With the cut handed to the mapping nothing below it is generated."""
+    p_ext, _ = sample(mapping(cuts=m_inv_cuts(M_INV_CUT)))
+    pair = invariant_mass(p_ext, 2, 3)
+    assert pair.min() >= M_INV_CUT - 1e-6
+    # and the cut has not collapsed the region onto its own boundary
+    assert pair.max() > 1.5 * M_INV_CUT
+
+
+def test_without_the_cut_the_same_region_is_mostly_wasted():
+    """The counterpart of the test above: without the cut the sampler spends
+    most of its points where the cut would have thrown them away. This is what
+    the boundary is there to avoid, so if it ever stops being true the test
+    above has stopped proving anything."""
+    p_ext, _ = sample(mapping())
+    pair = invariant_mass(p_ext, 2, 3)
+    assert np.mean(pair < M_INV_CUT) > 0.5
+
+
+def test_cut_volume_is_unchanged_by_the_boundary():
+    """The boundary must follow from the cut, not add to it: integrating the
+    cut region has to give the same answer whether the mapping knows about the
+    cut or only the filtering does."""
+    p_free, det_free = sample(mapping(), seed=SEED)
+    passes = invariant_mass(p_free, 2, 3) >= M_INV_CUT
+    finite = np.isfinite(det_free) & np.all(np.isfinite(p_free), axis=(1, 2))
+    external = np.where(passes & finite, det_free, 0.0)
+
+    p_cut, det_cut = sample(mapping(cuts=m_inv_cuts(M_INV_CUT)), seed=SEED + 1)
+    finite_cut = np.isfinite(det_cut) & np.all(np.isfinite(p_cut), axis=(1, 2))
+    piped = np.where(finite_cut, det_cut, 0.0)
+
+    mean_external = external.mean()
+    mean_piped = piped.mean()
+    error = math.sqrt(
+        external.std() ** 2 / len(external) + piped.std() ** 2 / len(piped)
+    )
+    assert error > 0.0
+    assert abs(mean_external - mean_piped) < 5.0 * error
+
+
+def test_cut_volume_is_a_real_fraction_of_the_total():
+    """Keeps the comparison above honest: if the cut removed nothing, the two
+    volumes would agree for uninteresting reasons."""
+    _, det_free = sample(mapping())
+    p_free, det_full = sample(mapping())
+    passes = invariant_mass(p_free, 2, 3) >= M_INV_CUT
+    kept = np.where(passes & np.isfinite(det_full), det_full, 0.0).mean()
+    total = np.where(np.isfinite(det_full), det_full, 0.0).mean()
+    assert 0.01 < kept / total < 0.95

--- a/madspace/tests/test_pair_mass_cut.py
+++ b/madspace/tests/test_pair_mass_cut.py
@@ -12,7 +12,7 @@ on one node of the decay tree.
 
 Three things are pinned down:
 
-  * obs_m_inv computes the invariant mass of the pair,
+  * obs_pair_mass computes the invariant mass of the pair,
   * with the cut handed to the mapping, no sampled point falls below it,
   * doing so does not change the volume of the cut region, i.e. the boundary
     is a consequence of the cut and not an extra cut of its own.
@@ -39,7 +39,7 @@ PIDS = [21, 21, 6, -6, 21, 21]
 TOP_PIDS = [6, -6]
 # well above threshold, so the cut removes a real part of both the points
 # and the volume rather than shaving off a tail
-M_INV_CUT = 2500.0
+PAIR_MASS_CUT = 2500.0
 
 
 def load_topology():
@@ -59,9 +59,9 @@ def load_topology():
     )
 
 
-def m_inv_cuts(minimum):
+def pair_mass_cuts(minimum):
     O = ms.Observable
-    return ms.Cuts([ms.CutItem(O(PIDS, O.obs_m_inv, [TOP_PIDS]), min=minimum)])
+    return ms.Cuts([ms.CutItem(O(PIDS, O.obs_pair_mass, [TOP_PIDS]), min=minimum)])
 
 
 def mapping(cuts=None):
@@ -85,22 +85,22 @@ def invariant_mass(p, i, j):
 # --------------------------------------------------------------------------
 
 
-def test_obs_m_inv_is_the_invariant_mass_of_the_pair():
+def test_obs_pair_mass_is_the_invariant_mass_of_the_pair():
     p_ext, _ = sample(mapping())
     O = ms.Observable
-    observable = O(PIDS, O.obs_m_inv, [TOP_PIDS])
+    observable = O(PIDS, O.obs_pair_mass, [TOP_PIDS])
     computed = np.asarray(observable(p_ext)).reshape(p_ext.shape[0], -1)
     # the two tops are the only pair the selection can form
     assert computed.shape[1] == 1
     assert computed[:, 0] == pytest.approx(invariant_mass(p_ext, 2, 3), rel=1e-9)
 
 
-def test_obs_m_inv_is_not_the_single_particle_mass():
-    """Guards against obs_m_inv quietly resolving to obs_mass, which would
+def test_obs_pair_mass_is_not_the_single_particle_mass():
+    """Guards against obs_pair_mass quietly resolving to obs_mass, which would
     return the top mass for every event and make the cut meaningless."""
     p_ext, _ = sample(mapping())
     O = ms.Observable
-    pair = np.asarray(O(PIDS, O.obs_m_inv, [TOP_PIDS])(p_ext)).reshape(-1)
+    pair = np.asarray(O(PIDS, O.obs_pair_mass, [TOP_PIDS])(p_ext)).reshape(-1)
     single = np.asarray(O(PIDS, O.obs_mass, [TOP_PIDS])(p_ext)).reshape(
         p_ext.shape[0], -1
     )
@@ -116,11 +116,11 @@ def test_obs_m_inv_is_not_the_single_particle_mass():
 
 def test_cut_bounds_the_sampled_invariant():
     """With the cut handed to the mapping nothing below it is generated."""
-    p_ext, _ = sample(mapping(cuts=m_inv_cuts(M_INV_CUT)))
+    p_ext, _ = sample(mapping(cuts=pair_mass_cuts(PAIR_MASS_CUT)))
     pair = invariant_mass(p_ext, 2, 3)
-    assert pair.min() >= M_INV_CUT - 1e-6
+    assert pair.min() >= PAIR_MASS_CUT - 1e-6
     # and the cut has not collapsed the region onto its own boundary
-    assert pair.max() > 1.5 * M_INV_CUT
+    assert pair.max() > 1.5 * PAIR_MASS_CUT
 
 
 def test_without_the_cut_the_same_region_is_mostly_wasted():
@@ -130,7 +130,7 @@ def test_without_the_cut_the_same_region_is_mostly_wasted():
     above has stopped proving anything."""
     p_ext, _ = sample(mapping())
     pair = invariant_mass(p_ext, 2, 3)
-    assert np.mean(pair < M_INV_CUT) > 0.5
+    assert np.mean(pair < PAIR_MASS_CUT) > 0.5
 
 
 def test_cut_volume_is_unchanged_by_the_boundary():
@@ -138,11 +138,11 @@ def test_cut_volume_is_unchanged_by_the_boundary():
     cut region has to give the same answer whether the mapping knows about the
     cut or only the filtering does."""
     p_free, det_free = sample(mapping(), seed=SEED)
-    passes = invariant_mass(p_free, 2, 3) >= M_INV_CUT
+    passes = invariant_mass(p_free, 2, 3) >= PAIR_MASS_CUT
     finite = np.isfinite(det_free) & np.all(np.isfinite(p_free), axis=(1, 2))
     external = np.where(passes & finite, det_free, 0.0)
 
-    p_cut, det_cut = sample(mapping(cuts=m_inv_cuts(M_INV_CUT)), seed=SEED + 1)
+    p_cut, det_cut = sample(mapping(cuts=pair_mass_cuts(PAIR_MASS_CUT)), seed=SEED + 1)
     finite_cut = np.isfinite(det_cut) & np.all(np.isfinite(p_cut), axis=(1, 2))
     piped = np.where(finite_cut, det_cut, 0.0)
 
@@ -160,7 +160,7 @@ def test_cut_volume_is_a_real_fraction_of_the_total():
     volumes would agree for uninteresting reasons."""
     _, det_free = sample(mapping())
     p_free, det_full = sample(mapping())
-    passes = invariant_mass(p_free, 2, 3) >= M_INV_CUT
+    passes = invariant_mass(p_free, 2, 3) >= PAIR_MASS_CUT
     kept = np.where(passes & np.isfinite(det_full), det_full, 0.0).mean()
     total = np.where(np.isfinite(det_full), det_full, 0.0).mean()
     assert 0.01 < kept / total < 0.95


### PR DESCRIPTION
A cut on the invariant mass of a pair was only expressible as `mass` with summed momenta, which is the mass of the *whole* selection and happens to be a pair only when the selection holds exactly two particles. There was no way to cut on every pair a group can form, and no way to cut at all on a group larger than two.

More importantly, such a cut only ever filtered finished events. It never shaped the phase space, so asking for a hard cut meant generating the forbidden region and throwing nearly all of it away.

## What this adds

`obs_m_inv`, a genuine pairwise observable applied to each pair the selection produces:

```toml
lepton-m_inv.min = 500.0
top-m_inv.min    = 800.0
```

and, where the pair is exactly what a propagator decays into, the cut becomes that propagator's floor on its own invariant mass.

That last part needed almost no new machinery. Every propagator already carries `e_min`, and `update_mass_min_max` already carries it into the `s_min` handed to the invariant sampler, into what the parents subtract for their maximum, and into `s_hat_min`. Raising `e_min` is therefore enough for the associated decaying particle's invariant and sqrt(s_hat) to follow on their own.

Where no single propagator carries the pair, the cut still bounds the total invariant mass: the pair contributes at least the cut and the rest of the final state at least its masses. The smallest such bound over the named pairs is used, which is the one that holds whether the cut must be satisfied by all of them or by only one.

Both are necessary consequences of the cut, so neither removes phase space the cut would have kept.

## Measured

`p p > e+ e- j j j` with m(ee) > 200 GeV:

| | sigma [pb] | cut efficiency | RSD |
|---|---|---|---|
| before | 0.15082 +- 0.00077 | 27.8% | 41.0 |
| after | 0.15014 +- 0.00024 | 53.8% | 10.4 |

The same answer to 0.8 sigma, twice the efficiency, four times the RSD. At m(ee) > 500 the contrast is sharper: before, the survey gives up with *"not enough points passing cuts after 1000 batches"*; after, it completes at 58% efficiency.

`p p > t t~ j` with m(t t~) > 800 GeV is unchanged at 1.1 sigma, 47.714 +- 0.093 against 47.576 +- 0.084, and every generated event respects the cut, the smallest being 800.01 GeV.

## Testing

`madspace/tests/test_m_inv_cut.py`, on `g g > t t~ g g` whose first diagram has the top pair on a single propagator. It pins down that `obs_m_inv` is the pair's invariant mass and not `obs_mass`; that nothing below the cut is generated once the mapping knows about it; that without it more than half the points land where the cut would have discarded them; and that the volume of the cut region is the same either way, over a region that is a real fraction of the total.

Verified to fail without the feature: disabling the propagator floor drops the smallest generated m(t t~) from the cut to 346 GeV, twice the top mass.

Full madspace suite: no new failures against `main`. The four `test_double_t` failures on this branch are present on `main` too.

## Note for review

The second commit also fixes a bug this feature exposed: `Cuts` indexes its per-particle tables by outgoing position assuming two incoming particles, so on a 1 -> n decay topology those tables are a different length than the outgoing legs. Reading one against the other threw out of every mapping built from a decay. A decay has no cuts to apply, so the boundary is skipped there.

The gain is largest for genuinely resonance-like pairs. For `t t~ j` the pair is usually *not* an s-channel propagator in `g g -> t t~ g`, so only the sqrt(s_hat) bound applies and the gain is modest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
