### PR TITLE
Machine-readable json output for parameter scans

### DIFF
--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -7879,8 +7879,11 @@ class RunCardIterator(object):
 
         if not path:
             return ff.getvalue()
-        
-         
+        ff.close()
+        param_card_reader.write_scan_summary_json(path, self.param_order, keys,
+                                                  to_print)
+
+
     def get_next_name(self, run_name):
         """returns a smart name for the next run"""
     

--- a/models/check_param_card.py
+++ b/models/check_param_card.py
@@ -6,6 +6,7 @@ import filecmp
 import xml.etree.ElementTree as ET
 import math
 
+import json
 import os
 import re
 import shutil
@@ -930,8 +931,56 @@ class ParamCardMP(ParamCard):
 
   
     
+def get_json_summary_path(path):
+    """returns the path of the machine-readable scan summary associated to the
+       human-readable one written at 'path'"""
+
+    if path.endswith('.txt'):
+        path = path[:-4]
+    return '%s.json' % path
+
+def write_scan_summary_json(path, param_order, keys, entries, ident=None):
+    """write the scan results in a json file (machine-readable counterpart of
+       the summary text file written by write_summary).
+       param_order/keys/entries are the ones used for the text summary and
+       ident (optional) maps a scanned parameter to its model variable name."""
+
+    def jsonify(value):
+        """json only handles the basic types, anything else is kept as text"""
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        return str(value)
+
+    scan_parameters = []
+    for name in param_order:
+        parameter = {'id': name}
+        if ident and name in ident:
+            parameter['name'] = ident[name]
+        scan_parameters.append(parameter)
+
+    points = []
+    for info in entries:
+        point = {'run_name': info['run_name'],
+                 'parameters': dict((name, jsonify(value)) for name, value in
+                                    zip(param_order, info['bench'])),
+                 'results': dict((k, jsonify(info[k]) if k in info else None)
+                                 for k in keys)}
+        if 'exception' in info:
+            point['exception'] = str(info['exception'])
+        points.append(point)
+
+    json_path = get_json_summary_path(path)
+    with open(json_path, 'w') as fsock:
+        json.dump({'scan_parameters': scan_parameters,
+                   'result_keys': list(keys),
+                   'points': points}, fsock, indent=2)
+        fsock.write('\n')
+    logger.info("write scan results in json format in %s" % json_path)
+    return json_path
+
+
 class ParamCardIterator(ParamCard):
-    """A class keeping track of the scan: flag in the param_card and 
+    """A class keeping track of the scan: flag in the param_card and
        having an __iter__() function to scan over all the points of the scan.
     """
 
@@ -1110,11 +1159,13 @@ class ParamCardIterator(ParamCard):
 
         if not path:
             return ff.getvalue()
-        
-         
+        ff.close()
+        write_scan_summary_json(path, self.param_order, keys, to_print, ident=ident)
+
+
     def get_next_name(self, run_name):
         """returns a smart name for the next run"""
-    
+
         if '_' in run_name:
             name, value = run_name.rsplit('_',1)
             if value.isdigit():

--- a/tests/acceptance_tests/test_cmd_madevent.py
+++ b/tests/acceptance_tests/test_cmd_madevent.py
@@ -2373,6 +2373,8 @@ C
         self.assertTrue(os.path.exists(pjoin(self.run_dir, 'Events', 'run_04')))
         self.assertTrue(os.path.exists(pjoin(self.run_dir, 'Events', 'scan_run_0[1-2].txt')))
         self.assertTrue(os.path.exists(pjoin(self.run_dir, 'Events', 'scan_run_0[3-4].txt')))
+        self.assertTrue(os.path.exists(pjoin(self.run_dir, 'Events', 'scan_run_0[1-2].json')))
+        self.assertTrue(os.path.exists(pjoin(self.run_dir, 'Events', 'scan_run_0[3-4].json')))
         
         banner1 = banner.Banner(pjoin(self.run_dir, 'Events','run_01', 'run_01_tag_1_banner.txt'))
         banner2 = banner.Banner(pjoin(self.run_dir, 'Events','run_02', 'run_02_tag_1_banner.txt'))                                

--- a/tests/unit_tests/various/test_banner.py
+++ b/tests/unit_tests/various/test_banner.py
@@ -16,6 +16,8 @@
 
 from __future__ import absolute_import
 import unittest
+import json
+import shutil
 import tempfile
 import madgraph.various.banner as bannermod
 import madgraph.various.misc as misc
@@ -1430,6 +1432,34 @@ class TestRunCardMG7(unittest.TestCase):
             self.assertIn(e_cm, (7000.0, 13000.0))
             # ren_scale and fact_scale1 share scan-id 1 -> always move together
             self.assertIn((ren, fac), [(91.0, 45.5), (172.0, 86.0)])
+
+    def test_run_card_scan_summary_json(self):
+        """RunCardIterator.write_summary also writes a json summary"""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            events = pjoin(tmpdir, 'Events')
+            for run in ['run_01', 'run_02']:
+                os.makedirs(pjoin(events, run))
+            it = bannermod.RunCardIterator.__new__(bannermod.RunCardIterator)
+            it.param_order = ['run_card#ebeam1']
+            it.cross = [
+                {'run_name': 'run_01', 'bench': [6500.], 'cross(pb)': 2.0, 'error(pb)': 0.1},
+                {'run_name': 'run_02', 'bench': [7000.], 'exception': ValueError('boom')},
+            ]
+            path = pjoin(events, 'scan_run_01.txt')
+            it.write_summary(path)
+            with open(pjoin(events, 'scan_run_01.json')) as fsock:
+                data = json.load(fsock)
+            self.assertEqual(data['scan_parameters'], [{'id': 'run_card#ebeam1'}])
+            self.assertEqual(data['points'][0]['parameters'], {'run_card#ebeam1': 6500.})
+            self.assertEqual(data['points'][0]['results'],
+                             {'cross(pb)': 2.0, 'error(pb)': 0.1})
+            # a point that crashed keeps its error message and has no result
+            self.assertEqual(data['points'][1]['exception'], 'boom')
+            self.assertEqual(data['points'][1]['results'],
+                             {'cross(pb)': None, 'error(pb)': None})
+        finally:
+            shutil.rmtree(tmpdir)
 
     def test_from_LO_conversion(self):
         """RunCardMG7.from_LO ports the supported LO settings and reports the rest"""

--- a/tests/unit_tests/various/test_check_param_card.py
+++ b/tests/unit_tests/various/test_check_param_card.py
@@ -14,10 +14,13 @@
 ################################################################################
 from __future__ import division
 from __future__ import absolute_import
+import json
 import random
 import io
 import os
+import shutil
 import sys
+import tempfile
 import tests.unit_tests as unittest
 
 _file_path = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
@@ -242,10 +245,59 @@ class TestParamCardIterator(unittest.TestCase):
             self.assertIn(choice, all_possibilities)
             all_possibilities.remove(choice)
             
-        self.assertEqual(i, 11)                    
+        self.assertEqual(i, 11)
         self.assertFalse(all_possibilities)
-        
-         
+
+    def test_scan_summary_json(self):
+        """write_summary also writes the same information in a json file"""
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            events = os.path.join(tmpdir, 'Events')
+            for run in ['run_01', 'run_02']:
+                os.makedirs(os.path.join(events, run))
+            os.makedirs(os.path.join(tmpdir, 'Cards'))
+            with open(os.path.join(tmpdir, 'Cards', 'ident_card.dat'), 'w') as fsock:
+                fsock.write('mass 6 mdl_MT\n')
+
+            itercard = writter.ParamCardIterator()
+            itercard.param_order = ['mass#6']
+            itercard.cross = [
+                {'run_name': 'run_01', 'bench': [170.], 'cross(pb)': 1.5,
+                 'error(pb)': 0.02, 'width#6': 1.3},
+                {'run_name': 'run_02', 'bench': [175.], 'cross(pb)': 1.7,
+                 'error(pb)': 0.03, 'width#6': 1.4},
+            ]
+            path = os.path.join(events, 'scan_run_01.txt')
+            itercard.write_summary(path)
+
+            json_path = os.path.join(events, 'scan_run_01.json')
+            self.assertTrue(os.path.exists(json_path))
+            with open(json_path) as fsock:
+                data = json.load(fsock)
+
+            self.assertEqual(data['scan_parameters'],
+                             [{'id': 'mass#6', 'name': 'mt'}])
+            self.assertEqual(sorted(data['result_keys']),
+                             ['cross(pb)', 'error(pb)', 'width#6'])
+            self.assertEqual([p['run_name'] for p in data['points']],
+                             ['run_01', 'run_02'])
+            self.assertEqual(data['points'][0]['parameters'], {'mass#6': 170.})
+            self.assertEqual(data['points'][1]['results'],
+                             {'cross(pb)': 1.7, 'error(pb)': 0.03, 'width#6': 1.4})
+
+            # the text and the json summary have to agree
+            with open(path) as fsock:
+                lines = [l.split() for l in fsock if not l.startswith('#')]
+            for line, point in zip(lines, data['points']):
+                self.assertEqual(line[0], point['run_name'])
+                values = [point['parameters'][p['id']] for p in data['scan_parameters']]
+                values += [point['results'][k] for k in data['result_keys']]
+                self.assertEqual([float(x) for x in line[1:]], values)
+        finally:
+            shutil.rmtree(tmpdir)
+
+
 class TestParamCardRule(unittest.TestCase):
     """ Test the ParamCardRule Object"""
     


### PR DESCRIPTION
## Summary

Parameter scans (multiple runs started automatically from `scan:[...]` entries in the param_card or the run_card) so far produced only the fixed-width human-readable summary `Events/scan_<name>.txt`. This adds a second file, `Events/scan_<name>.json`, holding the same results in a machine-readable format.

## Implementation

New `write_scan_summary_json` (plus `get_json_summary_path`) in `models/check_param_card.py`, called at the end of `ParamCardIterator.write_summary` and of `RunCardIterator.write_summary`. Since every scan driver funnels through `write_summary`, they all get the json for free: the `scanparamcardhandling` decorator (param_card and run_card scans, LO and NLO), `do_multi_run`, and the MG7 `launch.py` scan.

```json
{
  "scan_parameters": [ {"id": "mass#6", "name": "mt"} ],
  "result_keys": ["width#6", "cross(pb)", "error(pb)"],
  "points": [
    {"run_name": "run_01",
     "parameters": {"mass#6": 170.0},
     "results": {"width#6": 1.3, "cross(pb)": 1.5, "error(pb)": 0.02}}
  ]
}
```

Rows and columns follow the same order as the text table and cover every result column (cross section, error, scale/PDF variations, auto-widths, plugin entries). Two things the text file cannot express are added: the model variable name of each scanned parameter (resolved from `Cards/ident_card.dat`, as already done for the per-run `params.dat`), and a missing value written as `null` instead of the text file's `0.` — a point that crashed additionally carries its error message in an `exception` field.

## Test plan

- New unit test in `tests/unit_tests/various/test_check_param_card.py` (param_card scan; also checks the text and the json summary agree row by row).
- New unit test in `tests/unit_tests/various/test_banner.py` (run_card scan, including a point that crashed).
- The madevent acceptance scan test now also asserts the `.json` files exist.
- `python tests/test_manager.py -p U various` -> 396 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)