### PR TITLE
Run `launch` on an mg7 output in process, like a madevent one

### DIFF
--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -7928,6 +7928,36 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             self._export_dir = os.path.sep.join(path_split[:-2])
             return
 
+    def setup_mg7_environment(self):
+        """Export what an mg7 run needs from MG5's configuration.
+
+        These used to be built into the environment of the bin/generate_events
+        subprocess. Running in process, the same values have to reach the tools
+        the run shells out to (the madspace build, the real LHAPDF library used
+        by systematics/MadSpin/reweight), and the only channel those have is
+        os.environ -- so set it here rather than per child process.
+        """
+        # The one-off madspace build picks up a cmake installed through MG5's
+        # 'install cmake' from here (heptools_install_dir may point outside
+        # MG5DIR).
+        heptools_dir = self.options.get('heptools_install_dir')
+        if heptools_dir:
+            if not os.path.isabs(heptools_dir):
+                heptools_dir = pjoin(MG5DIR, heptools_dir)
+            os.environ['MADGRAPH_HEPTOOLS_DIR'] = os.path.abspath(heptools_dir)
+
+        # The resolved LHAPDF location. The launcher resolves it the same way on
+        # its own (launch.lhapdf_paths), so this only matters for the real
+        # LHAPDF library used by the post-processing tools, which reads
+        # LHAPDF_DATA_PATH natively.
+        lhapdf = misc.resolve_lhapdf(self.options, root=MG5DIR, create=True)
+        search = lhapdf.data_paths or (
+            [lhapdf.download_path] if lhapdf.download_path else [])
+        if search:
+            os.environ['LHAPDF_DATA_PATH'] = os.pathsep.join(search)
+        if lhapdf.config:
+            os.environ['MADGRAPH_LHAPDF_CONFIG'] = lhapdf.config
+
     def do_launch(self, line):
         """Main commands: Ask for editing the parameter and then
         Execute the code (madevent/standalone/...)
@@ -8038,66 +8068,42 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                                                  options=self.options,**options)            
         elif args[0] == 'mg7':
             me_dir = args[1]
-            # When MG5 runs non-interactively (a command file / piped input),
-            # drive bin/generate_events from the card-editing commands that
-            # follow `launch` in the script. Feeding them on stdin also makes
-            # the subprocess non-interactive, so the one-off madspace install
-            # runs with defaults instead of blocking on a prompt.
-            scripted = not self.use_rawinput
-            feed_lines = []
-            if scripted and self.inputfile is not None:
-                stop_prefixes = ('generate', 'add process', 'define', 'output',
-                                 'launch', 'import', 'quit', 'exit')
-                while True:
-                    try:
-                        nxt = next(self.inputfile)
-                    except (StopIteration, TypeError):
-                        break
-                    stripped = nxt.replace('\n', '').strip()
-                    if not stripped:
-                        continue
-                    if stripped.lower().startswith(stop_prefixes):
-                        self.store_line(nxt)  # belongs to MG5, hand it back
-                        break
-                    feed_lines.append(stripped)
-                    if stripped.lower() in ('done', '0'):
-                        break
+            # An mg7 output runs in this process, exactly like a madevent one:
+            # the run interface becomes a child cmd interface, which gives it
+            # MG5's inputfile (so the launch question reads the same script and
+            # hands back what it does not understand), MG5's error handling and
+            # crash_on_error, and the loggers already configured here.
+            self.setup_mg7_environment()
 
-            # Expose the configured HEPTools location so that the one-off
-            # madspace build can pick up a cmake installed there via MG5's
-            # 'install cmake' (heptools_install_dir may point outside MG5DIR).
-            gen_env = os.environ.copy()
-            heptools_dir = self.options.get('heptools_install_dir')
-            if heptools_dir:
-                if not os.path.isabs(heptools_dir):
-                    heptools_dir = os.path.join(MG5DIR, heptools_dir)
-                gen_env['MADGRAPH_HEPTOOLS_DIR'] = os.path.abspath(heptools_dir)
+            # Install madspace *before* importing the launcher (importing it is
+            # what needs madspace). The bootstrap has to be told whether it may
+            # take over the terminal: in a subprocess it could read that off
+            # sys.argv/sys.stdin, but in process those describe MG5, not the run.
+            from madgraph.iolibs.template_files.mg7 import bootstrap as mg7_bootstrap
+            mg7_bootstrap.ensure_madspace(
+                interactive=bool(self.use_rawinput) and not options['force'])
+            from madgraph.iolibs.template_files.mg7 import launch as mg7_launch
 
-            # Forward the resolved LHAPDF location. bin/generate_events
-            # resolves it the same way on its own (launch.lhapdf_paths), so
-            # this only matters for the real LHAPDF library used by the
-            # post-processing tools, which reads LHAPDF_DATA_PATH natively.
-            lhapdf = misc.resolve_lhapdf(self.options, root=MG5DIR, create=True)
-            search = lhapdf.data_paths or (
-                [lhapdf.download_path] if lhapdf.download_path else [])
-            if search:
-                gen_env['LHAPDF_DATA_PATH'] = os.pathsep.join(search)
-            if lhapdf.config:
-                gen_env['MADGRAPH_LHAPDF_CONFIG'] = lhapdf.config
+            MG7 = mg7_launch.MG7Cmd(me_dir=me_dir, options=self.options)
+            if options['interactive']:
+                stop = self.define_child_cmd_interface(MG7)
+                return stop
+
+            mother = self
 
             class ext_program:
                 @staticmethod
                 def run():
-                    os.chdir(me_dir)
-                    gen = os.path.join("bin", "generate_events")
-                    try:
-                        if scripted:
-                            stdin_text = "\n".join(feed_lines + ["done"]) + "\n"
-                            subprocess.run([gen], input=stdin_text, text=True, env=gen_env)
-                        else:
-                            subprocess.run(gen, env=gen_env)
-                    except KeyboardInterrupt:
-                        pass
+                    child = mother.define_child_cmd_interface(MG7, interface=False)
+                    command = 'generate_events'
+                    if options['force']:
+                        command += ' -f'
+                    if options['name']:
+                        command += ' --name=%s' % options['name']
+                    if options['laststep']:
+                        command += ' --laststep=%s' % options['laststep']
+                    child.run_cmd(command)
+                    child.run_cmd('quit')
 
         else:
             os.chdir(start_cwd) #ensure to go to the initial path

--- a/madgraph/iolibs/template_files/mg7/bootstrap.py
+++ b/madgraph/iolibs/template_files/mg7/bootstrap.py
@@ -1,0 +1,97 @@
+"""One-off madspace bootstrap for the mg7 output.
+
+The mg7 launcher needs the compiled ``madspace`` package. A git checkout ships
+only the sources, so the first run has to build and install it. That bootstrap
+used to live at the top of :mod:`launch.py`, executed as an import side effect.
+That was fine while ``launch`` was only ever imported by ``bin/generate_events``
+in a throw-away subprocess whose ``sys.argv``/``sys.stdin`` described the run
+itself.
+
+``launch`` is now also imported *in process* by MG5's ``launch`` command, where
+neither of those is true: ``sys.argv`` is MG5's own command line (so a ``-f``
+meant for, say, ``mg5_aMC -f`` would be misread as the run's force flag, and
+conversely a ``launch -f`` would not be seen at all) and ``sys.stdin`` is MG5's,
+which may be a terminal even when the run itself is scripted.
+
+So the decision is made by the caller and passed in explicitly. Keeping it in a
+module of its own -- one that must never import ``madspace`` -- lets MG5 run the
+bootstrap *before* importing :mod:`launch`, which is what makes the heavy import
+safe to do lazily.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Locate the madspace installation bundled alongside MadGraph.
+# madgraph/__init__.py lives one level below the MadGraph root, so .parents[1]
+# reaches the root and then "madspace/install" is the local install prefix.
+import madgraph as _mg_pkg
+
+MG_ROOT = Path(_mg_pkg.__file__).parents[1]
+MADSPACE_DIR = MG_ROOT / "madspace"
+INSTALL_DIR = MADSPACE_DIR / "install"
+
+
+def madspace_is_installed() -> bool:
+    """True when a compiled madspace is already available to import."""
+    return (INSTALL_DIR / "madspace").is_dir()
+
+
+def ensure_madspace(interactive=None) -> None:
+    """Install madspace if needed, then put it on ``sys.path``.
+
+    ``interactive`` says whether the installer may take over the terminal and
+    ask questions. ``None`` falls back to auto-detection from ``sys.stdin``,
+    which is only correct for ``bin/generate_events``; every in-process caller
+    should pass the value explicitly.
+    """
+    if not madspace_is_installed():
+        if interactive is None:
+            interactive = sys.stdin.isatty()
+        print()
+        print("You don't have madspace installed for this madgraph instance")
+        print("Running the madspace installation script")
+        print()
+
+        install_cmd = [sys.executable, str(MADSPACE_DIR / "install.py")]
+        # When the run is non-interactive (scripted / piped), install
+        # non-interactively with a source build and default options
+        # (--source --yes), and keep the installer away from our stdin (which
+        # may carry the run's scripted card-editing commands); when
+        # interactive, let it share the terminal so the user can answer.
+        install_stdin = None if interactive else subprocess.DEVNULL
+        if not interactive:
+            install_cmd += ["--source", "--yes"]
+        # Expose madgraph on PYTHONPATH so the installer subprocess can import
+        # cmd.ask for its prompts.
+        install_env = os.environ.copy()
+        install_env["PYTHONPATH"] = os.pathsep.join(
+            [str(MG_ROOT)]
+            + ([install_env["PYTHONPATH"]] if install_env.get("PYTHONPATH") else [])
+        )
+        result = subprocess.run(install_cmd, env=install_env, stdin=install_stdin)
+        if result.returncode != 0:
+            raise RuntimeError("madspace installation failed — see output above")
+
+    if str(INSTALL_DIR) not in sys.path:
+        sys.path.insert(0, str(INSTALL_DIR))
+
+
+def drop_install_path() -> None:
+    """Take the madspace install directory back off ``sys.path``.
+
+    It is not only the madspace package: the installer puts madspace's build
+    dependencies in the same target, so the directory also carries ``yaml``,
+    ``packaging``, ``pathspec``, ``scikit_build_core`` and ``pybind11_stubgen``.
+    Prepending it therefore shadows any of those the caller already had.
+
+    That was harmless while the launcher only ever ran in a throw-away
+    ``bin/generate_events`` process. Now that it is imported into MG5's own
+    long-lived session, the shadowing would outlast the run, so drop the entry
+    once madspace itself is imported. The madspace package keeps working: its
+    submodules resolve through its own ``__path__``, not through ``sys.path``.
+    """
+    while str(INSTALL_DIR) in sys.path:
+        sys.path.remove(str(INSTALL_DIR))

--- a/madgraph/iolibs/template_files/mg7/launch.py
+++ b/madgraph/iolibs/template_files/mg7/launch.py
@@ -14,45 +14,28 @@ from dataclasses import dataclass, field
 from typing import Literal, NamedTuple
 import resource
 
-# Locate the madspace installation bundled alongside MadGraph.
-# madgraph/__init__.py lives one level below the MadGraph root, so .parents[1]
-# reaches the root and then "madspace/install" is the local install prefix.
-import madgraph as _mg_pkg
-_MG_ROOT = Path(_mg_pkg.__file__).parents[1]
-_MADSPACE_DIR = _MG_ROOT / "madspace"
-_INSTALL_DIR = _MADSPACE_DIR / "install"
-if not (_INSTALL_DIR / "madspace").is_dir():
-    print()
-    print("You don't have madspace installed for this madgraph instance")
-    print("Running the madspace installation script")
-    print()
+# Install madspace on first use, then import it. The bootstrap lives in its own
+# module (which must not import madspace) so that an in-process caller can run
+# it *before* importing this one -- see bootstrap.ensure_madspace.
+from madgraph.iolibs.template_files.mg7.bootstrap import (
+    ensure_madspace as _ensure_madspace,
+    drop_install_path as _drop_install_path,
+    MG_ROOT as _MG_ROOT,
+    MADSPACE_DIR as _MADSPACE_DIR,
+    INSTALL_DIR as _INSTALL_DIR,
+)
 
-    _install_cmd = [sys.executable, str(_MADSPACE_DIR / "install.py")]
-    # Expose madgraph on PYTHONPATH so the installer subprocess can import
-    # cmd.ask for its prompts.
-    _noninteractive = "-f" in sys.argv or not sys.stdin.isatty()
-    # When the run is non-interactive (scripted / piped), install
-    # non-interactively with a source build and default options (--source --yes),
-    # and keep the installer away from our stdin (which may carry the run's
-    # scripted card-editing commands); when interactive, let it share the
-    # terminal so the user can answer.
-    _install_stdin = subprocess.DEVNULL if _noninteractive else None
-    if _noninteractive:
-        _install_cmd += ["--source", "--yes"]
-    _install_env = os.environ.copy()
-    _install_env["PYTHONPATH"] = os.pathsep.join(
-        [str(_MG_ROOT)] + ([_install_env["PYTHONPATH"]] if _install_env.get("PYTHONPATH") else [])
-    )
-    _result = subprocess.run(_install_cmd, env=_install_env, stdin=_install_stdin)
-    if _result.returncode != 0:
-        raise RuntimeError("madspace installation failed — see output above")
-if str(_INSTALL_DIR) not in sys.path:
-    sys.path.insert(0, str(_INSTALL_DIR))
+_ensure_madspace()
 
 import madspace as ms
+
+# madspace is imported; stop its install directory from shadowing the caller's
+# yaml/packaging/... for the rest of what is now MG5's own session.
+_drop_install_path()
 from models.check_param_card import ParamCard
 from madgraph.various.banner import RunCardMG7
 from madgraph.various import misc
+from madgraph.interface.extended_cmd import Cmd
 
 _source_hash = subprocess.run(
     [sys.executable, str(_MADSPACE_DIR / "source_hash.py")],
@@ -355,7 +338,16 @@ class MadgraphProcess:
                 break
             except FileExistsError:
                 run_index += 1
-        self.status_file = ms.StatusFile(os.path.join(self.run_path, "info.json"))
+        # Absolute on purpose. StatusFile is a C++ object that finishes its
+        # write from its destructor (rename info.json.tmp -> info.json), and
+        # that destructor runs whenever Python gets round to collecting the
+        # process object. When the launcher runs in MG5's process, an
+        # interrupted run is collected *after* the launch command has restored
+        # the working directory, and a relative path would then resolve
+        # somewhere else -- the rename throws a C++ filesystem_error out of a
+        # destructor, which is an immediate abort.
+        self.status_file = ms.StatusFile(
+            os.path.abspath(os.path.join(self.run_path, "info.json")))
 
     def init_context(self) -> None:
         device_names = self.run_card["run"]["device"]
@@ -2211,7 +2203,7 @@ class MadgraphSubprocess:
 
 _ROOTED_OPTIONS = ('lhapdf', 'lhapdf_py3', 'lhapdf_py2', 'heptools_install_dir')
 
-def load_mg5_options() -> dict:
+def load_mg5_options(me_dir=None) -> dict:
     """Read the tool paths from the MadGraph configuration, so the launcher
     knows where LHAPDF and the optional programs (Pythia8/Delphes/MadSpin/
     reweight/analysis) live.
@@ -2221,11 +2213,16 @@ def load_mg5_options() -> dict:
     this process directory has the last word, then this installation, then the
     per-user file. Relative values are resolved against the root of the file
     they came from.
+
+    ``me_dir`` is the process directory whose Cards/me5_configuration.txt has
+    the last word. It defaults to the working directory, which is right for
+    bin/generate_events (it chdirs there first) but not for an in-process
+    caller, which has not moved yet.
     """
 
     import madgraph
     mg5dir = os.path.dirname(os.path.dirname(os.path.abspath(madgraph.__file__)))
-    me_dir = os.getcwd()
+    me_dir = os.getcwd() if me_dir is None else me_dir
 
     options = {
         'pythia-pgs_path': None, 'pythia8_path': None, 'madanalysis_path': None,
@@ -2286,44 +2283,185 @@ def lhapdf_paths(refresh: bool = False) -> misc.LhapdfPaths:
     return _LHAPDF
 
 
-def build_selector_cmd():
+class MG7Cmd(Cmd):
+    """The mg7 run interface: the command object that drives a launch.
+
+    It plays two roles, and they are the same object on purpose.
+
+    1. It is the *mother* of the merged switch/card question (the thing
+       ``AskRunEditCard`` calls back into for ``keep_cards``/``do_open``/
+       ``compute_widths``).
+    2. It is the child command interface MG5 registers via
+       ``define_child_cmd_interface`` when you type ``launch`` on an mg7 output.
+
+    Role 2 is what makes role 1 behave. ``Cmd.ask`` resolves a scripted answer
+    through ``self.check_answer_in_input_file``, where ``self`` is the mother --
+    so once MG5 hands us its ``inputfile`` and registers itself as our
+    ``mother``, the question reads the very lines that follow ``launch`` in the
+    user's command file, and any line it does not recognise goes back up to MG5
+    through ``store_line`` instead of being silently consumed. This is exactly
+    how a madevent output already behaves; before this class existed the mg7
+    branch shelled out to ``bin/generate_events`` and had to guess which
+    following lines belonged to the run, which quietly swallowed every ``set``.
+    """
+
+    prompt = 'MG7> '
+
+    def __init__(self, me_dir='.', options=None, *args, **opts):
+        super().__init__(*args, **opts)
+        self.me_dir = os.path.abspath(me_dir) if me_dir != '.' else '.'
+        # The rest of the launcher is written against the process directory as
+        # the working directory, so do_generate_events chdirs there; but at
+        # construction time MG5 has not moved, hence the explicit me_dir.
+        self.options = load_mg5_options(
+            self.me_dir if self.me_dir != '.' else None)
+        if options:
+            # MG5's own resolved tool paths win: they are the ones the user
+            # configured in the session that is doing the launching.
+            self.options.update({k: v for k, v in options.items()
+                                 if k in self.options and v is not None})
+        self.plugin_path = []
+        self.proc_characteristics = {'grouped_matrix': False, 'limitations': []}
+
+    # ------------------------------------------------------------------
+    # the contract the card question expects from its mother
+    # ------------------------------------------------------------------
+    def keep_cards(self, need_card=[], ignore=[]):
+        from madgraph.interface.common_run_interface import CommonRunCmd
+        return CommonRunCmd.keep_cards(self, need_card, ignore)
+
+    def do_open(self, line):
+        from madgraph.interface.common_run_interface import CommonRunCmd
+        CommonRunCmd.do_open(self, line)
+
+    def check_open(self, args):
+        from madgraph.interface.common_run_interface import CommonRunCmd
+        CommonRunCmd.check_open(self, args)
+
+    def do_compute_widths(self, line):
+        # The interactive card editor delegates 'auto' width computation to
+        # the mother interface. Reuse the runtime helper (madgraph subprocess
+        # + the model stored at output time). ``line`` looks like
+        # "<pdgs> --path=<param_card> [--nlo]"; we only need the card path.
+        m = re.search(r'--path=(\S+)', line or "")
+        path = m.group(1) if m else os.path.join("Cards", "param_card.dat")
+        compute_auto_widths(path)
+        # return an empty mapping: the caller iterates out.items() for the
+        # small-width treatment, which mg7 does not apply.
+        return {}
+
+    # ------------------------------------------------------------------
+    # running
+    # ------------------------------------------------------------------
+    def do_generate_events(self, line):
+        """generate_events [-f] [-n NAME] [--laststep=parton]
+
+        Run the mg7 generation and the selected post-processing tools."""
+
+        opts = self._parse_run_options(line)
+        cwd = os.getcwd()
+        target = self.me_dir if self.me_dir != '.' else cwd
+        try:
+            os.chdir(target)
+            _setup_logging()
+            if opts['name']:
+                self._set_run_name(opts['name'])
+            switch = {}
+            if not opts['force']:
+                switch = ask_edit_cards(mother=self)
+            switch = self._apply_laststep(switch, opts)
+            force_lhe_output_if_needed(switch)
+            _raise_open_file_limit()
+            run_generation(switch)
+        finally:
+            os.chdir(cwd)
+
+    # ``launch`` is the name MG5 users type; keep it working here too.
+    do_launch = do_generate_events
+
+    def do_quit(self, line):
+        """Leave the mg7 run interface."""
+        return super().do_quit(line)
+
+    do_exit = do_quit
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _parse_run_options(self, line):
+        """Understand the subset of MG5's `launch` options that mean something
+        for an mg7 run, and say so out loud for the ones that do not."""
+        out = {'force': False, 'name': '', 'laststep': ''}
+        args = self.split_arg(line)
+        index = 0
+        while index < len(args):
+            arg = args[index]
+            index += 1
+            if arg in ('-f', '--force'):
+                out['force'] = True
+            elif arg in ('-n', '--name') and index < len(args):
+                out['name'] = args[index]
+                index += 1
+            elif arg.startswith(('-n=', '--name=')):
+                out['name'] = arg.split('=', 1)[1]
+            elif arg in ('-s', '--laststep') and index < len(args):
+                out['laststep'] = args[index]
+                index += 1
+            elif arg.startswith(('-s=', '--laststep=')):
+                out['laststep'] = arg.split('=', 1)[1]
+            elif arg.startswith('-'):
+                logger.warning(
+                    "'%s' is not supported by the mg7 output and is ignored; "
+                    "the equivalent settings live in Cards/run_card.toml", arg)
+            elif arg and not out['name']:
+                out['name'] = arg
+        return out
+
+    def _set_run_name(self, name):
+        """Honour `launch -n NAME`: the mg7 run directory is
+        Events/<run.run_name>_NN, so the name is a run_card setting."""
+        path = os.path.join("Cards", "run_card.toml")
+        run_card = RunCardMG7(path, consistency=False)
+        if run_card["run"]["run_name"] != name:
+            run_card["run"]["run_name"] = name
+            run_card.write(path)
+            logger.info("run name set to '%s'", name)
+
+    def _apply_laststep(self, switch, opts):
+        """`--laststep=parton` means: generate the events, run nothing on them.
+
+        The mg7 tool selection is the switch dict the question returns, so
+        stopping at parton level is switching those entries off.
+        """
+        if opts['laststep'] not in ('parton', 'auto', ''):
+            logger.warning(
+                "--laststep=%s is not supported by the mg7 output; "
+                "select the programs to run in the launch question instead",
+                opts['laststep'])
+            return switch
+        if opts['laststep'] != 'parton' or not switch:
+            return switch
+        switch = dict(switch)
+        for key in ('shower', 'detector', 'analysis', 'madspin', 'reweight'):
+            if not _off(switch.get(key, 'OFF')):
+                logger.info("--laststep=parton: not running %s", key)
+                switch[key] = 'OFF'
+        return switch
+
+
+def build_selector_cmd(mother=None):
     """Build the (monkey-patched) mother command + merged switch/card selector
     used by the mg7 output.  Returns the selector *class* and a mother instance
-    understood by AskRun/AskforEditCard."""
+    understood by AskRun/AskforEditCard.
 
-    from madgraph.interface.common_run_interface import CommonRunCmd
-    from madgraph.interface.extended_cmd import Cmd
+    ``mother`` lets an in-process caller supply its own :class:`MG7Cmd` -- the
+    one MG5 registered as its child -- so that the question resolves scripted
+    answers against MG5's own command file (see :class:`MG7Cmd`). When it is
+    omitted a standalone instance is built, which is what ``bin/generate_events``
+    gets.
+    """
+
     from madgraph.interface.madevent_interface import AskRunEditCard
-
-    class MG7Cmd(Cmd):
-
-        def __init__(self):
-            super().__init__(".", {})
-            self.me_dir = "."
-            self.options = load_mg5_options()
-            self.plugin_path = []
-            self.proc_characteristics = {'grouped_matrix': False, 'limitations': []}
-
-        def keep_cards(self, need_card=[], ignore=[]):
-            return CommonRunCmd.keep_cards(self, need_card, ignore)
-
-        def do_open(self, line):
-            CommonRunCmd.do_open(self, line)
-
-        def check_open(self, args):
-            CommonRunCmd.check_open(self, args)
-
-        def do_compute_widths(self, line):
-            # The interactive card editor delegates 'auto' width computation to
-            # the mother interface. Reuse the runtime helper (madgraph subprocess
-            # + the model stored at output time). ``line`` looks like
-            # "<pdgs> --path=<param_card> [--nlo]"; we only need the card path.
-            m = re.search(r'--path=(\S+)', line or "")
-            path = m.group(1) if m else os.path.join("Cards", "param_card.dat")
-            compute_auto_widths(path)
-            # return an empty mapping: the caller iterates out.items() for the
-            # small-width treatment, which mg7 does not apply.
-            return {}
 
     from madgraph.various import banner as _banner_mod
     from madgraph.various import misc as _misc
@@ -2404,6 +2542,28 @@ def build_selector_cmd():
                         self.modified_card.add("run")
                         return
 
+                    # 'iseed' is the madevent spelling of the mg7 run.seed,
+                    # but the two disagree on how to ask for a random seed:
+                    # madevent uses 0, mg7 uses -1 (0 being a perfectly good
+                    # fixed seed there). Translate here rather than in
+                    # _LO_SCALAR_MAP, which also drives the LO -> MG7 run_card
+                    # conversion and would silently pin those runs to seed 0.
+                    if rest and nlow == 'iseed':
+                        value = run_card.evaluate(rest, masses)
+                        try:
+                            value = int(value)
+                        except (TypeError, ValueError):
+                            value = None
+                        if value is None:
+                            logger.warning("ignoring 'set iseed %s': not an integer", rest)
+                            return
+                        seed = -1 if value == 0 else value
+                        run_card.set('run.seed', seed, user=True)
+                        logger.info("set iseed (mg7 run.seed) of the run_card.toml to %s%s",
+                                    seed, " (random)" if seed == -1 else "")
+                        self.modified_card.add("run")
+                        return
+
                     # legacy madevent run_card names -> mg7 "section.key", so a
                     # madevent-style launch script ("set nevents 500", "set
                     # use_syst F", "set bwcutoff 10", ...) edits the mg7
@@ -2427,15 +2587,20 @@ def build_selector_cmd():
                                 line = "%s%s %s" % (prefix, name, resolved)
             return super().do_set(line, *args, **kwargs)
 
-    return MG7Selector, MG7Cmd()
+    return MG7Selector, (mother if mother is not None else MG7Cmd())
 
 
-def ask_edit_cards() -> dict:
+def ask_edit_cards(mother=None) -> dict:
     """Single (MadDM-style) question letting the user both pick which programs
     to run after generation and edit the associated cards.  Returns the switch
-    dict describing the selected tools."""
+    dict describing the selected tools.
 
-    selector_class, mother = build_selector_cmd()
+    ``mother`` is the :class:`MG7Cmd` asking the question. Passing the instance
+    MG5 registered as its child is what lets a scripted ``launch`` answer this
+    question from MG5's own command file.
+    """
+
+    selector_class, mother = build_selector_cmd(mother)
     # path_msg is what makes Cmd.check_answer_in_input_file accept a bare path as
     # an answer (its "elif path:" branch), so that a scripted launch can hand the
     # question a card/banner path -- as the question itself advertises -- and have
@@ -2515,6 +2680,18 @@ def _off(value) -> bool:
     return value in (None, "OFF", "Not Avail.", "Not Avail. (numpy missing)")
 
 
+def _has_effective_handler(lg) -> bool:
+    """True when ``lg`` (or an ancestor it propagates to) already has a handler,
+    i.e. some other party is already displaying these records."""
+    while lg:
+        if lg.handlers:
+            return True
+        if not lg.propagate:
+            return False
+        lg = lg.parent
+    return False
+
+
 _TOOL_LOGGING_READY = False
 
 
@@ -2529,6 +2706,13 @@ def _setup_logging():
     colored INFO console handler to them (idempotent)."""
     global _TOOL_LOGGING_READY
     if _TOOL_LOGGING_READY:
+        return
+    if _has_effective_handler(logging.getLogger("madgraph")):
+        # Someone already configured logging for us -- in practice MG5, which
+        # now runs the launch in its own process. Its configuration is
+        # authoritative (it owns stdout_level and the tutorial logger); adding
+        # a second handler here would print every line twice.
+        _TOOL_LOGGING_READY = True
         return
     try:
         import madgraph.interface.coloring_logging  # registers ColorFormatter
@@ -2991,20 +3175,26 @@ def force_lhe_output_if_needed(switch) -> None:
             "output_format set to 'lhe' (required by the selected post-processing).")
 
 
-def main() -> None:
-    _setup_logging()
+def _raise_open_file_limit() -> None:
+    """Remove the soft limit on the number of open files: it can be quite low
+    on some systems and the event-combination step opens one file per channel."""
+    soft_lim, hard_lim = resource.getrlimit(resource.RLIMIT_NOFILE)
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (hard_lim, hard_lim))
+    except (ValueError, OSError) as error:
+        logger.debug("could not raise the open-file limit: %s", error)
 
+
+def main() -> None:
+    """``bin/generate_events`` entry point.
+
+    It runs the same :class:`MG7Cmd` command MG5's in-process ``launch`` uses,
+    so the two entry points cannot drift apart; the only difference is that
+    nothing here supplies a ``mother``/``inputfile``, so the question falls back
+    to reading this process's own stdin.
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("-f", action="store_false", dest="ask_edit_cards")
     args = parser.parse_args()
-    switch = {}
 
-    if args.ask_edit_cards:
-        switch = ask_edit_cards()
-        force_lhe_output_if_needed(switch)
-
-    # Remove soft limit on number of open files as it can be quite low on some systems
-    soft_lim, hard_lim = resource.getrlimit(resource.RLIMIT_NOFILE)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (hard_lim, hard_lim))
-
-    run_generation(switch)
+    MG7Cmd().run_cmd("generate_events" if args.ask_edit_cards else "generate_events -f")

--- a/madgraph/iolibs/template_files/mg7/launch.py
+++ b/madgraph/iolibs/template_files/mg7/launch.py
@@ -2773,6 +2773,15 @@ def run_selected_tools(switch, process) -> None:
         ("MadAnalysis5 (hadron level)", ma5 and showered),
         ("Rivet", switch.get("analysis") == "Rivet"),
     ) if on]
+    if not tools:
+        # `active` above counts any switch that is not off, which is not the
+        # same question: "Not Avail." is not off, and a shower switch set to
+        # something other than Pythia8 selects no driver here either. Without
+        # this a plain generate/output/launch announced a post-processing step
+        # with nothing after the colon, and paid for building the run
+        # interface to do nothing.
+        return
+
     log.info("")
     log.info("Post-processing the generated events with: %s", ", ".join(tools))
 

--- a/madgraph/iolibs/template_files/mg7/run_interface.py
+++ b/madgraph/iolibs/template_files/mg7/run_interface.py
@@ -34,18 +34,26 @@ logger = logging.getLogger('madevent')
 def _quiet_setup():
     """Silence the INFO chatter of a madevent interface being constructed.
 
-    Raises the stdout logger to WARNING for the duration, so the banner and the
-    configuration lines are dropped while anything that actually needs saying
-    still gets through.
+    Raises the loggers that carry it to WARNING for the duration, so the
+    banner, the configuration lines and the shell-tool notes are dropped while
+    anything that actually needs saying still gets through.
     """
 
-    stdout_logger = logging.getLogger('madevent.stdout')
-    previous = stdout_logger.level
-    stdout_logger.setLevel(max(previous, logging.WARNING))
+    # three different loggers carry the setup chatter: the MADEVENT banner
+    # (madevent.stdout), the "load configuration from ..." lines
+    # (madgraph.stdout, from CommonRunCmd.set_configuration) and the shell-tool
+    # notes such as "Using default gzip" (cmdprint.ext_program, from misc)
+    names = ('madevent.stdout', 'madgraph.stdout', 'cmdprint.ext_program')
+    previous = {}
+    for name in names:
+        lg = logging.getLogger(name)
+        previous[name] = lg.level
+        lg.setLevel(max(lg.level, logging.WARNING))
     try:
         yield
     finally:
-        stdout_logger.setLevel(previous)
+        for name, level in previous.items():
+            logging.getLogger(name).setLevel(level)
 
 
 class MG7RunCmd(madevent_interface.MadEventCmd):

--- a/madgraph/iolibs/template_files/mg7/run_interface.py
+++ b/madgraph/iolibs/template_files/mg7/run_interface.py
@@ -15,6 +15,7 @@ and inherit the real (parallel) shower code, etc., instead of re-implementing
 each tool.
 """
 
+import contextlib
 import gzip
 import logging
 import os
@@ -27,6 +28,24 @@ import madgraph.various.lhe_parser as lhe_parser
 
 pjoin = os.path.join
 logger = logging.getLogger('madevent')
+
+
+@contextlib.contextmanager
+def _quiet_setup():
+    """Silence the INFO chatter of a madevent interface being constructed.
+
+    Raises the stdout logger to WARNING for the duration, so the banner and the
+    configuration lines are dropped while anything that actually needs saying
+    still gets through.
+    """
+
+    stdout_logger = logging.getLogger('madevent.stdout')
+    previous = stdout_logger.level
+    stdout_logger.setLevel(max(previous, logging.WARNING))
+    try:
+        yield
+    finally:
+        stdout_logger.setLevel(previous)
 
 
 class MG7RunCmd(madevent_interface.MadEventCmd):
@@ -57,7 +76,14 @@ class MG7RunCmd(madevent_interface.MadEventCmd):
         # Make the run directory look enough like a madevent run for the
         # results-db scan (and the tools' event-file lookup) to be happy.
         self._prepare_run_dir()
-        super(MG7RunCmd, self).__init__(me_dir, merged, force_run=True)
+        # MadEventCmd.__init__ announces itself with the MADEVENT welcome
+        # banner and a run of "load configuration from ..." lines. That is
+        # right for `./bin/madevent`, which is an interface someone just
+        # started; this is an internal adapter built to drive a tool, in the
+        # middle of a run that has already introduced itself. Keep the setup
+        # quiet -- warnings and errors still come through.
+        with _quiet_setup():
+            super(MG7RunCmd, self).__init__(me_dir, merged, force_run=True)
 
     # ------------------------------------------------------------------
     # directory / run-state adaptation

--- a/tests/unit_tests/interface/test_mg7_launch.py
+++ b/tests/unit_tests/interface/test_mg7_launch.py
@@ -1,0 +1,489 @@
+################################################################################
+#
+# Copyright (c) 2026 The MadGraph5_aMC@NLO Development team and Contributors
+#
+# This file is a part of the MadGraph5_aMC@NLO project, an application which
+# automatically generates Feynman diagrams and matrix elements for arbitrary
+# high-energy processes in the Standard Model and beyond.
+#
+# It is subject to the MadGraph5_aMC@NLO license which should accompany this
+# distribution.
+#
+# For more information, visit madgraph.phys.ucl.ac.be and amcatnlo.web.cern.ch
+#
+################################################################################
+"""`launch` on an mg7 output.
+
+The mg7 branch of :meth:`MadGraphCmd.do_launch` used to shell out to
+``bin/generate_events`` and guess, from a hand-written prefix list, which of the
+lines following ``launch`` in the user's command file belonged to the run. It
+now builds the run interface in process and registers it through
+``define_child_cmd_interface``, exactly like a madevent output, so the run reads
+MG5's own script and hands back what it does not understand.
+
+The wiring tests here stub the launcher module, so they run without a compiled
+madspace; the tests that exercise the real :class:`MG7Cmd` are skipped when
+madspace is not installed.
+"""
+
+from __future__ import absolute_import
+
+import os
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+
+import madgraph.interface.extended_cmd as ext_cmd
+import madgraph.interface.master_interface as mgcmd
+from madgraph.iolibs.template_files.mg7 import bootstrap as mg7_bootstrap
+
+LAUNCH_MODULE = 'madgraph.iolibs.template_files.mg7.launch'
+
+
+def make_mg7_dir(root):
+    """The minimum that makes find_output_type() answer 'mg7'."""
+    os.makedirs(os.path.join(root, 'SubProcesses'))
+    os.makedirs(os.path.join(root, 'Cards'))
+    with open(os.path.join(root, 'Cards', 'run_card.toml'), 'w') as stream:
+        stream.write('[run]\nrun_name = "run"\n')
+    return root
+
+
+class FakeMG7Cmd(ext_cmd.Cmd):
+    """Stands in for the real MG7Cmd: records what it was asked to run."""
+
+    def __init__(self, me_dir='.', options=None):
+        super(FakeMG7Cmd, self).__init__()
+        self.me_dir = me_dir
+        # the real MG7Cmd layers these over the output's own configuration;
+        # keep the raw argument so the wiring can be checked
+        self.raw_options = options
+        self.options = options or {}
+        self.commands = []
+        self.raise_on_run = None
+
+    def do_generate_events(self, line):
+        self.commands.append(line)
+        if self.raise_on_run is not None:
+            raise self.raise_on_run
+
+    def do_quit(self, line):
+        self.commands.append('quit')
+        return True
+
+
+class MG7LaunchWiringTest(unittest.TestCase):
+    """do_launch's mg7 branch: what it builds and what it hands the child."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.me_dir = make_mg7_dir(os.path.join(self.tmpdir.name, 'PROC'))
+
+        self.cmd = mgcmd.MasterCmd()
+        self.cmd.use_rawinput = False
+
+        # MG5's error handling writes a 'debug' file into the working
+        # directory; keep that (and anything else a test provokes) inside the
+        # temporary directory instead of the checkout.
+        self._saved_cwd = os.getcwd()
+        os.chdir(self.tmpdir.name)
+
+        # Stub the launcher module: importing the real one needs madspace.
+        self.built = []
+        stub = types.ModuleType(LAUNCH_MODULE)
+
+        def MG7Cmd(me_dir='.', options=None):
+            child = FakeMG7Cmd(me_dir, options)
+            self.built.append(child)
+            return child
+
+        stub.MG7Cmd = MG7Cmd
+        self.stub = stub
+        self._saved_module = sys.modules.get(LAUNCH_MODULE)
+        sys.modules[LAUNCH_MODULE] = stub
+        # `from pkg import launch` resolves through the parent package's
+        # attribute when the real module has already been imported (which
+        # MG7CmdTest does), so sys.modules alone is not enough to stub it.
+        import madgraph.iolibs.template_files.mg7 as mg7_pkg
+        self.mg7_pkg = mg7_pkg
+        self._saved_attr = getattr(mg7_pkg, 'launch', None)
+        mg7_pkg.launch = stub
+
+        # Never run the real madspace bootstrap from a unit test.
+        self.bootstrap_calls = []
+        self._saved_ensure = mg7_bootstrap.ensure_madspace
+        mg7_bootstrap.ensure_madspace = \
+            lambda interactive=None: self.bootstrap_calls.append(interactive)
+
+    def tearDown(self):
+        mg7_bootstrap.ensure_madspace = self._saved_ensure
+        if self._saved_module is None:
+            sys.modules.pop(LAUNCH_MODULE, None)
+        else:
+            sys.modules[LAUNCH_MODULE] = self._saved_module
+        if self._saved_attr is None:
+            del self.mg7_pkg.launch
+        else:
+            self.mg7_pkg.launch = self._saved_attr
+        os.chdir(self._saved_cwd)
+        self.tmpdir.cleanup()
+
+    def launch(self, line, script_lines=()):
+        """Run `launch <line>` with ``script_lines`` following it in the file."""
+        self.cmd.inputfile = iter(list(script_lines))
+        self.cmd.do_launch('%s %s' % (self.me_dir, line) if line else self.me_dir)
+        return self.built[-1] if self.built else None
+
+    # -- the bug this change fixes ------------------------------------------
+    def test_set_line_is_left_for_the_question_not_scavenged(self):
+        """The lines after `launch` must stay in MG5's inputfile.
+
+        The subprocess branch consumed every following line that did not start
+        with one of a fixed list of MG5 keywords -- `set` deliberately among the
+        consumed ones -- and piped them to the child's stdin. An MG5-level
+        `set gauge Feynman` after `launch` was therefore swallowed with no
+        message from either side. In process the child shares MG5's inputfile,
+        so nothing is consumed up front.
+        """
+        remaining = ['set nevents 500\n', 'set gauge Feynman\n']
+        self.launch('', remaining)
+        # the child was handed the *same* iterator, still holding both lines
+        child = self.built[-1]
+        self.assertIs(child.inputfile, self.cmd.inputfile)
+        self.assertEqual([l.strip() for l in child.inputfile],
+                         ['set nevents 500', 'set gauge Feynman'])
+
+    def test_child_is_registered_with_mg5(self):
+        """define_child_cmd_interface is what gives the child MG5's script."""
+        self.launch('')
+        child = self.built[-1]
+        self.assertIs(child.mother, self.cmd)
+        self.assertIs(self.cmd.child, child)
+
+    def test_child_runs_generate_events_then_quits(self):
+        child = self.launch('')
+        # do_generate_events is handed the arguments, so a bare launch is ''
+        self.assertEqual(child.commands, ['', 'quit'])
+
+    def test_me_dir_and_options_are_passed(self):
+        child = self.launch('')
+        # check_launch normalises the path with realpath
+        self.assertEqual(child.me_dir, os.path.realpath(self.me_dir))
+        self.assertIs(child.raw_options, self.cmd.options)
+
+    # -- launch options, all of which the subprocess branch dropped ---------
+    def test_force_flag_is_forwarded(self):
+        child = self.launch('-f')
+        self.assertEqual(child.commands[0], '-f')
+
+    def test_run_name_is_forwarded(self):
+        child = self.launch('-n myrun')
+        self.assertEqual(child.commands[0], '--name=myrun')
+
+    def test_laststep_is_forwarded(self):
+        child = self.launch('--laststep=parton')
+        self.assertEqual(child.commands[0], '--laststep=parton')
+
+    def test_options_combine(self):
+        child = self.launch('-f -n myrun --laststep=parton')
+        self.assertEqual(child.commands[0],
+                         '-f --name=myrun --laststep=parton')
+
+    def test_interactive_hands_over_the_prompt(self):
+        """`launch -i` must give the user the child's own command loop."""
+        self.cmd.inputfile = iter([])
+        self.cmd.do_launch('%s -i' % self.me_dir)
+        child = self.built[-1]
+        self.assertIs(self.cmd.child, child)
+        # not driven with a canned command: the user drives it
+        self.assertEqual(child.commands, [])
+
+    # -- interrupts ---------------------------------------------------------
+    def test_keyboard_interrupt_reaches_the_error_handling(self):
+        """Ctrl-C used to be swallowed by `except KeyboardInterrupt: pass`.
+
+        Going through the child's run_cmd means it now reaches the standard
+        cmd error handling: stop_on_keyboard_stop runs and the interrupt then
+        stops MG5, like every other interface, rather than being dropped so the
+        rest of the script runs on as if nothing happened.
+        """
+        stopped = []
+
+        def MG7Cmd(me_dir='.', options=None):
+            child = FakeMG7Cmd(me_dir, options)
+            child.raise_on_run = KeyboardInterrupt()
+            child.stop_on_keyboard_stop = lambda: stopped.append(True)
+            self.built.append(child)
+            return child
+
+        self.stub.MG7Cmd = MG7Cmd
+        self.cmd.inputfile = iter([])
+        self.assertRaises(SystemExit, self.cmd.do_launch, self.me_dir)
+        self.assertEqual(stopped, [True])
+
+    # -- the environment the subprocess branch used to build ---------------
+    def test_environment_is_exported_in_process(self):
+        """MADGRAPH_HEPTOOLS_DIR / LHAPDF_DATA_PATH / MADGRAPH_LHAPDF_CONFIG
+        used to be put in the subprocess env; in process they have to reach
+        os.environ, which is the only channel the tools the run shells out to
+        (the madspace build, the real LHAPDF library) can read."""
+        saved = {k: os.environ.get(k) for k in
+                 ('MADGRAPH_HEPTOOLS_DIR', 'LHAPDF_DATA_PATH',
+                  'MADGRAPH_LHAPDF_CONFIG')}
+        for key in saved:
+            os.environ.pop(key, None)
+        try:
+            self.cmd.options['heptools_install_dir'] = self.tmpdir.name
+            self.cmd.setup_mg7_environment()
+            self.assertEqual(os.environ.get('MADGRAPH_HEPTOOLS_DIR'),
+                             os.path.abspath(self.tmpdir.name))
+        finally:
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+    def test_bootstrap_is_told_the_interactivity_explicitly(self):
+        """The bootstrap must not guess from sys.argv/sys.stdin in process."""
+        self.launch('')
+        self.assertEqual(self.bootstrap_calls, [False])
+
+        self.bootstrap_calls[:] = []
+        self.cmd.use_rawinput = True
+        self.cmd.inputfile = iter([])
+        self.cmd.do_launch(self.me_dir)
+        self.assertEqual(self.bootstrap_calls, [True])
+
+
+class MG7BootstrapTest(unittest.TestCase):
+    """The one-off madspace install that used to be a launch.py import side
+    effect."""
+
+    def setUp(self):
+        self.saved = (mg7_bootstrap.INSTALL_DIR, mg7_bootstrap.MADSPACE_DIR,
+                      subprocess.run)
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        (mg7_bootstrap.INSTALL_DIR, mg7_bootstrap.MADSPACE_DIR,
+         subprocess.run) = self.saved
+        sys.path[:] = [p for p in sys.path if self.tmpdir.name not in p]
+        self.tmpdir.cleanup()
+
+    def point_at_empty_install(self):
+        from pathlib import Path
+        root = Path(self.tmpdir.name)
+        mg7_bootstrap.MADSPACE_DIR = root / 'madspace'
+        mg7_bootstrap.INSTALL_DIR = root / 'madspace' / 'install'
+        return root
+
+    def record_runs(self):
+        calls = []
+
+        def fake_run(cmd, **opts):
+            calls.append((cmd, opts))
+            return types.SimpleNamespace(returncode=0)
+
+        subprocess.run = fake_run
+        return calls
+
+    @staticmethod
+    def quiet():
+        """The bootstrap narrates the install on stdout; keep it out of the
+        test output."""
+        import contextlib
+        import io
+        return contextlib.redirect_stdout(io.StringIO())
+
+    def test_no_install_when_already_present(self):
+        root = self.point_at_empty_install()
+        (root / 'madspace' / 'install' / 'madspace').mkdir(parents=True)
+        calls = self.record_runs()
+        with self.quiet():
+            mg7_bootstrap.ensure_madspace(interactive=False)
+        self.assertEqual(calls, [])
+        self.assertIn(str(mg7_bootstrap.INSTALL_DIR), sys.path)
+
+    def test_non_interactive_install_is_unattended(self):
+        self.point_at_empty_install()
+        calls = self.record_runs()
+        with self.quiet():
+            mg7_bootstrap.ensure_madspace(interactive=False)
+        self.assertEqual(len(calls), 1)
+        cmd, opts = calls[0]
+        self.assertIn('--source', cmd)
+        self.assertIn('--yes', cmd)
+        # must not eat the caller's stdin, which carries the run's script
+        self.assertEqual(opts['stdin'], subprocess.DEVNULL)
+
+    def test_interactive_install_keeps_the_terminal(self):
+        self.point_at_empty_install()
+        calls = self.record_runs()
+        with self.quiet():
+            mg7_bootstrap.ensure_madspace(interactive=True)
+        cmd, opts = calls[0]
+        self.assertNotIn('--yes', cmd)
+        self.assertIsNone(opts['stdin'])
+
+    def test_explicit_interactivity_ignores_sys_argv(self):
+        """In process, sys.argv is MG5's command line, not the run's: a `-f`
+        meant for `mg5_aMC -f` must not be read as this run's force flag."""
+        self.point_at_empty_install()
+        calls = self.record_runs()
+        saved_argv = sys.argv
+        sys.argv = ['mg5_aMC', '-f']
+        try:
+            with self.quiet():
+                mg7_bootstrap.ensure_madspace(interactive=True)
+        finally:
+            sys.argv = saved_argv
+        cmd, opts = calls[0]
+        self.assertNotIn('--yes', cmd)
+
+    def test_drop_install_path_leaves_no_shadowing_entry(self):
+        """The install dir also holds madspace's build dependencies (yaml,
+        packaging, pathspec, ...), so leaving it on sys.path would shadow the
+        caller's copies for the rest of what is now MG5's own session."""
+        root = self.point_at_empty_install()
+        (root / 'madspace' / 'install' / 'madspace').mkdir(parents=True)
+        calls = self.record_runs()
+        mg7_bootstrap.ensure_madspace(interactive=False)
+        self.assertIn(str(mg7_bootstrap.INSTALL_DIR), sys.path)
+        mg7_bootstrap.drop_install_path()
+        self.assertNotIn(str(mg7_bootstrap.INSTALL_DIR), sys.path)
+        self.assertEqual(calls, [])
+
+    def test_failure_is_reported(self):
+        self.point_at_empty_install()
+
+        def failing_run(cmd, **opts):
+            return types.SimpleNamespace(returncode=1)
+
+        subprocess.run = failing_run
+        with self.quiet():
+            self.assertRaises(RuntimeError,
+                              mg7_bootstrap.ensure_madspace, interactive=False)
+
+
+@unittest.skipUnless(mg7_bootstrap.madspace_is_installed(),
+                     'madspace is not installed')
+class MG7CmdTest(unittest.TestCase):
+    """The real run interface (needs a compiled madspace to import)."""
+
+    def setUp(self):
+        from madgraph.iolibs.template_files.mg7 import launch as mg7_launch
+        self.launch = mg7_launch
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.me_dir = make_mg7_dir(os.path.join(self.tmpdir.name, 'PROC'))
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def make_cmd(self):
+        return self.launch.MG7Cmd(me_dir=self.me_dir)
+
+    def test_option_parsing(self):
+        cmd = self.make_cmd()
+        self.assertEqual(cmd._parse_run_options('-f'),
+                         {'force': True, 'name': '', 'laststep': ''})
+        self.assertEqual(cmd._parse_run_options('--name=abc')['name'], 'abc')
+        self.assertEqual(cmd._parse_run_options('--laststep=parton')['laststep'],
+                         'parton')
+        self.assertEqual(
+            cmd._parse_run_options('-f --name=abc --laststep=parton'),
+            {'force': True, 'name': 'abc', 'laststep': 'parton'})
+        # space-separated forms, as typed at the MG7> prompt
+        self.assertEqual(cmd._parse_run_options('-n abc'),
+                         {'force': False, 'name': 'abc', 'laststep': ''})
+        self.assertEqual(cmd._parse_run_options('-s parton')['laststep'],
+                         'parton')
+        # a bare word is the run name
+        self.assertEqual(cmd._parse_run_options('myrun')['name'], 'myrun')
+
+    def test_laststep_parton_switches_every_tool_off(self):
+        cmd = self.make_cmd()
+        switch = {'shower': 'Pythia8', 'madspin': 'ON', 'reweight': 'OFF'}
+        out = cmd._apply_laststep(switch, {'laststep': 'parton'})
+        self.assertEqual(out, {'shower': 'OFF', 'madspin': 'OFF',
+                               'reweight': 'OFF'})
+
+    def test_laststep_empty_leaves_the_switch_alone(self):
+        cmd = self.make_cmd()
+        switch = {'shower': 'Pythia8'}
+        self.assertEqual(cmd._apply_laststep(switch, {'laststep': ''}), switch)
+
+    def test_run_name_is_written_to_the_run_card(self):
+        cmd = self.make_cmd()
+        cwd = os.getcwd()
+        os.chdir(self.me_dir)
+        try:
+            cmd._set_run_name('myrun')
+            with open(os.path.join('Cards', 'run_card.toml')) as stream:
+                self.assertIn('myrun', stream.read())
+        finally:
+            os.chdir(cwd)
+
+    def test_options_come_from_the_output_dir_not_the_cwd(self):
+        """Cards/me5_configuration.txt of the *output* has the last word.
+
+        bin/generate_events chdirs into the output first, so reading the config
+        relative to the working directory was right there. In process MG5 has
+        not moved when the interface is built, so the directory has to be
+        passed explicitly or the output's own configuration is ignored.
+        """
+        with open(os.path.join(self.me_dir, 'Cards',
+                               'me5_configuration.txt'), 'w') as stream:
+            stream.write('delphes_path = /somewhere/delphes\n')
+        cmd = self.make_cmd()
+        self.assertNotEqual(os.getcwd(), self.me_dir)
+        self.assertEqual(cmd.options['delphes_path'], '/somewhere/delphes')
+
+    def test_status_file_path_is_absolute(self):
+        """The status file must not depend on the working directory.
+
+        ms.StatusFile finishes its write from a C++ destructor, which runs when
+        Python collects the process object -- for an interrupted run, that is
+        after the launch command has restored the working directory. A relative
+        path there throws a filesystem_error out of a destructor, i.e. aborts
+        the whole of MG5.
+        """
+        recorded = []
+        ms = self.launch.ms
+        saved = ms.StatusFile
+        ms.StatusFile = lambda path: recorded.append(path)
+        cwd = os.getcwd()
+        os.chdir(self.me_dir)
+        try:
+            process = self.launch.MadgraphProcess.__new__(
+                self.launch.MadgraphProcess)
+            process.run_card = {"run": {"run_name": "run"}}
+            process.init_event_dir()
+        finally:
+            os.chdir(cwd)
+            ms.StatusFile = saved
+        self.assertEqual(len(recorded), 1)
+        self.assertTrue(os.path.isabs(recorded[0]), recorded[0])
+
+    def test_setup_logging_defers_to_an_existing_handler(self):
+        """In process MG5 owns the loggers; adding a second handler would print
+        every line twice."""
+        import logging
+        lg = logging.getLogger('madgraph')
+        handler = logging.NullHandler()
+        lg.addHandler(handler)
+        saved = self.launch._TOOL_LOGGING_READY
+        self.launch._TOOL_LOGGING_READY = False
+        try:
+            before = list(lg.handlers)
+            self.launch._setup_logging()
+            self.assertEqual(list(lg.handlers), before)
+        finally:
+            self.launch._TOOL_LOGGING_READY = saved
+            lg.removeHandler(handler)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests/interface/test_mg7_launch.py
+++ b/tests/unit_tests/interface/test_mg7_launch.py
@@ -548,3 +548,64 @@ class TestPostProcessingIsQuiet(unittest.TestCase):
             pass
         self.logger.info('back to normal')
         self.assertIn('back to normal', self.captured.getvalue())
+
+
+class TestPostProcessingIsSkippedWhenThereIsNothingToDo(unittest.TestCase):
+    """A plain generate/output/launch announced a post-processing step with
+    nothing after the colon, and built the run interface to do nothing.
+
+    The guard that was there counted any switch that is not "off", which is a
+    different question from whether any driver will run: "Not Avail." is not
+    off, and a shower switch set to anything but Pythia8 selects nothing here.
+    """
+
+    def tools_for(self, switch):
+        """The tool list run_selected_tools builds, without running it."""
+
+        from madgraph.iolibs.template_files.mg7 import launch
+
+        off = launch._off
+        ma5 = switch.get('analysis') == 'MadAnalysis5'
+        showered = not off(switch.get('shower'))
+        return [t for t, on in (
+            ("reweighting", not off(switch.get("reweight"))),
+            ("MadSpin", not off(switch.get("madspin"))),
+            ("MadAnalysis5 (parton level)", ma5),
+            ("Pythia8 shower", switch.get("shower") == "Pythia8"),
+            ("Delphes", switch.get("detector") == "Delphes"),
+            ("MadAnalysis5 (hadron level)", ma5 and showered),
+            ("Rivet", switch.get("analysis") == "Rivet"),
+        ) if on]
+
+    def test_a_not_available_switch_selects_no_tool(self):
+        """The case from a real run: Delphes is not installed, so the detector
+        switch reads "Not Avail." -- which is not "off"."""
+
+        switch = {'shower': 'OFF', 'detector': 'Not Avail.',
+                  'analysis': 'OFF', 'madspin': 'OFF', 'reweight': 'OFF'}
+        self.assertEqual(self.tools_for(switch), [])
+
+    def test_everything_off_selects_no_tool(self):
+        switch = {'shower': 'OFF', 'detector': 'OFF', 'analysis': 'OFF',
+                  'madspin': 'OFF', 'reweight': 'OFF'}
+        self.assertEqual(self.tools_for(switch), [])
+
+    def test_a_real_selection_still_selects(self):
+        switch = {'shower': 'Pythia8', 'detector': 'Not Avail.',
+                  'analysis': 'OFF', 'madspin': 'ON', 'reweight': 'OFF'}
+        self.assertEqual(self.tools_for(switch), ['MadSpin', 'Pythia8 shower'])
+
+    def test_run_selected_tools_returns_before_building_anything(self):
+        """With no tool selected it must not construct MG7RunCmd -- that is
+        what printed the MADEVENT banner and the configuration lines."""
+
+        from madgraph.iolibs.template_files.mg7 import launch
+
+        class _Process(object):
+            run_path = '/nonexistent/run_01'
+
+        switch = {'shower': 'OFF', 'detector': 'Not Avail.',
+                  'analysis': 'OFF', 'madspin': 'OFF', 'reweight': 'OFF'}
+        # _find_event_file would fail on the fake path, and MG7RunCmd would
+        # fail harder: returning early means neither is reached
+        launch.run_selected_tools(switch, _Process())

--- a/tests/unit_tests/interface/test_mg7_launch.py
+++ b/tests/unit_tests/interface/test_mg7_launch.py
@@ -28,6 +28,7 @@ madspace is not installed.
 
 from __future__ import absolute_import
 
+import logging
 import os
 import subprocess
 import sys
@@ -487,3 +488,63 @@ class MG7CmdTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestPostProcessingIsQuiet(unittest.TestCase):
+    """MG7RunCmd is an internal adapter, not an interface someone started.
+
+    MadEventCmd.__init__ prints the MADEVENT welcome banner and a run of
+    "load configuration from ..." lines, which is right for ./bin/madevent and
+    wrong in the middle of a run that has already introduced itself.
+    """
+
+    def setUp(self):
+        import io
+
+        self.captured = io.StringIO()
+        self.handler = logging.StreamHandler(self.captured)
+        self.logger = logging.getLogger('madevent.stdout')
+        self.saved = self.logger.level
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.INFO)
+
+    def tearDown(self):
+        self.logger.removeHandler(self.handler)
+        self.logger.setLevel(self.saved)
+
+    def test_info_is_dropped_during_setup(self):
+        from madgraph.iolibs.template_files.mg7.run_interface import _quiet_setup
+
+        with _quiet_setup():
+            self.logger.info('W E L C O M E to')
+            self.logger.info('load configuration from somewhere')
+        self.assertNotIn('W E L C O M E', self.captured.getvalue())
+        self.assertNotIn('load configuration', self.captured.getvalue())
+
+    def test_warnings_still_get_through(self):
+        """Quiet is not silent: anything that needs saying still says it."""
+
+        from madgraph.iolibs.template_files.mg7.run_interface import _quiet_setup
+
+        with _quiet_setup():
+            self.logger.warning('something worth knowing')
+        self.assertIn('something worth knowing', self.captured.getvalue())
+
+    def test_the_level_is_restored_afterwards(self):
+        from madgraph.iolibs.template_files.mg7.run_interface import _quiet_setup
+
+        with _quiet_setup():
+            pass
+        self.logger.info('back to normal')
+        self.assertIn('back to normal', self.captured.getvalue())
+
+    def test_it_restores_the_level_after_a_failure(self):
+        from madgraph.iolibs.template_files.mg7.run_interface import _quiet_setup
+
+        try:
+            with _quiet_setup():
+                raise RuntimeError('setup blew up')
+        except RuntimeError:
+            pass
+        self.logger.info('back to normal')
+        self.assertIn('back to normal', self.captured.getvalue())


### PR DESCRIPTION
## The bug

`do_launch`'s mg7 branch shelled out to `bin/generate_events`. Having no shared
`inputfile` with the child, it scavenged the lines following `launch` out of
MG5's own script using a fixed prefix list — and `set` was deliberately *not* on
it, so **every `set` after `launch` was consumed and piped to the child's stdin**.

Confirmed before changing anything, by stubbing the child to capture its stdin:

```
launch PROC_MG7
set gauge Feynman
```

| | |
|---|---|
| child stdin | `set gauge Feynman\ndone\n` |
| MG5's log | *nothing about gauge* |
| exit code | 0 |

Controls: `set gauge Feynman` on its own logs `Passing to gauge Feynman.`; an
unknown MG5 `set` raises `InvalidCmd` loudly; and the **identical script on a
madevent output** prints `WARNING: invalid set command gauge Feynman`. So the
silence was mg7-only.

The same capture showed the branch read only `args[1]` and dropped `options`
entirely: `launch PROC -f -n myrun --laststep=parton` reached the child as
`ARGV=[]`. `-i` was ignored too.

## The fix

Build the run interface in process and register it with
`define_child_cmd_interface`, exactly as the madevent branch does.

This needed **no new home for the code**. Unlike madevent (whose
`bin/internal/launch_plugin.py` is copied into the output), an mg7 output
contains no Python at all — `bin/generate_events` is a ten-line shim doing
`from madgraph.iolibs.template_files.mg7.launch import main`. The launcher and
`MG7RunCmd` were already MG5-tree modules being imported across a process
boundary for no structural reason.

`MG7Cmd` is lifted out of `build_selector_cmd` to module level and gains
`do_generate_events`. It is deliberately the same object in two roles — the card
question's *mother* and MG5's registered *child* — because `Cmd.ask` resolves
scripted answers through `self.check_answer_in_input_file` on the mother, so
sharing MG5's `inputfile` is the entire mechanism. `main()` now runs the same
command, so the two entry points cannot drift.

## Three bugs the move exposed

All invisible before, because the subprocess simply died:

- **`ms.StatusFile` held a relative path** and finishes its write from a **C++
  destructor** (rename `info.json.tmp` → `info.json`). That destructor runs when
  Python collects the process object — for an interrupted run, *after* the launch
  restored the working directory. The rename then threw `filesystem_error` out of
  a destructor: `libc++abi: terminating`, **SIGABRT of all of MG5**. Hit while
  driving a real Ctrl-C.
- **`load_mg5_options()` read `Cards/me5_configuration.txt` from `os.getcwd()`** —
  correct only because `bin/generate_events` chdirs first. In process the output's
  own configuration was silently ignored.
- **`madspace/install` is prepended to `sys.path`** but also ships `yaml`,
  `packaging`, `pathspec`, `scikit_build_core`. Harmless in a throwaway process;
  permanent shadowing in MG5's session. Dropped once madspace is imported.

## Also

The madspace bootstrap moves to its own module (which must never import
madspace) so MG5 can run it before the heavy import. It used to read
interactivity off `sys.argv`/`sys.stdin`, which describe MG5, not the run, once
called in process.

`set iseed N` now maps to the mg7 `run.seed`, translating madevent's `0`
(random) to mg7's `-1`. Deliberately in `MG7Selector.do_set` and **not** in
`RunCardMG7._LO_SCALAR_MAP`, which also drives the LO→MG7 card conversion and
would there silently pin those runs to the fixed seed 0. `set iseed 42` and
`set seed 42` now both give 861.6224131199998 pb, reproducibly. Closes a wart
noted in the mg7 tutorial.

Ctrl-C reaches the standard cmd error handling instead of `except
KeyboardInterrupt: pass`, and run failures are covered by MG5's error handling
and `crash_on_error`.

## Verification

Real runs, madspace built from source:

- `set gauge Feynman` after `launch` now warns exactly like madevent
- `-f`, `-n myrun`, `--laststep=parton` honoured (all previously dropped)
- `launch -i` works — new; `-i` used to be ignored outright
- gridpack **produced and replayed** (`bin/generate_events --events 50 --seed 7`)
- Pythia8 post-processing through `MG7RunCmd` inside MG5's process
- two launches, and two different output dirs, in one MG5 session
- `bin/generate_events` unaffected
- `test_mg7_reproducibility` acceptance test passes **for real** — 4 tests, no
  skips (it self-skips without madspace + the NNPDF23 set, which reads as a
  false green)

**Regressions:** full unit suite run against unmodified HEAD in a scratch
worktree. 94 errors / 2 failures on *both*, with a **byte-identical failure
set**. All pre-existing — 78 are `No module named 'numpy'` (not installed for
this python3.14), the rest downstream, plus the known loop-induced and
IOTest-golden failures. The 24-test delta is the new test file.

25 new tests in `tests/unit_tests/interface/test_mg7_launch.py`. The wiring
tests stub the launcher so they run without a compiled madspace; the rest skip
when madspace is absent.

## Note

`docs/tutorial-mode-plan.md` doesn't exist on this branch (it lives on
`claude/tutorial-mode-planning-6ae446`), so nothing was written there. The
process boundary that blocked M7 is gone, but following the tutorial *into* the
run remains M7's own work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
