### PR TITLE
Fix UFO custom propagators in the C++/madmatrix backend

### DIFF
--- a/aloha/create_aloha.py
+++ b/aloha/create_aloha.py
@@ -1233,7 +1233,7 @@ class AbstractALOHAModel(dict):
                         self[(lorentzname, outgoing)].add_combine(list_l_name[1:])
                     continue
 
-                builder = CombineRoutineBuilder(l_lorentz)
+                builder = CombineRoutineBuilder(l_lorentz, self.model)
                                
                 for conjg in request[list_l_name[0]]:
                     #ensure that routines are in rising order (for symetries)

--- a/madgraph/iolibs/template_files/madmatrix/mgOnGpuVectors.h
+++ b/madgraph/iolibs/template_files/madmatrix/mgOnGpuVectors.h
@@ -10,6 +10,7 @@
 #include "mgOnGpuCxtypes.h"
 #include "mgOnGpuFptypes.h"
 
+#include <cassert>
 #include <iostream>
 
 //==========================================================================
@@ -370,6 +371,18 @@ namespace mg5amcCpu
     return cxtype_v( a.real() + b, a.imag() );
   }
 
+  inline cxtype_v
+  operator+( const cxtype& a, const cxtype_v& b )
+  {
+    return cxtype_v( a.real() + b.real(), a.imag() + b.imag() );
+  }
+
+  inline cxtype_v
+  operator+( const cxtype_v& a, const cxtype& b )
+  {
+    return cxtype_v( a.real() + b.real(), a.imag() + b.imag() );
+  }
+
   inline const cxtype_v&
   operator+( const cxtype_v& a )
   {
@@ -416,6 +429,18 @@ namespace mg5amcCpu
   operator-( const fptype_v& a, const cxtype& b )
   {
     return cxtype_v( a - b.real(), fptype_v{} - b.imag() ); // IIII=0000-b.imag()
+  }
+
+  inline cxtype_v
+  operator-( const cxtype& a, const cxtype_v& b )
+  {
+    return cxtype_v( a.real() - b.real(), a.imag() - b.imag() );
+  }
+
+  inline cxtype_v
+  operator-( const cxtype_v& a, const cxtype& b )
+  {
+    return cxtype_v( a.real() - b.real(), a.imag() - b.imag() );
   }
 
   inline cxtype_v
@@ -505,6 +530,14 @@ namespace mg5amcCpu
   operator/( const cxtype_v& a, const fptype& b )
   {
     return cxtype_v( a.real() / b, a.imag() / b );
+  }
+
+  inline cxtype_v
+  operator/( const cxtype_v& a, const cxtype& b )
+  {
+    const fptype bnorm = b.real() * b.real() + b.imag() * b.imag();
+    return cxtype_v( ( a.real() * b.real() + a.imag() * b.imag() ) / bnorm,
+                     ( a.imag() * b.real() - a.real() * b.imag() ) / bnorm );
   }
 
 #endif // #ifdef MGONGPU_CPPSIMD
@@ -923,6 +956,22 @@ namespace mg5amcCpu
   cxabs2( const cxtype_sv& c )
   {
     return cxreal( c ) * cxreal( c ) + cximag( c ) * cximag( c );
+  }
+
+  // ALOHA raises the denominator of a custom propagator to an integer power (the
+  // squared Breit-Wigner of the SMEFTsim width corrections, for instance). There
+  // is no std::pow overload for cxtype_v, so expand the power by repeated
+  // multiplication: the exponent comes from the UFO propagator and is a small
+  // positive integer.
+  template<class T>
+  inline __host__ __device__ T
+  cxpow( const T& base, const fptype n )
+  {
+    const int k = (int)n;
+    assert( (fptype)k == n && k >= 1 ); // only positive integer powers are supported
+    T out = base;
+    for( int i = 1; i < k; i++ ) out = out * base;
+    return out;
   }
 
   //==========================================================================

--- a/madmatrix/model_handling.py
+++ b/madmatrix/model_handling.py
@@ -16,6 +16,7 @@ PLUGIN_NAME = __name__.rsplit('.',1)[0]
 logger = logging.getLogger('madgraph.%s.model_handling'%PLUGIN_NAME)
 _file_path = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0] + '/'
 
+from madgraph import MadGraph5Error
 from madgraph.iolibs import export_cpp, export_mg7
 from madgraph.iolibs import file_writers as writers
 
@@ -291,6 +292,11 @@ class MadMatrixALOHAWriter(aloha_writers.ALOHAWriterForGPU):
         for type, name in self.declaration.tolist():
             ###print(name) # FOR DEBUGGING
             ###out.write('    %s %s;\n' % ( type, name ) ) # FOR DEBUGGING
+            if type == 'fct':
+                continue # OM an external function name (e.g. 'pow'): nothing to declare in C++
+            if type == 'parameter':
+                out.write(self.get_model_parameter_txt(name)) # OM a model parameter used in the body (custom propagators)
+                continue
             if type.startswith('list'):
                 type = type[5:]
                 if name.startswith('P'):
@@ -332,6 +338,38 @@ class MadMatrixALOHAWriter(aloha_writers.ALOHAWriterForGPU):
                 out.write('    %s;\n' % codedict[fullname] ) # AV old behaviour (separate declaration with no initialization)
         ###out.write('    // END DECLARATION\n') # FOR DEBUGGING
         return out.getvalue()
+
+    # OM - the names of the aS-dependent parameters, filled by write_aloha_routines.
+    # They are recomputed event by event from G inside computeDependentCouplings_fromG,
+    # so they have no addressable value a HelAmps routine could read.
+    dependent_params = ()
+
+    # OM - the body of a routine may refer to a model parameter: this happens for
+    # the custom propagators of a UFO model, whose numerator/denominator are
+    # written in terms of model parameters (e.g. the width corrections dWT, dWZ,
+    # dWW and dWH of SMEFTsim). aloha_writers.ALOHAWriterForCPP reads them from
+    # the Parameters singleton; that is host-only code, so on GPUs the value has
+    # to be a compile-time constant, i.e. HRDCOD=1 is required there.
+    def get_model_parameter_txt(self, name):
+        """Define a model parameter which the routine body uses"""
+        # ALOHA sees the UFO name ('dWT'), the generated Parameters class uses
+        # the prefixed one ('mdl_dWT'), exactly as in the fortran writer
+        mdlname = '%s%s' % (aloha.aloha_prefix, name)
+        if mdlname in self.dependent_params:
+            raise MadGraph5Error(
+                'The custom propagator used by routine %s needs the model parameter %s, '
+                'which depends on alphaS and is therefore recomputed event by event. '
+                'The C++/CUDA backend can only read alphaS-independent parameters inside '
+                'a HelAmps routine, so this process can only be generated with '
+                '"output madevent" or "output standalone_fortran".' % (self.name, mdlname))
+        return ('#ifdef MGONGPU_HARDCODE_PARAM\n'
+                '    constexpr auto %(var)s = Parameters::%(mdl)s;\n'
+                '#elif !defined MGONGPUCPP_GPUIMPL\n'
+                '    const auto %(var)s = Parameters::getInstance()->%(mdl)s;\n'
+                '#else\n'
+                '#error Model parameter %(mdl)s is used inside a HelAmps routine '
+                '(custom propagator) and is not available in device code: rebuild with HRDCOD=1\n'
+                '#endif\n') % { 'var': name, 'mdl': mdlname }
 
     # AV - modify aloha_writers.ALOHAWriterForCPP method (improve formatting)
     # This affects 'V1[0] = ' in HelAmps_sm.cc
@@ -580,6 +618,16 @@ class MadMatrixALOHAWriter(aloha_writers.ALOHAWriterForGPU):
                     out.write('    %s = C_ACCESS::kernelAccessConst( M%s.value + C_ACCESS::flv_stride*flv_index1 );\n' % (name, name))
         return out.getvalue()
 
+    # OM - add the formats which aloha_writers.ALOHAWriterForCPP is missing.
+    # Without this 'pow' falls back to std::pow, which has no overload for the
+    # (possibly SIMD) complex types: cxpow in HelAmps expands the integer power.
+    def get_fct_format(self, fct):
+        """Put the function in the correct format"""
+        if not hasattr(self, 'fct_format'):
+            super().get_fct_format('sqrt') # a known key: builds self.fct_format with no side effect
+            self.fct_format['pow'] = 'cxpow( %s, %s )'
+        return super().get_fct_format(fct)
+
     # AV - modify aloha_writers.ALOHAWriterForCPP method (improve formatting)
     # This is called once per FFV function, i.e. once per WriteALOHA instance?
     # It is called by WriteALOHA.write, after get_header_txt, get_declaration_txt, get_momenta_txt, before get_foot_txt
@@ -604,8 +652,19 @@ class MadMatrixALOHAWriter(aloha_writers.ALOHAWriterForGPU):
                     out.write('    %s = %s;\n' % (name, self.write_obj(obj))) # AV
                     self.declaration.add(('complex', name))
         for name, (fct, objs) in self.routine.fct.items():
-            format = ' %s = %s;\n' % (name, self.get_fct_format(fct))
-            out.write(format % ','.join([self.write_obj(obj) for obj in objs])) # AV not used in eemumu?
+            # OM the FCTn variable needs to be defined, not only assigned (and
+            # write_combined_parts_cc looks for exactly this 'const <type> FCTn ='
+            # form when it merges the structures of an assembled routine)
+            if self.nodeclare:
+                format = '    const %s %s = %s;\n' % (self.type2def['complex_v'], name, self.get_fct_format(fct))
+            else:
+                format = '    %s = %s;\n' % (name, self.get_fct_format(fct))
+                self.declaration.add(('complex', name))
+            args = [self.write_obj(obj) for obj in objs]
+            try:
+                out.write(format % ','.join(args)) # single-argument formats
+            except TypeError:
+                out.write(format % tuple(args)) # e.g. 'pow', which takes two
         numerator = self.routine.expr
         if self.coup_name:
             # one term of an assembled routine: its own coupling among COUP1, ...
@@ -1546,6 +1605,9 @@ class MadMatrixUFOModelConverter(export_cpp.UFOModelConverterGPU):
         # Read in the template .h and .cc files, stripped of compiler commands and namespaces
         template_h_files = self.read_aloha_template_files(ext = 'h')
         template_cc_files = self.read_aloha_template_files(ext = 'cc')
+        # OM - the writer needs to know which parameters are alphaS-dependent (they
+        # cannot be read from the Parameters class inside a routine)
+        self.aloha_writer.dependent_params = frozenset(p.name for p in self.params_dep)
         if(fd_gauge):
             aloha_model = create_aloha.AbstractALOHAModel(self.model.get('name'), explicit_combine=False)
         else:


### PR DESCRIPTION
## What

`import model SMEFTsim_U35_MwScheme_UFO; generate p p > t t~ NP=1; output` died with

```
aloha/create_aloha.py:593  propagator = getattr(self.model.propagators, propa)
AttributeError: 'NoneType' object has no attribute 'propagators'
```

That turned out to be the first of four bugs on the same path. A UFO model can attach a **custom propagator** to a particle — SMEFTsim uses them for the finite-width corrections of the t, W, Z and H — and none of these paths had ever been exercised, because they all sit behind `explicit_combine=True`, i.e. the C++/madmatrix backend only. `output madevent` and `output standalone_fortran` were never affected: fortran picks the parameters up from `coupl.inc`.

## The four bugs

**1. `aloha/create_aloha.py` — the builder never got the model.**
`AbstractALOHAModel.compute_subset` built the explicit-combine builder as `CombineRoutineBuilder(l_lorentz)`, dropping the optional `model` argument. Every other builder in the file passes `self.model`; this one call site was missed back in `e8c2a673b` (2012). It only bites when a `P<name>` custom-propagator tag needs `model.propagators`, and the `assert model` in `AbstractRoutineBuilder.__init__` is commented out, so nothing caught it in between.

**2/3. `madmatrix/model_handling.py` — two missing declaration branches.**
`MadMatrixALOHAWriter.get_declaration_txt` had no case for declaration type `fct` (`KeyError: 'fct_v'`) or `parameter` (`KeyError: 'parameter_v'`). `aloha_writers.ALOHAWriterForCPP` handles both; the GPU override never copied them.

A model parameter used inside a routine body is now defined from the `Parameters` class — `constexpr` under `MGONGPU_HARDCODE_PARAM`, the host singleton otherwise, which is why HRDCOD=1 is required on GPUs (there is no `-rdc=true` in the build, so a cross-TU device symbol is not an option either).

`FCTn` was assigned but never declared, and the single-`%s` format could not express `pow`. It is now emitted as `const cxtype_sv FCTn = ...` — which is exactly the form `write_combined_parts_cc` already greps for when merging the structures of an assembled routine — and `pow` maps to a new `cxpow` helper.

**4. `mgOnGpuVectors.h` — missing mixed operators.**
The propagator expressions produce `cxsmpl<double> + cxtype_v`, which had no overload: `*` and `/` already had both orders, `+`/`-` did not. Added `cxtype ± cxtype_v` (both orders) and `cxtype_v / cxtype`, plus `cxpow` (no `std::pow` for `cxtype_v`; the exponent always comes from the UFO propagator and is a small positive integer).

`cxpow` deliberately lives in `mgOnGpuVectors.h` rather than `cpp_hel_amps_h.inc` — the latter is an `IOTestFDGauge` golden, and this way no golden moves.

## Validation

- **Cross-backend, custom propagator**: `u d~ > e+ ve NP=1` (SMEFTsim W1 propagator, `dWW`). C++ `check_sa.exe matrix 1000`, simd_128 / `FPTYPE=d`: `7.1300507507539050e-03`; fortran `./check`: `7.1300507507539058e-03`. **1 ulp.** (The default `FPTYPE=m` build differs at 1e-8, as expected for mixed precision.) Builds clean under `-Wall -Wshadow -Wextra`.
- **No regression**: SM `g g > t t~` regenerates a **byte-identical** `HelAmps_sm.h`, and `check_sa.exe matrix 1000` gives `5.9262614118518897e-01` both before and after — so the new operators introduce no overload ambiguity anywhere.
- `tests/parallel_tests/test_aloha.py` (124 tests) and `IOTestFDGauge` pass.
- Full `./tests/test_manager.py -p U` (1551 tests): failure set **identical** to a `HEAD~1` baseline run on the same machine (2 failures / 94 errors, all pre-existing — madspin density, numpy pools, `test_output_standalone_cpp_refuses_loop_induced` which expects the removed `standalone_cpp`, ...). Note the suite shares a gitignored `UNITTEST_proc/` between runs, so the first run in a fresh tree reports a few extra order-dependent failures either way.

## Known limitation (unchanged, now explicit)

`p p > t t~ NP=1` still cannot be generated for the C++ backend. The Higgs propagator needs `mdl_dWH`, which depends on alphaS (through `gHgg1`/`gHgg2`) and is therefore recomputed event by event inside `computeDependentCouplings_fromG` — there is no addressable value a HelAmps routine could read, in any build mode. Instead of emitting code that cannot compile, the writer now raises:

> The custom propagator used by routine FFS2PH1_3 needs the model parameter mdl_dWH, which depends on alphaS and is therefore recomputed event by event. The C++/CUDA backend can only read alphaS-independent parameters inside a HelAmps routine, so this process can only be generated with "output madevent" or "output standalone_fortran".

Supporting it means threading the value in as an extra routine argument through the dependent-coupling buffer (new `DependentCouplings_sv` member + signature change in the ALOHA writer + matching change at every call site in the ME writer). That is a feature, not a fix, so it is out of scope here.

Separately, and unrelated to this PR: `HRDCOD=1` does not build for SMEFTsim at all, because `Parameters.h` initialises `constexpr double mdl_propCorr` with `std::abs(...)`, which is not a constant expression (6 errors, all in `Parameters.h`). Worth its own issue if the hardcoded-parameter path matters for this model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
