### PR TITLE
Fix the LHE intermediate-particle record in the mg7 output

### DIFF
--- a/madgraph/iolibs/export_mg7.py
+++ b/madgraph/iolibs/export_mg7.py
@@ -226,6 +226,33 @@ class OneProcessExporterMG7(export_cpp.OneProcessExporterCPP):
             leg_sets.append(downstream)
         return leg_sets
 
+    def propagator_pdg(self, leg, leg_set):
+        """Signed pdg id of the internal line `leg`, oriented the way the
+        phase-space topology reads it: flowing away from the initial state.
+
+        Madgraph records, on the leg a vertex creates, the pdg of the line
+        flowing into the legs that were combined to make it -- `leg_set`.
+        That is already the decay orientation while those are all final
+        state, but a line holding *every* initial leg is the one madspace
+        roots the other way round: its decay products are the complementary
+        legs, so what belongs in the LHE is the anti-particle. Without this
+        the s-channel W+ of `p p > e+ ve` is written as a W- decaying to
+        e+ ve. A leg set holding only some of the initial legs is a
+        t-channel, which never becomes a decay and is left as madgraph put
+        it.
+
+        Only colour singlets actually depend on this: for a coloured line
+        lhe_output.cpp's compute_decay_color infers the orientation from the
+        colour flow and flips the pdg back itself.
+        """
+        part = self.model.get_particle(leg.get("id"))
+        if part.get("self_antipart"):
+            return part.get("pdg_code")
+        sign = 1 if part.get("is_part") else -1
+        if sum(1 for name in leg_set if name.startswith("i")) == self.n_initial:
+            sign = -sign
+        return sign * part.get("pdg_code")
+
     def diagram_propagator_pdgs(self, diagram, channel_leg_sets, sym_perm):
         """Signed pdg id of each internal line of `diagram`, reordered to
         match `channel_leg_sets` (the order used for
@@ -237,13 +264,9 @@ class OneProcessExporterMG7(export_cpp.OneProcessExporterCPP):
         pdg_by_leg_set = {}
         for i_vert, vertex in enumerate(diag_vertices[:-1]):
             legs = vertex.get("legs")
-            final_part = self.model.get_particle(legs[-1].get("id"))
-            sign = (
-                1
-                if final_part.get("is_part") or final_part.get("self_antipart") else
-                -1
+            pdg_by_leg_set[leg_sets[i_vert]] = self.propagator_pdg(
+                legs[-1], leg_sets[i_vert]
             )
-            pdg_by_leg_set[leg_sets[i_vert]] = sign * final_part.get("pdg_code")
         return [pdg_by_leg_set[leg_set] for leg_set in channel_leg_sets]
 
     def set_channels_colors_map(self):
@@ -304,12 +327,14 @@ class OneProcessExporterMG7(export_cpp.OneProcessExporterCPP):
             on_shell_propagators = []
             diagram_edge_names = dict(self.edge_names)
             diag_vertices = diagram.get("vertices")
+            # Index-aligned with `propagators`: both are filled in vertex-list
+            # order and both skip the closing vertex, which is the last one.
+            leg_sets = self.diagram_edge_leg_sets(diagram)
             for i_vert, vertex in enumerate(diag_vertices):
                 legs = vertex.get("legs")
                 # Last amplitude vertex does not create new edges
                 vertex_props = [diagram_edge_names[leg.get("number")] for leg in legs[:-1]]
 
-                final_part = self.model.get_particle(legs[-1].get("id"))
                 if i_vert == len(diag_vertices) - 1:
                     vertex_props.append(diagram_edge_names[legs[-1].get("number")])
                 else:
@@ -317,12 +342,9 @@ class OneProcessExporterMG7(export_cpp.OneProcessExporterCPP):
                     prop_name = f"p{prop_index}"
                     diagram_edge_names[legs[-1].get("number")] = prop_name
                     vertex_props.append(prop_name)
-                    sign = (
-                        1
-                        if final_part.get("is_part") or final_part.get("self_antipart") else
-                        -1
+                    propagators.append(
+                        self.propagator_pdg(legs[-1], leg_sets[prop_index])
                     )
-                    propagators.append(sign * final_part.get("pdg_code"))
                     if legs[-1].get("onshell"):
                         on_shell_propagators.append(prop_index)
                 vertices.append(vertex_props)
@@ -330,7 +352,7 @@ class OneProcessExporterMG7(export_cpp.OneProcessExporterCPP):
             chan_index = len(self.channels)
             self.diagram_tags.append([IdentifyTopologyTag(diagram, self.model)])
             channel_indices.append(chan_index)
-            channel_leg_sets.append(self.diagram_edge_leg_sets(diagram))
+            channel_leg_sets.append(leg_sets)
             self.channels.append(
                 {
                     "propagators": propagators,

--- a/madspace/src/driver/lhe_output.cpp
+++ b/madspace/src/driver/lhe_output.cpp
@@ -252,6 +252,14 @@ void LHECompleter::find_resonant_propagators(
     std::vector<std::tuple<int, int>>& prop_colors,
     std::vector<int>& resonant_prop_indices
 ) {
+    // For each decay, the propagators hanging below it with no propagator in
+    // between. A decay that never becomes a propagator is not written to the
+    // LHE, so what sits under it belongs to the nearest ancestor that is: its
+    // mask passes straight through. Without this a resonance separated from
+    // its parent resonance by a plain internal line keeps mother (1,2) -- the
+    // W of a q q~ > Z > l l(-> l W) diagram, say.
+    std::vector<int> subtree_prop_masks(topo.decays().size(), 0);
+
     // Pass 1: resonance status from mass/width alone, no color involved.
     for (auto& decay : std::views::reverse(topo.decays())) {
         if (decay.child_indices.size() == 0) {
@@ -270,9 +278,12 @@ void LHECompleter::find_resonant_propagators(
             int child_prop_index = resonant_prop_indices.at(child_index);
             if (child_prop_index != -1) {
                 child_prop_mask |= 1 << child_prop_index;
+            } else {
+                child_prop_mask |= subtree_prop_masks.at(child_index);
             }
         }
         if (e_min_item >= decay.mass) {
+            subtree_prop_masks.at(decay.index) = child_prop_mask;
             continue;
         }
 
@@ -578,7 +589,13 @@ void LHECompleter::complete_event_data(
             momentum_mask >>= 1;
         }
         double m2 = e * e - px * px - py * py - pz * pz;
-        double m_min = propagator.mass - _bw_cutoff * propagator.width;
+        // Once bw_cutoff exceeds mass/width the window reaches below zero,
+        // where there is no invariant mass left to exclude. Squaring a
+        // negative m_min would instead turn it into a large positive floor and
+        // reject nearly everything, so a wider window would write *fewer*
+        // resonances than a narrow one.
+        double m_min =
+            std::max(0., propagator.mass - _bw_cutoff * propagator.width);
         double m_max = propagator.mass + _bw_cutoff * propagator.width;
         if (m2 > m_min * m_min && m2 < m_max * m_max) {
             auto [color, anti_color] = prop_color;
@@ -604,6 +621,19 @@ void LHECompleter::complete_event_data(
     event.particles.insert(
         event.particles.begin() + n_in, new_particles.rbegin(), new_particles.rend()
     );
+    // Where each propagator ended up among the ones this event actually wrote,
+    // which is the order they were just inserted in: outermost first. Only the
+    // propagators inside resonant_prop_mask have a row, and child_prop_mask
+    // names them by prop_index, so the two orders have to be related
+    // explicitly -- counting set mask bits instead lands on the wrong row as
+    // soon as a propagator in between is resonant without being a child.
+    std::vector<int> res_index_of_prop(prop_count, -1);
+    for (std::size_t prop_index = prop_count, next_res_index = 0; prop_index-- > 0;) {
+        if (resonant_prop_mask & (1 << prop_index)) {
+            res_index_of_prop.at(prop_index) = static_cast<int>(next_res_index++);
+        }
+    }
+
     for (std::size_t prop_index = prop_count, res_index = 0;
          auto& propagator : std::views::reverse(
              std::span(
@@ -613,16 +643,24 @@ void LHECompleter::complete_event_data(
          )) {
         --prop_index;
         if (resonant_prop_mask & (1 << prop_index)) {
-            int child_prop_mask = propagator.child_prop_mask;
-            for (int child_prop_index = prop_index - 1, child_res_index = res_index + 1;
-                 child_prop_index >= 0;
-                 --child_prop_index) {
-                if (child_prop_mask & (1 << child_prop_index)) {
-                    auto& child_particle = event.particles.at(child_res_index + n_in);
-                    child_particle.mother1 = res_index + n_in + 1;
-                    child_particle.mother2 = res_index + n_in + 1;
-                    ++child_res_index;
+            // Descend through the propagators this event left off shell: they
+            // have no row of their own, so their children attach here.
+            int pending_prop_mask = propagator.child_prop_mask;
+            while (pending_prop_mask != 0) {
+                int child_prop_index = 0;
+                while ((pending_prop_mask & (1 << child_prop_index)) == 0) {
+                    ++child_prop_index;
                 }
+                pending_prop_mask &= ~(1 << child_prop_index);
+                int child_res_index = res_index_of_prop.at(child_prop_index);
+                if (child_res_index == -1) {
+                    pending_prop_mask |=
+                        _propagators.at(prop_offset + child_prop_index).child_prop_mask;
+                    continue;
+                }
+                auto& child_particle = event.particles.at(child_res_index + n_in);
+                child_particle.mother1 = res_index + n_in + 1;
+                child_particle.mother2 = res_index + n_in + 1;
             }
 
             int momentum_mask = propagator.momentum_mask >> n_in;


### PR DESCRIPTION
Three defects in what madspace writes for LHE status-2 (intermediate) lines. Weights, momenta and cross sections are untouched throughout — but MadSpin, Rivet routines keyed on a boson, and any decay-chain analysis read these rows.

Found while checking the W sign for `p p > w+ 1-2j` and `p p > e+ ve +0-2j`. **W+jets was already correct** (the W is external there, status 1, and `subprocesses.json` has no W propagator at all); the problem is entirely on the `e+ ve` side.

## 1. Resonances built from the beam side got the anti-particle pdg

Madgraph records, on the leg a vertex creates, the pdg of the line flowing *into* the legs that were combined. That is already the decay orientation while those are all final state — but a line holding **every** initial leg is the one madspace roots the other way round, so what belongs in the LHE is the anti-particle.

```
p p > e+ ve       every 0-jet event wrote  -24  decaying to e+ ve
p p > e+ ve h     one channel carried the production W- and the decaying W+
p p > t b~        -24
```

`madevent` does not have this: it re-orients first via `get_s_and_t_channels`.

Fixed in `OneProcessExporterMG7.propagator_pdg`, now used by both propagator writers. Flipping on *any* initial leg instead would also hit t-channels, which never become decays — that wider rule wrongly flipped a top in a `t t~` decay chain.

## 2. Nested resonances lost their parent link

A resonance sitting under a plain internal line kept mother `(1,2)`, because `child_prop_mask` only ever named *direct* children — a `q q~ > Z > l l(-> l W)` diagram wrote the W as a child of the beams and left the Z with the wrong daughters. Two more ways the same link broke, found by reading the loop rather than from a failing event:

- `complete_event_data` mapped `prop_index` to row by counting set mask bits, which lands on the wrong row as soon as a propagator in between is resonant without being a child;
- the mask is decided once from `e_min < mass` while resonance is re-decided per event from the BW window, so it could name a child this event never wrote.

## 3. `bw_cutoff` reversed past `mass/width`

`m2 > m_min*m_min` with an unclamped `m_min = mass - bw_cutoff*width` turned a below-zero window into a large positive floor, so *raising* `bw_cutoff` wrote *fewer* resonances. `m_min` is now clamped at 0. The phase-space side never needed this — it already guards with `e_min > 0.` and `std::max`.

## Verification

Every comparison has the seed pinned, so only the intended columns may move.

| | change |
|---|---|
| (1) `p p > e+ ve +0,1,2j` | exactly 14150 lines, all `-24` → `24`, rest of line identical |
| (1) `p p > e+ ve mu- vm~` | byte-identical (219 371 lines) |
| (2) `p p > e+ ve mu- vm~`, 200k events | 27 lines of 2 198 022, each a W's mother `1 2` → `3 3` |
| (3) `bw_cutoff` 15 and 30 | byte-identical; row count monotonic again — 393848 / 398021 / 439769 / 443691 at 15 / 30 / 150 / 1000 |

Bad-mother counts on the `p p > e+ ve mu- vm~` reproducer went 7 → 0 at the default `bw_cutoff = 15` and 27 → 0 at 30. Both arms were rebuilt from source at identical flags for that comparison — an older install differs by a couple of borderline resonances purely from build flags, which looks like a behaviour change and is not.

The check used throughout is stronger than a charge test: for every status-2 line, its declared daughters' four-momenta must sum to its own. Clean across `p p > e+ ve +0,1,2j`, `p p > w+ j / j j`, `p p > e+ ve mu- vm~` and a `t t~` decay chain — and at `bw_cutoff = 1000`, where nearly every propagator is written and resonances nest everywhere.

`test_color_flow_consistency_mg7` and `test_add_time_of_flight_mg7` pass (the former zeroes all masses, so every propagator's colour is validated through the real C++ walk). `test_group_subprocess_mg7` skips on my machine for a missing LHAPDF data path, and `test_w_production_with_ms_decay_mg7` fails identically on and off this branch (no numpy in the interpreter MadSpin spawns) — both pre-existing and unrelated.

## Note for reviewers

This touches madspace C++, so `python3 madspace/install.py --source --yes` is needed to pick it up — the launcher only installs when `madspace/install/` is missing outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
