### PR TITLE
CI: stop the xsec and madspace workflows running twice per push

### DIFF
--- a/.github/workflows/check_xsec_processes_mg7.yml
+++ b/.github/workflows/check_xsec_processes_mg7.yml
@@ -59,6 +59,7 @@ jobs:
   # The build logic lives in the build_madspace composite action so it stays in
   # sync with acceptancetest_mg7.yml.
   build_madspace:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -66,6 +67,7 @@ jobs:
 
   check_xsec_processes:
     needs: build_madspace
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -101,7 +103,7 @@ jobs:
 
   xsec_summary:
     needs: check_xsec_processes
-    if: always()
+    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/madspace.yml
+++ b/.github/workflows/madspace.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
`check_xsec_processes_mg7.yml` and `madspace.yml` declare both `push:` and `pull_request:` triggers but carry **no job-level event gate**, unlike the six workflows that do. On a same-repo PR branch every push fires both events, so the full 3jets cross-section matrix and the entire madspace wheel build each run **twice**.

Measured on a single commit (`88ad9423d`):

| workflow | push | pull_request |
|---|---|---|
| acceptance test (rest / madevent / mg7) | success | **skipped** |
| parralel test, unittest, aloha | success | **skipped** |
| running IOTests | success | – (no PR trigger) |
| **systematic cross-section tests (mg7)** | ran | **ran** |
| **MadSpace** | success | **success** |

The six correct ones gate every job with
`github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true`,
which is why their PR runs finish `skipped` in 1–2 s.

## What this changes

Adds the gate to `build_madspace`, `check_xsec_processes` and `xsec_summary` in the xsec workflow, and to `build_wheels` in madspace.

Two details worth reviewing:

1. **`xsec_summary` already had `if: always()`.** The gate is AND-ed into it, not appended — otherwise the summary job resurrects itself on the skipped pull_request runs and the workflow still shows up.

2. **The gate uses the negative form** — `github.event_name != 'pull_request' || <fork>` — rather than the existing positive form. Reason: inside a reusable workflow the `github` context belongs to the **caller**, so `github.event_name` is the caller's event (`release`, for `release.yml`) and is **never** the literal `'workflow_call'`. The negative form runs for push, release/workflow_call, workflow_dispatch and fork PRs alike, and skips only a same-repo PR, so it is correct under either reading.

Fork PRs keep full coverage — they receive no push event, so gating on push alone would leave them untested. That is what the fork clause is for.

## Noted, not changed

- **The existing six workflows may skip the entire release test suite.** `release.yml` calls `unittest.yml`, `acceptancetest*.yml`, `parralel.yml`, `IOtest.yml` and `aloha.yml` via `uses:`, and is triggered by `release: published`. If `github.event_name` is indeed the caller's event there, their `event_name == 'workflow_call'` clause never matches and every job skips — making the release gate a silent no-op. **`release.yml` has never run** (zero release-triggered runs in this repo's history), so this is untested in either direction. I did not touch those six here; worth confirming on the next release, or switching them to the same negative form.

- **`madspin_parallel.yml` has the opposite anomaly**: its `push:` is restricted to `branches: ['3.x']`, so on any other branch it runs *only* from `pull_request`, and it never runs on a direct push to `main`. Not duplicated, but likely unintended. Left alone.

- `IOtest.yml` needs no gate — it has no `pull_request` trigger at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
