### PR TITLE
Read the PDF sets from CVMFS when it is mounted

### DIFF
--- a/Template/LO/SubProcesses/refine.sh
+++ b/Template/LO/SubProcesses/refine.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
 # For support of LHAPATH in cluster mode
+# LHAPDF 6 only falls back to LHAPATH when LHAPDF_DATA_PATH is unset, so
+# extend that one too when the node inherited it.
 if [ $CLUSTER_LHAPATH ]; then
+  if [ $LHAPDF_DATA_PATH ]; then
+    export LHAPDF_DATA_PATH=$LHAPDF_DATA_PATH:$CLUSTER_LHAPATH;
+  fi
   export LHAPATH=$CLUSTER_LHAPATH;
 fi
 

--- a/Template/LO/SubProcesses/refine_splitted.sh
+++ b/Template/LO/SubProcesses/refine_splitted.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
 # For support of LHAPATH in cluster mode
+# LHAPDF 6 only falls back to LHAPATH when LHAPDF_DATA_PATH is unset, so
+# extend that one too when the node inherited it.
 if [ $CLUSTER_LHAPATH ]; then
+  if [ $LHAPDF_DATA_PATH ]; then
+    export LHAPDF_DATA_PATH=$LHAPDF_DATA_PATH:$CLUSTER_LHAPATH;
+  fi
   export LHAPATH=$CLUSTER_LHAPATH;
 fi
 if [[ -e MadLoop5_resources.tar.gz && ! -e MadLoop5_resources ]]; then

--- a/Template/LO/SubProcesses/survey.sh
+++ b/Template/LO/SubProcesses/survey.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
 # For support of LHAPATH in cluster mode
-if [ $CLUSTER_LHAPATH ]; then 
+# LHAPDF 6 only falls back to LHAPATH when LHAPDF_DATA_PATH is unset, so
+# extend that one too when the node inherited it.
+if [ $CLUSTER_LHAPATH ]; then
+  if [ $LHAPDF_DATA_PATH ]; then
+    export LHAPDF_DATA_PATH=$LHAPDF_DATA_PATH:$CLUSTER_LHAPATH;
+  fi
   export LHAPATH=$CLUSTER_LHAPATH;
 fi
 

--- a/input/.mg7_configuration_default.txt
+++ b/input/.mg7_configuration_default.txt
@@ -147,6 +147,13 @@
 #! to avoid to send them to the node (if cluster_temp_path is on True or condor)
 # cluster_local_path =  None # example: /cvmfs/cp3.uclouvain.be/madgraph/
 
+#! Directory of the LHAPDF sets mirrored via CVMFS. When it is mounted, a PDF
+#!  set found there is read from it directly: never downloaded, never copied
+#!  into lib/PDFsets and therefore never transferred to the cluster nodes.
+#!  A path which is not mounted is ignored, so this default is safe everywhere.
+#!  Set it to None to switch that fallback off.
+# cvmfs_lhapdf_path = /cvmfs/sft.cern.ch/lcg/external/lhapdfsets/current
+
 #! Cluster waiting time for status update 
 #!  First number is when the number of waiting job is higher than the number 
 #!  of running one (time in second). The second number is in the second case.

--- a/madgraph/interface/amcatnlo_run_interface.py
+++ b/madgraph/interface/amcatnlo_run_interface.py
@@ -5097,7 +5097,7 @@ RESTART = %(mint_mode)s
             # Find the correct PDF input file
             input_files, output_files = [], []
             pdfinput = self.get_pdf_input_filename()
-            if os.path.exists(pdfinput):
+            if pdfinput.strip() and os.path.exists(pdfinput):
                 input_files.append(pdfinput)
             input_files.append(pjoin(os.path.dirname(exe), os.path.pardir, 'reweight_xsec_events'))
             input_files.append(pjoin(cwd, os.path.pardir, 'leshouche_info.dat'))
@@ -5280,7 +5280,7 @@ RESTART = %(mint_mode)s
 
         #Find the correct PDF input file
         pdfinput = self.get_pdf_input_filename()
-        if os.path.exists(pdfinput):
+        if pdfinput.strip() and os.path.exists(pdfinput):
             input_files.append(pdfinput)            
         return input_files, output_files, required_output,  args
 

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -682,6 +682,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                        'cluster_status_update': (600, 30),
                        'cluster_nb_retry':1,
                        'cluster_local_path': None,
+                       'cvmfs_lhapdf_path': misc.CVMFS_LHAPDF_PATH,
                        'cluster_retry_wait':300,
                        'heptools_install_dir': pjoin(root_path,'HEPTools'),}
 
@@ -3721,7 +3722,10 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
     ############################################################################
     def get_pdf_input_filename(self):
-        """return the name of the file which is used by the pdfset"""
+        """return the name of the file which has to be shipped with a job for
+        the PDF to be readable from the node. An empty string means that the
+        node reads the PDF on its own (CVMFS, cluster_local_path) and that
+        nothing has to be transferred."""
 
         if self.options["cluster_local_path"] and \
                os.path.exists(self.options["cluster_local_path"]) and \
@@ -3735,13 +3739,12 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                         self.options['run_mode'] !=1:
                 return path
             main = self.options["cluster_local_path"]
-            if os.path.isfile(path):
-                filename = os.path.basename(path)
+            filename = os.path.basename(path)
             possible_path = [pjoin(main, filename),
-                             pjoin(main, "lhadpf", filename),
+                             pjoin(main, "lhapdf", filename),
                              pjoin(main, "Pdfdata", filename)]
             if any(os.path.exists(p) for p in possible_path):
-                return " "
+                return ''
             else:
                 return path
                              
@@ -3757,12 +3760,14 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     self.pdffile = check_cluster(pjoin(self.me_dir, 'lib', 'Pdfdata', data[2]))
                     return self.pdffile
             else:
-                # possible when using lhapdf
+                # possible when using lhapdf. copy_lhapdf_set leaves that
+                # directory empty for every set served by a shared path, so an
+                # empty one means there is nothing to send to the node.
                 path = pjoin(self.me_dir, 'lib', 'PDFsets')
-                if os.path.exists(path):
+                if os.path.isdir(path) and os.listdir(path):
                     self.pdffile = path
                 else:
-                    self.pdffile = " "
+                    self.pdffile = ''
                 return self.pdffile
                       
     ############################################################################
@@ -4401,7 +4406,13 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             else:
                 name = name.strip()
                 value = value.strip()
-                if name.endswith('_path') and not name.startswith('cluster'):
+                # 'cluster_local_path' and 'cvmfs_lhapdf_path' name a
+                # directory on the *worker node*: it may well not exist here,
+                # and resolving symlinks ('.../lhapdfsets/current') would pin a
+                # version the node does not necessarily have.
+                if name.endswith('_path') and \
+                        not name.startswith('cluster') and \
+                        name != 'cvmfs_lhapdf_path':
                     path = value
                     if os.path.isdir(path):
                         self.options[name] = os.path.realpath(path)
@@ -4424,7 +4435,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         # delphes/pythia/... path
         for key in self.options:
             # Final cross check for the path
-            if key.endswith('path') and not key.startswith("cluster"):
+            if key.endswith('path') and not key.startswith("cluster") \
+                    and key != 'cvmfs_lhapdf_path':
                 path = self.options[key]
                 if path is None:
                     continue
@@ -4441,6 +4453,10 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                         self.options[key] = os.path.realpath(path)
                         continue
                 self.options[key] = None
+            elif key == 'cvmfs_lhapdf_path':
+                if isinstance(self.options[key], str) and \
+                        self.options[key].strip().lower() in ('none', ''):
+                    self.options[key] = None
             elif key.startswith('cluster') and key != 'cluster_status_update':
                 if key in ('cluster_nb_retry','cluster_wait_retry'):
                     self.options[key] = int(self.options[key]) 
@@ -4891,6 +4907,12 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         """
         if not pdfset_dir or not os.path.isdir(pdfset_dir):
             return
+        if not os.access(pdfset_dir, os.W_OK):
+            # a read-only share (CVMFS, a central install): nothing to patch
+            # here, and warning about it on every run is only noise
+            logger.debug('%s is read-only: skipping the LHAPDF metadata patch',
+                         pdfset_dir)
+            return
         try:
             info_names = [n for n in os.listdir(pdfset_dir) if n.endswith('.info')]
         except OSError:
@@ -4933,6 +4955,61 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     'file manually.',
                     ', '.join(e2.split(':')[0] for e2 in extra), path, e)
 
+
+    def get_shared_pdfsets_dirs(self):
+        """Directories holding LHAPDF sets that every node of this run can read
+        on its own, so that a set found there needs neither to be downloaded
+        nor to be shipped along with the job.
+
+        Two sources, in that order:
+        - the CVMFS mirror ('cvmfs_lhapdf_path'), when it is mounted. CVMFS is
+          a read-only network filesystem, so a mounted mirror is available to
+          the local run as well as to the cluster nodes;
+        - 'cluster_local_path', a node-local directory declared by the user.
+          That one says nothing about the submitting machine, so it is only
+          trusted for an actual cluster run (run_mode 1).
+        """
+
+        dirs = []
+        cvmfs = misc.get_cvmfs_lhapdf_path(self.options)
+        if cvmfs:
+            dirs.append(cvmfs)
+
+        local = self.options.get("cluster_local_path")
+        if local and self.options.get("run_mode") == 1:
+            dirs += [local,
+                     pjoin(local, "lhapdf"),
+                     pjoin(local, "lhapdf", "pdfsets"),
+                     pjoin(local, os.pardir, "lhapdf"),
+                     pjoin(local, os.pardir, "lhapdf", "pdfsets"),
+                     pjoin(local, os.pardir, "lhapdf", "pdfsets", "6.1"),
+                     ]
+        return dirs
+
+    @staticmethod
+    def use_shared_pdfsets_dir(path, default_dir=None):
+        """Make *path* part of the LHAPDF search path for this run.
+
+        LHAPATH is what the Template survey.sh/refine.sh re-export on the node
+        (through CLUSTER_LHAPATH). LHAPDF 6 only falls back to LHAPATH when
+        LHAPDF_DATA_PATH is unset, so that one is extended too when it is set.
+        *default_dir* (the local PDF-set directory) is kept in the list: once
+        LHAPATH is defined LHAPDF no longer looks into its own datadir, and a
+        run can well need one set from the mirror and another one from there.
+        """
+
+        def extend(var, entries):
+            current = [p for p in os.environ.get(var, '').split(':') if p]
+            for entry in entries:
+                if entry and entry not in current:
+                    current.append(entry)
+            if current:
+                os.environ[var] = ':'.join(current)
+
+        extend('LHAPATH', [default_dir, path])
+        os.environ['CLUSTER_LHAPATH'] = os.environ['LHAPATH']
+        if os.environ.get('LHAPDF_DATA_PATH'):
+            extend('LHAPDF_DATA_PATH', [path])
 
     def copy_lhapdf_set(self, lhaid_list, pdfsets_dir, require_local=True):
         """copy (if needed) the lhapdf set corresponding to the lhaid in lhaid_list
@@ -4983,16 +5060,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     except Exception as error:
                         logger.debug('%s', error)
         
-        if self.options["cluster_local_path"]:
-            lhapdf_cluster_possibilities = [self.options["cluster_local_path"],
-                                      pjoin(self.options["cluster_local_path"], "lhapdf"),
-                                      pjoin(self.options["cluster_local_path"], "lhapdf", "pdfsets"),
-                                      pjoin(self.options["cluster_local_path"], "..", "lhapdf"),
-                                      pjoin(self.options["cluster_local_path"], "..", "lhapdf", "pdfsets"),
-                                      pjoin(self.options["cluster_local_path"], "..", "lhapdf","pdfsets", "6.1")
-                                      ]
-        else:
-            lhapdf_cluster_possibilities = []
+        lhapdf_shared_possibilities = self.get_shared_pdfsets_dirs()
 
         for pdfset in pdfsetname:
             # Patch the *source* set (the one LHAPDF actually loads from its
@@ -5002,21 +5070,26 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             # Done here (before the early 'continue's) so it always runs.
             self.patch_lhapdf_info_file(pjoin(pdfsets_dir, pdfset))
         # Check if we need to copy the pdf
-            if self.options["cluster_local_path"] and self.options["run_mode"] == 1 and \
-                any((os.path.exists(pjoin(d, pdfset)) for d in lhapdf_cluster_possibilities)):
-    
-                os.environ["LHAPATH"] = [d for d in lhapdf_cluster_possibilities if os.path.exists(pjoin(d, pdfset))][0]
-                os.environ["CLUSTER_LHAPATH"] = os.environ["LHAPATH"]
-                self.patch_lhapdf_info_file(pjoin(os.environ["LHAPATH"], pdfset))
-                # no need to copy it
-                if os.path.exists(pjoin(pdfsets_dir, pdfset)):
+            shared = next((d for d in lhapdf_shared_possibilities
+                           if os.path.exists(pjoin(d, pdfset))), None)
+            if shared:
+                # the set is readable from every node of this run (CVMFS or a
+                # user-declared node-local mirror): point LHAPDF at it, and
+                # neither download it nor keep a copy under lib/PDFsets --
+                # that copy is what would be shipped to the worker node.
+                logger.info('Using the PDF set %s from %s', pdfset, shared)
+                self.use_shared_pdfsets_dir(shared, pdfsets_dir)
+                self.patch_lhapdf_info_file(pjoin(shared, pdfset))
+                local_copy = pjoin(self.me_dir, 'lib', 'PDFsets', pdfset)
+                if os.path.exists(local_copy):
                     try:
-                        if os.path.isdir(pjoin(pdfsets_dir, name)):
-                            shutil.rmtree(pjoin(pdfsets_dir, name))
+                        if os.path.isdir(local_copy):
+                            shutil.rmtree(local_copy)
                         else:
-                            os.remove(pjoin(pdfsets_dir, name))
+                            os.remove(local_copy)
                     except Exception as error:
                         logger.debug('%s', error)
+                continue
             if not require_local and (os.path.exists(pjoin(pdfsets_dir, pdfset)) or \
                                     os.path.isdir(pjoin(pdfsets_dir, pdfset))):
                 self.patch_lhapdf_info_file(pjoin(pdfsets_dir, pdfset))
@@ -5288,8 +5361,12 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             for totry in datadir.split(':'):
                 if os.path.exists(pjoin(totry, 'pdfsets.index')):
                     return totry
-            else:
-                return None
+            # no index anywhere: keep the first directory that does exist
+            # rather than None, which every caller then joins paths onto
+            for totry in datadir.split(':'):
+                if totry and os.path.isdir(totry):
+                    return totry
+            return None
         
         return datadir
 

--- a/madgraph/interface/madevent_interface.py
+++ b/madgraph/interface/madevent_interface.py
@@ -6308,8 +6308,11 @@ tar -czf split_$1.tar.gz split_$1
                 required_output = []
                 
 
-                #Find the correct PDF input file
-                input_files.append(self.get_pdf_input_filename())
+                #Find the correct PDF input file ('' when the node reads it
+                # on its own -- CVMFS/cluster_local_path -- so nothing to send)
+                pdfinput = self.get_pdf_input_filename()
+                if pdfinput.strip():
+                    input_files.append(pdfinput)
                         
                 #Find the correct ajob
                 Gre = re.compile(r"\s*j=(G[\d\.\w]+)")
@@ -6349,8 +6352,11 @@ tar -czf split_$1.tar.gz split_$1
                     input_files.append(pjoin(self.me_dir,'SubProcesses', 
                                                    'MadLoop5_resources.tar.gz'))
 
-                #Find the correct PDF input file
-                input_files.append(self.get_pdf_input_filename())
+                #Find the correct PDF input file ('' when the node reads it
+                # on its own -- CVMFS/cluster_local_path -- so nothing to send)
+                pdfinput = self.get_pdf_input_filename()
+                if pdfinput.strip():
+                    input_files.append(pdfinput)
 
 
                 output_files = []
@@ -6402,8 +6408,11 @@ tar -czf split_$1.tar.gz split_$1
                     input_files.append(pjoin(self.me_dir,'SubProcesses', 
                                                    'MadLoop5_resources.tar.gz'))
 
-                #Find the correct PDF input file
-                input_files.append(self.get_pdf_input_filename())
+                #Find the correct PDF input file ('' when the node reads it
+                # on its own -- CVMFS/cluster_local_path -- so nothing to send)
+                pdfinput = self.get_pdf_input_filename()
+                if pdfinput.strip():
+                    input_files.append(pdfinput)
 
 
                 output_files = [argument[0]]

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -3235,6 +3235,7 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
                        'cluster_temp_path':None,
                        'mg5amc_py8_interface_path': './HEPTools/MG5aMC_PY8_interface',
                        'cluster_local_path': None,
+                       'cvmfs_lhapdf_path': misc.CVMFS_LHAPDF_PATH,
                        'mg5amc_py8_interface_path': './HEPTools/MG5aMC_PY8_interface',
                        'OLP': 'MadLoop',
                        'cluster_nb_retry':1,
@@ -8965,6 +8966,20 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         args = ['max_npoint_for_channel'] + args
         self.check_set(args)
         self.options[args[0]] = int(args[1])
+
+    def set2_cvmfs_lhapdf_path(self, args, log=True):
+        """default=/cvmfs/sft.cern.ch/lcg/external/lhapdfsets/current
+        Directory of the LHAPDF sets mirrored via CVMFS. When that directory is
+        mounted, a PDF set found there is read directly from it: it is neither
+        downloaded nor copied into lib/PDFsets, and therefore not transferred to
+        the cluster nodes (which mount the same read-only filesystem).
+        A path that is not mounted is simply ignored; set the option to None to
+        switch the fallback off.
+        """
+        args = ['cvmfs_lhapdf_path'] + args
+        self.check_set(args)
+        value = args[1].strip()
+        self.options[args[0]] = None if value in ['None', 'none', ''] else value
 
     def set2_cluster_local_path(self, args, log=True):
         """default=None 

--- a/madgraph/interface/madweight_interface.py
+++ b/madgraph/interface/madweight_interface.py
@@ -464,10 +464,13 @@ class MadWeightCmd(CmdExtended, HelpToCmd, CompleteForCmd, common_run.CommonRunC
         
         input_files = [pjoin(self.me_dir, 'SubProcesses', dirname, 'comp_madweight'), 
                        pjoin(self.me_dir, 'Cards', 'param_card_%i.dat' % nb_card),
-                       self.get_pdf_input_filename(),
                        pjoin(self.me_dir, 'Cards', 'ident_card.dat'),
                        pjoin(self.me_dir, 'Cards', 'run_card.dat')
                        ]
+        # empty when the node reads the PDF on its own (CVMFS/cluster_local_path)
+        pdfinput = self.get_pdf_input_filename()
+        if pdfinput.strip():
+            input_files.insert(2, pdfinput)
         
         # add event_file:
         if not evt_file:

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -1380,6 +1380,22 @@ C
          """ % {"path" : self.opt["cluster_local_path"]}
             changer = {"cluster_specific_path": to_add}
 
+        # The CVMFS mirror is tried after every local candidate, so that a set
+        # copied into lib/PDFsets still wins. Emitting it costs nothing when
+        # CVMFS is not mounted (the Inquire simply fails), and the directory
+        # may well be mounted on the running node but not on this one, so it is
+        # written out without checking that it exists here.
+        cvmfs = self.opt.get("cvmfs_lhapdf_path", misc.CVMFS_LHAPDF_PATH)
+        if not cvmfs:
+            changer["cvmfs_specific_path"] = ""
+        else:
+            changer["cvmfs_specific_path"] = """
+         LHAPath='%(path)s'
+         Inquire(File=LHAPath, exist=exists)
+         if(exists)return
+         LHAPath='./PDFsets'
+         """ % {"path": cvmfs}
+
         # this is for LHAPDF
         ff = writers.FortranWriter(pjoin(self.dir_path, "Source", "PDF", "pdfwrap_lhapdf.f"))        
         #ff = open(pjoin(self.dir_path, "Source", "PDF", "pdfwrap_lhapdf.f"),"w")
@@ -11654,6 +11670,8 @@ def ExportV4Factory(cmd, noclean, output_type='default', group_subprocesses=True
       'compute_color_flows':cmd.options['loop_color_flows'],
       'mode': 'reweight' if cmd._export_format == "standalone_rw" else '',
       'cluster_local_path': cmd.options['cluster_local_path'],
+      'cvmfs_lhapdf_path': cmd.options.get('cvmfs_lhapdf_path',
+                                           misc.CVMFS_LHAPDF_PATH),
       'output_options': cmd_options
       }
 

--- a/madgraph/iolibs/template_files/pdf_wrap_emela.f
+++ b/madgraph/iolibs/template_files/pdf_wrap_emela.f
@@ -71,6 +71,9 @@ c     first try in the current directory
          Inquire(File=LHAPath, exist=exists)
          if(exists)return
       enddo
+c     shared read-only mirror (CVMFS): tried last, so that a local
+c     lib/PDFsets always wins over it
+      %(cvmfs_specific_path)s
 
 c      
 c     getting the path of the executable

--- a/madgraph/iolibs/template_files/pdf_wrap_lhapdf.f
+++ b/madgraph/iolibs/template_files/pdf_wrap_lhapdf.f
@@ -71,6 +71,9 @@ c     first try in the current directory
          Inquire(File=LHAPath, exist=exists)
          if(exists)return
       enddo
+c     shared read-only mirror (CVMFS): tried last, so that a local
+c     lib/PDFsets always wins over it
+      %(cvmfs_specific_path)s
 
 c      
 c     getting the path of the executable

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -2494,6 +2494,32 @@ def _lhapdf_datadirs(exe):
     return _lhapdf_datadirs_cache[exe]
 
 
+# The LHAPDF sets mirrored on CVMFS. Where it is mounted -- most grid and
+# laboratory clusters -- it is a complete, read-only, node-local copy of the
+# sets, so a set found there needs neither a download nor a transfer to the
+# worker node.
+CVMFS_LHAPDF_PATH = '/cvmfs/sft.cern.ch/lcg/external/lhapdfsets/current'
+
+def get_cvmfs_lhapdf_path(options=None):
+    """Return the CVMFS PDF-set mirror to use, or None.
+
+    The location is configurable ('cvmfs_lhapdf_path'); setting it to None
+    switches the fallback off. A configured path that is not mounted is
+    simply ignored, so the default value is safe on any machine.
+    """
+
+    path = CVMFS_LHAPDF_PATH
+    if options is not None:
+        try:
+            path = options.get('cvmfs_lhapdf_path', CVMFS_LHAPDF_PATH)
+        except AttributeError:
+            pass
+    if not path or str(path).strip().lower() in ('none', 'false', ''):
+        return None
+    path = str(path).strip()
+    return path if os.path.isdir(path) else None
+
+
 def _writable_dir(path):
     """True if *path* is a writable directory or can be created as one."""
 
@@ -2555,6 +2581,12 @@ def resolve_lhapdf(options=None, root=None, use_env=True, create=False):
     search += data_dirs
     search.append(pjoin(heptools, 'lhapdf_pdfsets'))
     search.append(pjoin(root, 'lhapdf_pdfsets'))
+    # last resort before a download: the read-only CVMFS mirror. It is never a
+    # download target -- _writable_dir rejects it -- so it only ever spares us
+    # from fetching a set that is already on the machine.
+    cvmfs = get_cvmfs_lhapdf_path(options)
+    if cvmfs:
+        search.append(cvmfs)
     search = [os.path.abspath(p) for p in search]
 
     data_paths = []

--- a/tests/acceptance_tests/test_cmd.py
+++ b/tests/acceptance_tests/test_cmd.py
@@ -228,6 +228,8 @@ class TestCmdShell1(unittest.TestCase):
                     'cluster_size': 100,
                     'loop_color_flows': False,
                     'cluster_local_path': None,
+                    'cvmfs_lhapdf_path':
+                              '/cvmfs/sft.cern.ch/lcg/external/lhapdfsets/current',
                     'max_npoint_for_channel': 0,
                     'low_mem_multicore_nlo_generation': False,
                     'ninja': './HEPTools/lib',

--- a/tests/unit_tests/interface/test_madevent.py
+++ b/tests/unit_tests/interface/test_madevent.py
@@ -299,15 +299,22 @@ AlphaS_Type: ipol
         if self.saved_datapath is not None:
             os.environ['LHAPDF_DATA_PATH'] = self.saved_datapath
 
-    def get_fake_cmd(self):
+    def get_fake_cmd(self, **options):
         common_run = self.common_run
         class FakeRunCmd(object):
             patch_lhapdf_info_file = staticmethod(
                           common_run.CommonRunCmd.patch_lhapdf_info_file)
+            use_shared_pdfsets_dir = staticmethod(
+                          common_run.CommonRunCmd.use_shared_pdfsets_dir)
+            get_shared_pdfsets_dirs = common_run.CommonRunCmd.get_shared_pdfsets_dirs
             copy_lhapdf_set = common_run.CommonRunCmd.copy_lhapdf_set
         cmd = FakeRunCmd()
         cmd.me_dir = self.me_dir
-        cmd.options = {'cluster_local_path': None, 'run_mode': 2}
+        # cvmfs_lhapdf_path is None unless a test asks for it: the default
+        # points at a real mount which may exist on the machine running this
+        cmd.options = {'cluster_local_path': None, 'run_mode': 2,
+                       'cvmfs_lhapdf_path': None}
+        cmd.options.update(options)
         cmd.lhapdf_pdfsets = {}
         return cmd
 
@@ -351,3 +358,98 @@ AlphaS_Type: ipol
         self.assertFalse(os.path.exists(local_set))
         self.assertIn('AlphaS_FlavorScheme: variable', open(global_info).read())
         self.assertIn('AlphaS_NumFlavors: 5', open(global_info).read())
+
+class TestSharedPdfsetsDir(unittest.TestCase):
+    """a PDF set readable from every node (CVMFS, or the user-declared
+    cluster_local_path) is used in place, so it is never copied into
+    lib/PDFsets -- which is exactly what would be shipped to the node."""
+
+    def setUp(self):
+        import madgraph.interface.common_run_interface as common_run
+        self.common_run = common_run
+        self.tmpdir = tempfile.mkdtemp(prefix='mg5_cvmfs_test')
+        # stand-in for /cvmfs/sft.cern.ch/lcg/external/lhapdfsets/current
+        self.cvmfs = pjoin(self.tmpdir, 'cvmfs')
+        os.makedirs(pjoin(self.cvmfs, 'MYSET'))
+        # the local LHAPDF data directory, holding a different set
+        self.pdfsets_dir = pjoin(self.tmpdir, 'share', 'LHAPDF')
+        os.makedirs(pjoin(self.pdfsets_dir, 'OTHERSET'))
+        self.me_dir = pjoin(self.tmpdir, 'PROC')
+        os.makedirs(pjoin(self.me_dir, 'lib', 'PDFsets'))
+        self.saved = {key: os.environ.get(key) for key in
+                      ('LHAPATH', 'CLUSTER_LHAPATH', 'LHAPDF_DATA_PATH')}
+        for key in self.saved:
+            os.environ.pop(key, None)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        for key, value in self.saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def get_fake_cmd(self, **options):
+        common_run = self.common_run
+        class FakeRunCmd(object):
+            patch_lhapdf_info_file = staticmethod(
+                          common_run.CommonRunCmd.patch_lhapdf_info_file)
+            use_shared_pdfsets_dir = staticmethod(
+                          common_run.CommonRunCmd.use_shared_pdfsets_dir)
+            get_shared_pdfsets_dirs = common_run.CommonRunCmd.get_shared_pdfsets_dirs
+            copy_lhapdf_set = common_run.CommonRunCmd.copy_lhapdf_set
+            get_pdf_input_filename = common_run.CommonRunCmd.get_pdf_input_filename
+        cmd = FakeRunCmd()
+        cmd.me_dir = self.me_dir
+        cmd.options = {'cluster_local_path': None, 'run_mode': 2,
+                       'cvmfs_lhapdf_path': self.cvmfs}
+        cmd.options.update(options)
+        cmd.lhapdf_pdfsets = {}
+        return cmd
+
+    def test_set_on_cvmfs_is_not_copied_locally(self):
+        cmd = self.get_fake_cmd()
+        cmd.copy_lhapdf_set(['MYSET'], self.pdfsets_dir)
+        self.assertFalse(os.path.exists(
+                              pjoin(self.me_dir, 'lib', 'PDFsets', 'MYSET')))
+        # ... and LHAPDF is told where to read it, keeping the local dir too
+        self.assertIn(self.cvmfs, os.environ['LHAPATH'].split(':'))
+        self.assertIn(self.pdfsets_dir, os.environ['LHAPATH'].split(':'))
+        self.assertEqual(os.environ['CLUSTER_LHAPATH'], os.environ['LHAPATH'])
+
+    def test_nothing_is_shipped_to_the_node(self):
+        """an empty lib/PDFsets means the node reads the PDF on its own"""
+
+        cmd = self.get_fake_cmd()
+        cmd.run_card = {'pdlabel': 'lhapdf'}
+        # no Source/PDF/pdf_list.txt: the lhapdf branch is the one reached
+        os.makedirs(pjoin(self.me_dir, 'Source', 'PDF'))
+        open(pjoin(self.me_dir, 'Source', 'PDF', 'pdf_list.txt'), 'w').close()
+        cmd.copy_lhapdf_set(['MYSET'], self.pdfsets_dir)
+        self.assertEqual(cmd.get_pdf_input_filename(), '')
+        # a set which is NOT on the mirror is copied, and then shipped
+        cmd = self.get_fake_cmd()
+        cmd.run_card = {'pdlabel': 'lhapdf'}
+        cmd.copy_lhapdf_set(['OTHERSET'], self.pdfsets_dir)
+        self.assertTrue(os.path.isdir(
+                            pjoin(self.me_dir, 'lib', 'PDFsets', 'OTHERSET')))
+        self.assertEqual(cmd.get_pdf_input_filename(),
+                         pjoin(self.me_dir, 'lib', 'PDFsets'))
+
+    def test_cvmfs_disabled(self):
+        """with the mirror switched off, the ordinary local copy is made"""
+
+        cmd = self.get_fake_cmd(cvmfs_lhapdf_path=None)
+        self.assertEqual(cmd.get_shared_pdfsets_dirs(), [])
+        # OTHERSET lives in the local data dir, not on the mirror
+        cmd.copy_lhapdf_set(['OTHERSET'], self.pdfsets_dir)
+        self.assertTrue(os.path.isdir(
+                            pjoin(self.me_dir, 'lib', 'PDFsets', 'OTHERSET')))
+        self.assertNotIn('CLUSTER_LHAPATH', os.environ)
+
+    def test_cluster_local_path_only_for_a_cluster_run(self):
+        cmd = self.get_fake_cmd(cvmfs_lhapdf_path=None,
+                                cluster_local_path=self.cvmfs)
+        self.assertEqual(cmd.get_shared_pdfsets_dirs(), [])
+        cmd.options['run_mode'] = 1
+        self.assertEqual(cmd.get_shared_pdfsets_dirs()[0], self.cvmfs)

--- a/tests/unit_tests/various/test_lhapdf_resolve.py
+++ b/tests/unit_tests/various/test_lhapdf_resolve.py
@@ -121,6 +121,9 @@ class TestResolveLhapdf(unittest.TestCase):
         return exe
 
     def resolve(self, **options):
+        # the CVMFS mirror is a real path which may be mounted on the machine
+        # running the tests: opt out unless the test is about it
+        options.setdefault('cvmfs_lhapdf_path', None)
         return misc.resolve_lhapdf(options, root=self.root)
 
     def test_absolute_lhapdf(self):
@@ -183,11 +186,13 @@ class TestResolveLhapdf(unittest.TestCase):
         other = pjoin(self.tmpdir, 'other')
         os.makedirs(pjoin(other, 'MYSET'))
         os.environ['LHAPDF_DATA_PATH'] = os.pathsep.join([other, self.datadir])
-        paths = misc.resolve_lhapdf({'lhapdf': self.exe}, root=self.root)
+        paths = misc.resolve_lhapdf({'lhapdf': self.exe,
+                                     'cvmfs_lhapdf_path': None}, root=self.root)
         self.assertEqual(paths.data_paths[0], other)
         self.assertEqual(paths.find_set('MYSET'), other)
         # ... and use_env=False ignores the environment entirely
-        paths = misc.resolve_lhapdf({'lhapdf': self.exe}, root=self.root,
+        paths = misc.resolve_lhapdf({'lhapdf': self.exe,
+                                     'cvmfs_lhapdf_path': None}, root=self.root,
                                     use_env=False)
         self.assertEqual(paths.data_paths, [self.datadir])
 
@@ -196,7 +201,8 @@ class TestResolveLhapdf(unittest.TestCase):
         os.makedirs(other)
         exe = self.write_config('lhaenv', other)
         os.environ['MADGRAPH_LHAPDF_CONFIG'] = exe
-        paths = misc.resolve_lhapdf({'lhapdf': self.exe}, root=self.root)
+        paths = misc.resolve_lhapdf({'lhapdf': self.exe,
+                                     'cvmfs_lhapdf_path': None}, root=self.root)
         self.assertEqual(paths.config, exe)
 
     def test_lhapdf_py3_fallback(self):
@@ -228,11 +234,30 @@ class TestResolveLhapdf(unittest.TestCase):
     def test_create_makes_the_download_directory(self):
         os.environ['PATH'] = pjoin(self.tmpdir, 'empty')
         target = pjoin(self.root, 'HEPTools', 'lhapdf_pdfsets')
-        paths = misc.resolve_lhapdf({}, root=self.root)
+        paths = misc.resolve_lhapdf({'cvmfs_lhapdf_path': None}, root=self.root)
         self.assertEqual(paths.download_path, target)
         self.assertFalse(os.path.isdir(target))
-        paths = misc.resolve_lhapdf({}, root=self.root, create=True)
+        paths = misc.resolve_lhapdf({'cvmfs_lhapdf_path': None}, root=self.root,
+                                    create=True)
         self.assertTrue(os.path.isdir(target))
+
+    def test_cvmfs_mirror_is_searched_last_and_never_downloaded_into(self):
+        """a set present on the CVMFS mirror is found there instead of being
+        downloaded, but the mirror is read-only so it is never a download
+        target"""
+
+        mirror = pjoin(self.tmpdir, 'cvmfs')
+        os.makedirs(pjoin(mirror, 'CVMFSSET'))
+        paths = self.resolve(lhapdf=self.exe, cvmfs_lhapdf_path=mirror)
+        self.assertEqual(paths.data_paths, [self.datadir, mirror])
+        self.assertEqual(paths.find_set('CVMFSSET'), mirror)
+        # the local data directory still wins for a set it holds
+        self.assertEqual(paths.find_set('MYSET'), self.datadir)
+        self.assertNotEqual(paths.download_path, mirror)
+        # a mirror which is not mounted is simply ignored
+        paths = self.resolve(lhapdf=self.exe,
+                             cvmfs_lhapdf_path=pjoin(self.tmpdir, 'nomount'))
+        self.assertEqual(paths.data_paths, [self.datadir])
 
     def test_with_data_path_promotes_a_directory(self):
         paths = self.resolve(lhapdf=self.exe)


### PR DESCRIPTION
## The `cluster_local_path` trick is still there — but it never skipped the copy

`copy_lhapdf_set` carries the "no need to copy it" branch from MG5, and it has **no `continue`**: with the default `require_local=True` (every madevent / aMC@NLO run) it set `LHAPATH` and then fell straight through to the copy block, putting the set into `lib/PDFsets` — which is exactly what then gets shipped to the node. It also deleted `pjoin(pdfsets_dir, name)`, `name` being a leftover from an earlier loop, so it aimed at the *global* LHAPDF directory rather than at the local copy.

## What this does

Fixes that branch and generalises it. A new `cvmfs_lhapdf_path` option, defaulting to `/cvmfs/sft.cern.ch/lcg/external/lhapdfsets/current`, is used in place whenever it is mounted: the set is neither downloaded, nor copied into `lib/PDFsets`, nor transferred to the cluster nodes. A path that is not mounted is ignored, so the default is safe on any machine, and `set cvmfs_lhapdf_path None` switches the fallback off. `cluster_local_path` keeps its `run_mode == 1` restriction; CVMFS is trusted in every run mode since it is a network filesystem the submitting machine sees too.

Whether a job needs the PDF shipped is now decided by "`lib/PDFsets` is non-empty" rather than by a flag, so a run taking one set from the mirror and downloading another still transfers what it must. The empty string `get_pdf_input_filename` returns in that case used to be appended blindly to `input_files` in three madevent sites and in madweight, producing an empty entry in condor's `transfer_input_files` list.

## Two runtime traps this uncovered

- **LHAPDF 6 falls back to `LHAPATH` only when `LHAPDF_DATA_PATH` is unset.** The pre-existing `CLUSTER_LHAPATH` mechanism was therefore silently ignored wherever `LHAPDF_DATA_PATH` is exported. `survey.sh` / `refine.sh` / `refine_splitted.sh` and the Python side now extend both.
- **Once `LHAPATH` is set it replaces LHAPDF's own datadir**, so the local pdfsets directory is kept in the list next to the mirror — otherwise a second set stops being found.

## Smaller fixes along the way

- `patch_lhapdf_info_file` no longer warns once per run trying to append to a read-only share.
- `get_lhapdf_pdfsetsdir_static` no longer returns `None` (which callers then `pjoin` onto) when no `pdfsets.index` is found in a multi-entry path.
- The generated `pdfwrap_lhapdf.f` / `pdfwrap_emela.f` try the mirror *after* every local candidate, so a populated `lib/PDFsets` still wins.
- `misc.resolve_lhapdf` (the mg7/madspace path) searches it last, and never as a download target.
- `get_pdf_input_filename`'s dead `check_cluster` loses its `lhadpf` typo and an `UnboundLocalError`.

## Testing

New unit tests in `test_madevent.py` (set on the mirror is not copied, nothing shipped, mixed case, disabled case, `cluster_local_path` only for `run_mode 1`) and `test_lhapdf_resolve.py`. `test_madevent`, `test_lhapdf_resolve` and `test_cmd` (unit + acceptance) pass.

The full unit suite reports 94 errors and 2 failures, all pre-existing and unrelated to this branch: the 94 are `ModuleNotFoundError: No module named 'numpy'` in the madspin tests under the Python 3.14 environment used locally, and the 2 are a MadLoop `MP__MDL_*` golden drift and the `standalone_cpp` loop-induced refusal message.

## One judgement call

Defaulting the option **on** means a cluster job now relies on the worker nodes mounting CVMFS when the submit host does. That is essentially always true — it is what CVMFS is for — but if you would rather have it opt-in, changing `misc.CVMFS_LHAPDF_PATH` to `None` is a one-line switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
