### PR TITLE
ALOHA: sort the tag in combine_name so Majorana MadLoop output links

### DIFF
--- a/aloha/aloha_writers.py
+++ b/aloha/aloha_writers.py
@@ -1741,6 +1741,13 @@ def combine_name(name, other_names, outgoing, tag=None, unknown_tag=False):
         else:
             return 'ALOHA_%s%s' % (str(hash(target_string.lower())).replace('-','m'), suffix)
 
+    if tag:
+        # same normalisation as get_routine_name, which sorts the tag before
+        # building the routine name; without it a loop wavefunction that also
+        # carries a conjugation flag is CALLed as FFS4L3C1_2 while ALOHA writes
+        # FFS4C1L3_2.
+        tag.sort()
+
     if tag and any(t.startswith('P') for t in tag[:-1]):
         # propagator need to be the last entry for the tag
         for i,t  in enumerate(tag):


### PR DESCRIPTION
`fa710f7ad` ("fixing some MSSM flavor merging issue") added `tag.sort()` to `aloha/aloha_writers.py :: get_routine_name`, so ALOHA now writes a loop wavefunction that also carries a conjugation flag as `FFS4C1L3_2.f`. `combine_name`, which builds the corresponding CALL, was not given the same normalisation and still emits `CALL FFS4L3C1_2`, in the order the caller assembled the flags — `helas_call_writers` inserts the loop tag in front of the conjugation tags.

Every Majorana loop line therefore calls a routine no file defines, and MadLoop output fails at link time:

```
ld: symbol(s) not found for architecture arm64
  "_mp_ffs4l3c1_2_", referenced from: _ml5_0_mp_coef_construction_1_
  "_mp_ffv1l1c1_2_", ...
```

Nothing in the SM or EW test surface puts a conjugation flag on a loop line, so the default suites stayed green while all gluino and neutralino NLO output was broken.

## Why sort rather than revert

`06e163cb0` (2013, *"a small fix for calling the conjugated loop helas function, which will appear in process with majorana fermions"*) deliberately changed `flag.append("L")` to `flag.insert(0,"L")`: the L-before-C order at the call site was intentional and matched what ALOHA wrote when nothing sorted. `fa710f7ad` reordered the routine name from the other side and silently broke that.

Reverting `tag.sort()` also makes the tests pass, but presumably re-breaks the flavour merging it was added for. Sorting both sides retires the order-sensitivity instead of re-pinning it.

## Not the same as 3a3e2c4a4

`3a3e2c4a4` ("ALOHA: route the FLV flag through 'tags' for amplitudes in the cross-base name"), already on main, fixes the same *class* of bug in the same function — call site names a routine ALOHA did not write — but a different aspect: which placeholder carries the FLV `M` flag (`%(propa)s` vs `%(tags)s`) in the cross-base scheme. That flag never enters the `tag` list; it arrives through the format placeholders, and both naming schemes join `tag` before appending them. Disjoint statements, disjoint data. The link failure above reproduces on a pristine `main` that already contains `3a3e2c4a4`.

## MadGraph7 only

`fa710f7ad` is not on `mg5/3.8.0` — `get_routine_name` there has no sort — so this fix must not be ported upstream: it would make the call side sort while the routine side does not, which is how you would *introduce* the mismatch. Confirmed empirically: the MSSM MadLoop comparisons link and pass on 3.8.0 with no change to `combine_name`.

## Tests

| suite | result |
| --- | --- |
| `./tests/test_manager.py -p U loop` | 2 failures, both pre-existing `standalone_cpp` naming, identical on an untouched tree |
| `LoopSquaredOrder_IOTest` | 1/1 |
| `short_ML_SMQCD_default` / `_optimized` | 2/2 each |
| `long_ML_SMQCD_default` / `_optimized` | 2/2 each |
| `short_ML_SMQCD_LoopInduced` | 1/1 |
| `IOExportFKSTest` | 6/6 |
| `test_short_mssm_vs_stored_HCR_gg_gogo_QCD` | OK (link error before this change) |
| `test_long_mssm_vs_stored_HCR_gg_gogog_QCD` | OK |
| `test_long_mssm_vs_stored_HCR_uux_gogog_QCD`, `gg_t1t1xg`, `gg_n1n1`, `uux_gogo` | OK |

Note `combine_name` is also called from the ALOHA writer side with the routine's own tag (`aloha_writers.py:1329`, `2400`, `3114`), and that same list is read a few lines later for `data['addon'] = ''.join(self.tag)`. Sorting in place therefore reorders it — the goldens above cover that path and are unchanged, because those tags already arrive sorted. The function already mutated `tag` in place via the propagator shuffle, so this is not a new class of side effect.

## Related

The loop-wavefunction mother corruption originally in this PR ([LP#2159043](https://bugs.launchpad.net/mg5amcnlo/+bug/2159043)) is an upstream bug present in 3.8.0 verbatim, and has moved to mg5amcnlo/mg5amcnlo#414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
