### PR TITLE
Fix three failures the native systematics introduce (SIGABRT, and every mg7 decay)

### DIFF
--- a/madgraph/iolibs/template_files/mg7/launch.py
+++ b/madgraph/iolibs/template_files/mg7/launch.py
@@ -941,6 +941,22 @@ class MadgraphProcess:
         )
         return path
 
+    def needs_systematics_matrix_elements(self) -> bool:
+        """The systematics will re-evaluate a matrix element per scale point.
+
+        True when the native weights are on and some subprocess mixes alpha_s
+        powers (qcd_power < 0), i.e. when build_systematics_matrix_elements()
+        loads a matrix element. Conservative: it does not check that a CPU
+        backend exists, so it can be True where that call ends up loading
+        nothing.
+        """
+        if not self.systematics_enabled():
+            return False
+        if self.run_card["run"]["dummy_matrix_element"]:
+            return False
+        return any(int(meta.get("qcd_power", -1)) < 0
+                   for meta in self.subprocess_data)
+
     def init_generator_config(self) -> None:
         run_args = self.run_card["run"]
         gen_args = self.run_card["generation"]
@@ -961,6 +977,21 @@ class MadgraphProcess:
         cfg.gpu_batch_size = gen_args["gpu_batch_size"]
         cfg.verbosity = resolve_verbosity(run_args["verbosity"])
         cfg.combine_thread_count = run_args["combine_thread_pool_size"]
+        if self.needs_systematics_matrix_elements() and cfg.combine_thread_count != 1:
+            # SystematicsCalculator::compute() runs inside the combine workers,
+            # and a matrix element's per-thread process instances live in a
+            # ThreadResource indexed by ThreadPool::thread_index() -- the
+            # *calling* thread's index. A parallel combine pool would therefore
+            # need one process instance per worker; building N of them to index
+            # them safely is not worth it, the more so as
+            # SystematicsCalculator::matrix_elements() already serialises every
+            # evaluation on its own mutex, so that parallelism was not being
+            # used anyway. Run the combine stage single-threaded instead.
+            logger.info(
+                "systematics: the combine stage runs single-threaded because a "
+                "subprocess needs its matrix element re-evaluated for the "
+                "renormalisation scale variations")
+            cfg.combine_thread_count = 1
         cfg.cut_efficiency_threshold = gen_args["cut_efficiency_threshold"]
         cfg.max_cut_repetitions = gen_args["max_cut_repetitions"]
         self.event_generator_config = cfg

--- a/madgraph/iolibs/template_files/mg7/launch.py
+++ b/madgraph/iolibs/template_files/mg7/launch.py
@@ -518,6 +518,13 @@ class MadgraphProcess:
     def init_beam(self) -> None:
         beam_args = self.run_card["beam"]
 
+        # built lazily by build_systematics (needs the subprocess data)
+        self.systematics = None
+        self.systematics_data = None
+        self.systematics_context = None
+        self.event_histograms = None
+        self.event_histograms_context = None
+
         if self.is_decay:
             # No beams: the total energy is the decaying particle's mass, and
             # "leptonic" is what the mappings call "no parton luminosity".
@@ -576,12 +583,6 @@ class MadgraphProcess:
             self.pdf_grid.initialize_globals(context)
             self.alphas_grid.initialize_globals(context)
         self.running_coupling = ms.RunningCoupling(self.alphas_grid)
-        # built lazily by build_systematics (needs the subprocess data)
-        self.systematics = None
-        self.systematics_data = None
-        self.systematics_context = None
-        self.event_histograms = None
-        self.event_histograms_context = None
 
     # ------------------------------------------------------------------
     # scale / PDF systematics
@@ -740,13 +741,22 @@ class MadgraphProcess:
         config.dyn_scales = self.resolve_dynamical_scales()
         config.write_inputs = bool(syst["write_inputs"])
         config.has_pdf = not self.leptonic
-        info_path = os.path.join(self.pdf_dir, self.pdf_set, f"{self.pdf_set}.info")
-        info = self.pdf_set_info(info_path)
-        config.nominal_set_name = self.pdf_set
-        config.nominal_lhaid = info["SetIndex"]
-        config.nominal_error_type = info["ErrorType"]
-        config.nominal_description = info["SetDesc"]
-        config.pdf_members = self.resolve_pdf_variations() if not self.leptonic else []
+        # Without parton luminosity -- a decay, or leptonic beams -- there is no
+        # nominal PDF set to describe: init_beam() returns before self.pdf_set
+        # is assigned and leaves self.pdf_dir None, so this has to be skipped
+        # rather than just left unused. Only the scale variations remain, and
+        # SystematicsCalculator asks for a nominal PDF grid only when has_pdf.
+        info_path = None
+        if config.has_pdf:
+            info_path = os.path.join(self.pdf_dir, self.pdf_set, f"{self.pdf_set}.info")
+            info = self.pdf_set_info(info_path)
+            config.nominal_set_name = self.pdf_set
+            config.nominal_lhaid = info["SetIndex"]
+            config.nominal_error_type = info["ErrorType"]
+            config.nominal_description = info["SetDesc"]
+            config.pdf_members = self.resolve_pdf_variations()
+        else:
+            config.pdf_members = []
         args = self.build_systematics_args()
         # the PDFs, alpha_s and (for mixed-order subprocesses) the matrix
         # elements are evaluated with the batched madspace functions on this
@@ -762,7 +772,9 @@ class MadgraphProcess:
         self.systematics_data = {
             "config": json.loads(config.to_json()),
             "subproc_args": [json.loads(a.to_json()) for a in args],
-            "nominal_grid_file": os.path.join(self.pdf_dir, self.pdf_set, f"{self.pdf_set}_0000.dat"),
+            "nominal_grid_file": os.path.join(
+                self.pdf_dir, self.pdf_set, f"{self.pdf_set}_0000.dat")
+                if config.has_pdf else None,
             "nominal_info_file": info_path,
             # matrix elements re-evaluated for the mixed-order subprocesses
             "me_paths": [meta["me_path"] for meta in self.subprocess_data],

--- a/madspace/include/madspace/driver/thread_pool.hpp
+++ b/madspace/include/madspace/driver/thread_pool.hpp
@@ -2,6 +2,7 @@
 
 #include <condition_variable>
 #include <deque>
+#include <exception>
 #include <functional>
 #include <mutex>
 #include <optional>
@@ -34,6 +35,9 @@ private:
 
     void thread_loop(std::size_t index);
     bool fill_done_cache();
+    // Called with *lock* held and _exception set: cancels the queue, waits for
+    // the running jobs and rethrows on the caller's thread.
+    [[noreturn]] void rethrow_job_exception(std::unique_lock<std::mutex>& lock);
 
     std::mutex _mutex;
     std::condition_variable _cv_run, _cv_done;
@@ -43,6 +47,10 @@ private:
     std::deque<std::size_t> _done_queue;
     std::vector<std::size_t> _done_buffer;
     std::size_t _busy_threads = 0;
+    // The first exception thrown by a job, rethrown by wait()/wait_multiple().
+    // Without it an exception escaping a job would leave std::thread with no
+    // handler, i.e. terminate the process.
+    std::exception_ptr _exception;
     std::size_t _listener_id = 0;
     std::unordered_map<std::size_t, std::function<void(std::size_t)>> _listeners;
 };

--- a/madspace/src/driver/thread_pool.cpp
+++ b/madspace/src/driver/thread_pool.cpp
@@ -66,17 +66,33 @@ void ThreadPool::submit(std::vector<JobFunc>& jobs) {
     _cv_run.notify_all();
 }
 
+void ThreadPool::rethrow_job_exception(std::unique_lock<std::mutex>& lock) {
+    _job_queue.clear();
+    _cv_done.wait(lock, [&] { return _busy_threads == 0; });
+    auto exception = _exception;
+    _exception = nullptr;
+    _done_queue.clear();
+    _done_buffer.clear();
+    std::rethrow_exception(exception);
+}
+
 bool ThreadPool::fill_done_cache() {
     if (!_done_buffer.empty()) {
         return true;
     }
 
     std::unique_lock<std::mutex> lock(_mutex);
+    if (_exception) {
+        rethrow_job_exception(lock);
+    }
     if (_done_queue.empty()) {
         if (_job_queue.empty() && _busy_threads == 0) {
             return false;
         }
-        _cv_done.wait(lock, [&] { return !_done_queue.empty(); });
+        _cv_done.wait(lock, [&] { return !_done_queue.empty() || _exception; });
+        if (_exception) {
+            rethrow_job_exception(lock);
+        }
     }
     _done_buffer.insert(_done_buffer.begin(), _done_queue.rbegin(), _done_queue.rend());
     _done_queue.clear();
@@ -128,13 +144,31 @@ void ThreadPool::thread_loop(std::size_t index) {
         _job_queue.pop_front();
         ++_busy_threads;
         lock.unlock();
-        std::optional<std::size_t> result = job();
+        std::optional<std::size_t> result;
+        try {
+            result = job();
+        } catch (...) {
+            // A job must never let an exception escape: it would unwind out of
+            // the thread function and terminate the process. Hand the first one
+            // to whoever is waiting, and drop the jobs still queued -- the
+            // waiter is about to unwind and they capture its locals.
+            lock.lock();
+            if (!_exception) {
+                _exception = std::current_exception();
+            }
+            _job_queue.clear();
+            --_busy_threads;
+            _cv_done.notify_all();
+            continue;
+        }
         lock.lock();
         --_busy_threads;
         if (result) {
             _done_queue.push_back(*result);
-            _cv_done.notify_one();
         }
+        // notify_all, not notify_one: rethrow_job_exception() waits here for
+        // _busy_threads to drain, and a job returning nullopt must wake it too.
+        _cv_done.notify_all();
     }
 }
 


### PR DESCRIPTION
Three bugs the native `[systematics]` — on by default — introduce on this branch.
`test_generation_heft_mg7` died with **SIGABRT** (`subprocess.call` returning `-6`),
and **every mg7 MadSpin decay** failed outright.

## 1. `madspace`: a thread-pool job could abort the process

`ThreadPool::thread_loop` ran its jobs bare — `std::optional<std::size_t> result = job();`
— so an exception escaping one unwound out of the `std::thread` function and called
`std::terminate()`. The combine stage does all its per-batch work inside these jobs, so
*any* failure there could only ever surface as an unattributable `-6`.

The first exception is now stored and rethrown on the waiting thread, so
`wait()`/`wait_multiple()` raise it like any other error — through pybind11, a normal
Python exception. Three details beyond the `try`/`catch`:

- the `_cv_done` predicate must test `_exception`, or a waiter blocks forever when the
  only outstanding job threw and queued no result;
- the queued jobs capture the waiter's locals and the waiter is about to unwind, so
  `rethrow_job_exception()` drops the queue and waits for the running jobs first —
  otherwise the rethrow is a use-after-free;
- that drain waits on `_cv_done`, so completions `notify_all` rather than `notify_one`;
  a job returning `nullopt` previously notified nobody and would hang it.

## 2. `mg7`: the combine stage must be single-threaded when the systematics need a ME

HEFT mixes alpha_s powers (`GC_13`/`GC_16` carry aS at QCD order 0), so `qcd_power = -1`
and the scale weights cannot come from rescaling alpha_s^n.
`build_systematics_matrix_elements()` loads the matrix element to re-evaluate |M|^2 per
scale point, into a context built with `thread_count=1` — one entry in
`MatrixElementApi::_instances`. But `SystematicsCalculator::compute()` runs inside the
combine workers, and `ThreadResource::get()` indexes `_resources` with
`ThreadPool::thread_index()`, the *calling* thread's index (0..N-1). The first batch
scheduled onto a worker other than 0 threw `std::out_of_range`.

Sizing that context to the combine pool fixes the lookup but builds one process instance
per worker. This runs the combine stage single-threaded instead: `matrix_elements()`
already serialises every evaluation on `_runtime_mutex`, so the parallelism was not being
used in this case. Measured on `g g > b b~ HIW<=1`, 50k events: **0.31 s wall / 0.37 s cpu**
single-threaded against **0.16 s / 0.36 s** on 18 workers — the same cpu time.

## 3. `mg7`: no nominal PDF lookup when there is no parton luminosity

Every mg7 MadSpin decay died with

```
File ".../mg7/launch.py", line 743, in build_systematics
  info_path = os.path.join(self.pdf_dir, self.pdf_set, f"{self.pdf_set}.info")
AttributeError: 'MadgraphProcess' object has no attribute 'pdf_set'
```

surfacing as `the mg7 decay generator failed in decay_24_0 (exit 1)` and then
`produced no decayed events`.

`init_beam()` returns early for a decay — no beams, so `pdf_grid`/`lhapdf`/`pdf_dir` are
`None` — *before* `self.pdf_set` is assigned. `build_systematics()` already knew about
this case one line later (`config.has_pdf = not self.leptonic`, with `pdf_members` guarded
on it) but read the nominal PDF set unconditionally first. That block is now guarded too,
and `systematics_data` records no nominal grid/info file when there is none.
`SystematicsCalculator` only requires a nominal PDF grid when `has_pdf`; the alpha_s grid
a decay does have, fixed at the decaying mass.

The same early return also skipped the five `self.systematics*` / `self.event_histograms*`
initialisations at the end of `init_beam`, leaving a decay process without those
attributes at all — hoisted above it.

## Validation

| check | before | after |
|---|---|---|
| HEFT, systematics ON (the SIGABRT) | `-6` | exit 0, xsec 1.8233e+08 (ref 1.820e+08) |
| HEFT, systematics OFF | exit 0 | exit 0, guard does not fire |
| `u u > u u`, systematics ON (definite `qcd_power`) | exit 0 | exit 0, guard does not fire, full pool, 8 weights/event |
| `w+ > j j` decay | exit 1, `AttributeError` | exit 0, `Variations per event: 2 (2 scale, 0 PDF members)`, scale variation `+0% -0%` |
| the 4 mg7 tests below | 3 failures | `Ran 4 tests — OK` |

Tests: `test_generation_heft_mg7`, `test_systematics_mg7`,
`test_w_production_with_ms_decay_mg7`, `test_madspin_mixed_flavor_decay_log_summary_mg7`.

`0 PDF members` and `+0% -0%` are the right answer for a decay: no PDF, one fixed scale.

Commit 1 is tested against a real throw, not just the happy path: with commit 2's guard
temporarily disabled so the `out_of_range` fires again, the run ends in a Python traceback
(`IndexError: vector` at `combine_to_lhe(...)`) instead of SIGABRT.

## Caveats

- The commit-2 guard does not check that a CPU backend exists, so a GPU-only build can
  serialise the combine stage where `build_systematics_matrix_elements()` would have loaded
  nothing. Duplicating that backend check puts the logic in two places; flagging rather
  than deciding.
- Commit 2 is a call-site fix, not a fix to `ThreadResource::get()`: a context built with a
  small `thread_count` and consumed from a *different* pool would still be out of range.
  Only the matrix-element lookup is demonstrated to fire here — the histogram context
  (`build_event_histograms`, also `thread_count=1`, filled from the same combine lambda)
  does **not** abort, so it is left alone.

## Unrelated CI red

`IOtest_TIR` and `IOtest_matchbox` fail here but also on `main` and on every recent branch.
The `looptools-ubuntu24` cache (which carries ninja/collier) is gone, along with the other
HEPTools sub-caches, and the `heptools-ubuntu24` cache re-created 2026-09-08T15:12 has no
ninja. MadLoop then emits its Fortran without the TIR routines and the goldens mismatch.
It needs `heptools-ubuntu24` deleted and `warm_cache.yml` re-run; nothing to do with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
