### PR TITLE
Give the mg7 interfaces a get_model, so the param_card is validated

### DIFF
--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -7928,6 +7928,36 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             self._export_dir = os.path.sep.join(path_split[:-2])
             return
 
+    def setup_mg7_environment(self):
+        """Export what an mg7 run needs from MG5's configuration.
+
+        These used to be built into the environment of the bin/generate_events
+        subprocess. Running in process, the same values have to reach the tools
+        the run shells out to (the madspace build, the real LHAPDF library used
+        by systematics/MadSpin/reweight), and the only channel those have is
+        os.environ -- so set it here rather than per child process.
+        """
+        # The one-off madspace build picks up a cmake installed through MG5's
+        # 'install cmake' from here (heptools_install_dir may point outside
+        # MG5DIR).
+        heptools_dir = self.options.get('heptools_install_dir')
+        if heptools_dir:
+            if not os.path.isabs(heptools_dir):
+                heptools_dir = pjoin(MG5DIR, heptools_dir)
+            os.environ['MADGRAPH_HEPTOOLS_DIR'] = os.path.abspath(heptools_dir)
+
+        # The resolved LHAPDF location. The launcher resolves it the same way on
+        # its own (launch.lhapdf_paths), so this only matters for the real
+        # LHAPDF library used by the post-processing tools, which reads
+        # LHAPDF_DATA_PATH natively.
+        lhapdf = misc.resolve_lhapdf(self.options, root=MG5DIR, create=True)
+        search = lhapdf.data_paths or (
+            [lhapdf.download_path] if lhapdf.download_path else [])
+        if search:
+            os.environ['LHAPDF_DATA_PATH'] = os.pathsep.join(search)
+        if lhapdf.config:
+            os.environ['MADGRAPH_LHAPDF_CONFIG'] = lhapdf.config
+
     def do_launch(self, line):
         """Main commands: Ask for editing the parameter and then
         Execute the code (madevent/standalone/...)
@@ -8038,66 +8068,42 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                                                  options=self.options,**options)            
         elif args[0] == 'mg7':
             me_dir = args[1]
-            # When MG5 runs non-interactively (a command file / piped input),
-            # drive bin/generate_events from the card-editing commands that
-            # follow `launch` in the script. Feeding them on stdin also makes
-            # the subprocess non-interactive, so the one-off madspace install
-            # runs with defaults instead of blocking on a prompt.
-            scripted = not self.use_rawinput
-            feed_lines = []
-            if scripted and self.inputfile is not None:
-                stop_prefixes = ('generate', 'add process', 'define', 'output',
-                                 'launch', 'import', 'quit', 'exit')
-                while True:
-                    try:
-                        nxt = next(self.inputfile)
-                    except (StopIteration, TypeError):
-                        break
-                    stripped = nxt.replace('\n', '').strip()
-                    if not stripped:
-                        continue
-                    if stripped.lower().startswith(stop_prefixes):
-                        self.store_line(nxt)  # belongs to MG5, hand it back
-                        break
-                    feed_lines.append(stripped)
-                    if stripped.lower() in ('done', '0'):
-                        break
+            # An mg7 output runs in this process, exactly like a madevent one:
+            # the run interface becomes a child cmd interface, which gives it
+            # MG5's inputfile (so the launch question reads the same script and
+            # hands back what it does not understand), MG5's error handling and
+            # crash_on_error, and the loggers already configured here.
+            self.setup_mg7_environment()
 
-            # Expose the configured HEPTools location so that the one-off
-            # madspace build can pick up a cmake installed there via MG5's
-            # 'install cmake' (heptools_install_dir may point outside MG5DIR).
-            gen_env = os.environ.copy()
-            heptools_dir = self.options.get('heptools_install_dir')
-            if heptools_dir:
-                if not os.path.isabs(heptools_dir):
-                    heptools_dir = os.path.join(MG5DIR, heptools_dir)
-                gen_env['MADGRAPH_HEPTOOLS_DIR'] = os.path.abspath(heptools_dir)
+            # Install madspace *before* importing the launcher (importing it is
+            # what needs madspace). The bootstrap has to be told whether it may
+            # take over the terminal: in a subprocess it could read that off
+            # sys.argv/sys.stdin, but in process those describe MG5, not the run.
+            from madgraph.iolibs.template_files.mg7 import bootstrap as mg7_bootstrap
+            mg7_bootstrap.ensure_madspace(
+                interactive=bool(self.use_rawinput) and not options['force'])
+            from madgraph.iolibs.template_files.mg7 import launch as mg7_launch
 
-            # Forward the resolved LHAPDF location. bin/generate_events
-            # resolves it the same way on its own (launch.lhapdf_paths), so
-            # this only matters for the real LHAPDF library used by the
-            # post-processing tools, which reads LHAPDF_DATA_PATH natively.
-            lhapdf = misc.resolve_lhapdf(self.options, root=MG5DIR, create=True)
-            search = lhapdf.data_paths or (
-                [lhapdf.download_path] if lhapdf.download_path else [])
-            if search:
-                gen_env['LHAPDF_DATA_PATH'] = os.pathsep.join(search)
-            if lhapdf.config:
-                gen_env['MADGRAPH_LHAPDF_CONFIG'] = lhapdf.config
+            MG7 = mg7_launch.MG7Cmd(me_dir=me_dir, options=self.options)
+            if options['interactive']:
+                stop = self.define_child_cmd_interface(MG7)
+                return stop
+
+            mother = self
 
             class ext_program:
                 @staticmethod
                 def run():
-                    os.chdir(me_dir)
-                    gen = os.path.join("bin", "generate_events")
-                    try:
-                        if scripted:
-                            stdin_text = "\n".join(feed_lines + ["done"]) + "\n"
-                            subprocess.run([gen], input=stdin_text, text=True, env=gen_env)
-                        else:
-                            subprocess.run(gen, env=gen_env)
-                    except KeyboardInterrupt:
-                        pass
+                    child = mother.define_child_cmd_interface(MG7, interface=False)
+                    command = 'generate_events'
+                    if options['force']:
+                        command += ' -f'
+                    if options['name']:
+                        command += ' --name=%s' % options['name']
+                    if options['laststep']:
+                        command += ' --laststep=%s' % options['laststep']
+                    child.run_cmd(command)
+                    child.run_cmd('quit')
 
         else:
             os.chdir(start_cwd) #ensure to go to the initial path

--- a/madgraph/iolibs/export_cpp.py
+++ b/madgraph/iolibs/export_cpp.py
@@ -3499,20 +3499,31 @@ class ProcessExporterMG7(ProcessExporterCPP):
         if processes:
             run_card.create_default_for_process(self.proc_characteristic,
                                                 history, processes)
-            # persist the model so the runtime can compute widths set to 'auto'
-            # in the param_card (and recompute them at each scan point). A hash
-            # of the model's python source is stored on the second line so the
-            # runtime can detect a model that changed since output.
+            # persist the model so the runtime can reload it: to compute the
+            # widths set to 'auto' in the param_card (and recompute them at
+            # each scan point) and to reset the parameters the model derives
+            # from the free ones (launch.MG7Cmd.get_model). A hash of the
+            # model's python source is stored on the second line so the runtime
+            # can detect a model that changed since output.
             try:
                 model = processes[0][0].get('model')
-                model_path = model.get('modelpath')
-                model_ref = model_path or model.get('name')
+                try:
+                    model_path = model.get('modelpath')
+                    model_hash = misc.hash_model_files(model_path)
+                except Exception:
+                    model_path, model_hash = None, None
+                # the restriction is part of the model the process was
+                # generated with ('sm-no_b_mass' is not 'sm'), so store the
+                # reference that reproduces it, not the bare UFO directory.
+                try:
+                    model_ref = model.get('modelpath+restriction')
+                except Exception:
+                    model_ref = model_path or model.get('name')
                 if model_ref:
-                    model_hash = misc.hash_model_files(model_path) if model_path else None
                     with open(pjoin(self.dir_path, 'SubProcesses', 'model.txt'), 'w') as f:
                         f.write(model_ref + '\n' + (model_hash or '') + '\n')
-            except Exception:
-                pass
+            except Exception as error:
+                logger.debug('could not record the model: %s', error)
 
         template = pjoin(_file_path, 'iolibs', 'template_files',
                          'mg7', 'run_card.toml')

--- a/madgraph/iolibs/template_files/mg7/bootstrap.py
+++ b/madgraph/iolibs/template_files/mg7/bootstrap.py
@@ -1,0 +1,97 @@
+"""One-off madspace bootstrap for the mg7 output.
+
+The mg7 launcher needs the compiled ``madspace`` package. A git checkout ships
+only the sources, so the first run has to build and install it. That bootstrap
+used to live at the top of :mod:`launch.py`, executed as an import side effect.
+That was fine while ``launch`` was only ever imported by ``bin/generate_events``
+in a throw-away subprocess whose ``sys.argv``/``sys.stdin`` described the run
+itself.
+
+``launch`` is now also imported *in process* by MG5's ``launch`` command, where
+neither of those is true: ``sys.argv`` is MG5's own command line (so a ``-f``
+meant for, say, ``mg5_aMC -f`` would be misread as the run's force flag, and
+conversely a ``launch -f`` would not be seen at all) and ``sys.stdin`` is MG5's,
+which may be a terminal even when the run itself is scripted.
+
+So the decision is made by the caller and passed in explicitly. Keeping it in a
+module of its own -- one that must never import ``madspace`` -- lets MG5 run the
+bootstrap *before* importing :mod:`launch`, which is what makes the heavy import
+safe to do lazily.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Locate the madspace installation bundled alongside MadGraph.
+# madgraph/__init__.py lives one level below the MadGraph root, so .parents[1]
+# reaches the root and then "madspace/install" is the local install prefix.
+import madgraph as _mg_pkg
+
+MG_ROOT = Path(_mg_pkg.__file__).parents[1]
+MADSPACE_DIR = MG_ROOT / "madspace"
+INSTALL_DIR = MADSPACE_DIR / "install"
+
+
+def madspace_is_installed() -> bool:
+    """True when a compiled madspace is already available to import."""
+    return (INSTALL_DIR / "madspace").is_dir()
+
+
+def ensure_madspace(interactive=None) -> None:
+    """Install madspace if needed, then put it on ``sys.path``.
+
+    ``interactive`` says whether the installer may take over the terminal and
+    ask questions. ``None`` falls back to auto-detection from ``sys.stdin``,
+    which is only correct for ``bin/generate_events``; every in-process caller
+    should pass the value explicitly.
+    """
+    if not madspace_is_installed():
+        if interactive is None:
+            interactive = sys.stdin.isatty()
+        print()
+        print("You don't have madspace installed for this madgraph instance")
+        print("Running the madspace installation script")
+        print()
+
+        install_cmd = [sys.executable, str(MADSPACE_DIR / "install.py")]
+        # When the run is non-interactive (scripted / piped), install
+        # non-interactively with a source build and default options
+        # (--source --yes), and keep the installer away from our stdin (which
+        # may carry the run's scripted card-editing commands); when
+        # interactive, let it share the terminal so the user can answer.
+        install_stdin = None if interactive else subprocess.DEVNULL
+        if not interactive:
+            install_cmd += ["--source", "--yes"]
+        # Expose madgraph on PYTHONPATH so the installer subprocess can import
+        # cmd.ask for its prompts.
+        install_env = os.environ.copy()
+        install_env["PYTHONPATH"] = os.pathsep.join(
+            [str(MG_ROOT)]
+            + ([install_env["PYTHONPATH"]] if install_env.get("PYTHONPATH") else [])
+        )
+        result = subprocess.run(install_cmd, env=install_env, stdin=install_stdin)
+        if result.returncode != 0:
+            raise RuntimeError("madspace installation failed — see output above")
+
+    if str(INSTALL_DIR) not in sys.path:
+        sys.path.insert(0, str(INSTALL_DIR))
+
+
+def drop_install_path() -> None:
+    """Take the madspace install directory back off ``sys.path``.
+
+    It is not only the madspace package: the installer puts madspace's build
+    dependencies in the same target, so the directory also carries ``yaml``,
+    ``packaging``, ``pathspec``, ``scikit_build_core`` and ``pybind11_stubgen``.
+    Prepending it therefore shadows any of those the caller already had.
+
+    That was harmless while the launcher only ever ran in a throw-away
+    ``bin/generate_events`` process. Now that it is imported into MG5's own
+    long-lived session, the shadowing would outlast the run, so drop the entry
+    once madspace itself is imported. The madspace package keeps working: its
+    submodules resolve through its own ``__path__``, not through ``sys.path``.
+    """
+    while str(INSTALL_DIR) in sys.path:
+        sys.path.remove(str(INSTALL_DIR))

--- a/madgraph/iolibs/template_files/mg7/launch.py
+++ b/madgraph/iolibs/template_files/mg7/launch.py
@@ -14,45 +14,28 @@ from dataclasses import dataclass, field
 from typing import Literal, NamedTuple
 import resource
 
-# Locate the madspace installation bundled alongside MadGraph.
-# madgraph/__init__.py lives one level below the MadGraph root, so .parents[1]
-# reaches the root and then "madspace/install" is the local install prefix.
-import madgraph as _mg_pkg
-_MG_ROOT = Path(_mg_pkg.__file__).parents[1]
-_MADSPACE_DIR = _MG_ROOT / "madspace"
-_INSTALL_DIR = _MADSPACE_DIR / "install"
-if not (_INSTALL_DIR / "madspace").is_dir():
-    print()
-    print("You don't have madspace installed for this madgraph instance")
-    print("Running the madspace installation script")
-    print()
+# Install madspace on first use, then import it. The bootstrap lives in its own
+# module (which must not import madspace) so that an in-process caller can run
+# it *before* importing this one -- see bootstrap.ensure_madspace.
+from madgraph.iolibs.template_files.mg7.bootstrap import (
+    ensure_madspace as _ensure_madspace,
+    drop_install_path as _drop_install_path,
+    MG_ROOT as _MG_ROOT,
+    MADSPACE_DIR as _MADSPACE_DIR,
+    INSTALL_DIR as _INSTALL_DIR,
+)
 
-    _install_cmd = [sys.executable, str(_MADSPACE_DIR / "install.py")]
-    # Expose madgraph on PYTHONPATH so the installer subprocess can import
-    # cmd.ask for its prompts.
-    _noninteractive = "-f" in sys.argv or not sys.stdin.isatty()
-    # When the run is non-interactive (scripted / piped), install
-    # non-interactively with a source build and default options (--source --yes),
-    # and keep the installer away from our stdin (which may carry the run's
-    # scripted card-editing commands); when interactive, let it share the
-    # terminal so the user can answer.
-    _install_stdin = subprocess.DEVNULL if _noninteractive else None
-    if _noninteractive:
-        _install_cmd += ["--source", "--yes"]
-    _install_env = os.environ.copy()
-    _install_env["PYTHONPATH"] = os.pathsep.join(
-        [str(_MG_ROOT)] + ([_install_env["PYTHONPATH"]] if _install_env.get("PYTHONPATH") else [])
-    )
-    _result = subprocess.run(_install_cmd, env=_install_env, stdin=_install_stdin)
-    if _result.returncode != 0:
-        raise RuntimeError("madspace installation failed — see output above")
-if str(_INSTALL_DIR) not in sys.path:
-    sys.path.insert(0, str(_INSTALL_DIR))
+_ensure_madspace()
 
 import madspace as ms
+
+# madspace is imported; stop its install directory from shadowing the caller's
+# yaml/packaging/... for the rest of what is now MG5's own session.
+_drop_install_path()
 from models.check_param_card import ParamCard
 from madgraph.various.banner import RunCardMG7
 from madgraph.various import misc
+from madgraph.interface.extended_cmd import Cmd
 
 _source_hash = subprocess.run(
     [sys.executable, str(_MADSPACE_DIR / "source_hash.py")],
@@ -355,7 +338,16 @@ class MadgraphProcess:
                 break
             except FileExistsError:
                 run_index += 1
-        self.status_file = ms.StatusFile(os.path.join(self.run_path, "info.json"))
+        # Absolute on purpose. StatusFile is a C++ object that finishes its
+        # write from its destructor (rename info.json.tmp -> info.json), and
+        # that destructor runs whenever Python gets round to collecting the
+        # process object. When the launcher runs in MG5's process, an
+        # interrupted run is collected *after* the launch command has restored
+        # the working directory, and a relative path would then resolve
+        # somewhere else -- the rename throws a C++ filesystem_error out of a
+        # destructor, which is an immediate abort.
+        self.status_file = ms.StatusFile(
+            os.path.abspath(os.path.join(self.run_path, "info.json")))
 
     def init_context(self) -> None:
         device_names = self.run_card["run"]["device"]
@@ -2211,7 +2203,7 @@ class MadgraphSubprocess:
 
 _ROOTED_OPTIONS = ('lhapdf', 'lhapdf_py3', 'lhapdf_py2', 'heptools_install_dir')
 
-def load_mg5_options() -> dict:
+def load_mg5_options(me_dir=None) -> dict:
     """Read the tool paths from the MadGraph configuration, so the launcher
     knows where LHAPDF and the optional programs (Pythia8/Delphes/MadSpin/
     reweight/analysis) live.
@@ -2221,11 +2213,16 @@ def load_mg5_options() -> dict:
     this process directory has the last word, then this installation, then the
     per-user file. Relative values are resolved against the root of the file
     they came from.
+
+    ``me_dir`` is the process directory whose Cards/me5_configuration.txt has
+    the last word. It defaults to the working directory, which is right for
+    bin/generate_events (it chdirs there first) but not for an in-process
+    caller, which has not moved yet.
     """
 
     import madgraph
     mg5dir = os.path.dirname(os.path.dirname(os.path.abspath(madgraph.__file__)))
-    me_dir = os.getcwd()
+    me_dir = os.getcwd() if me_dir is None else me_dir
 
     options = {
         'pythia-pgs_path': None, 'pythia8_path': None, 'madanalysis_path': None,
@@ -2286,44 +2283,185 @@ def lhapdf_paths(refresh: bool = False) -> misc.LhapdfPaths:
     return _LHAPDF
 
 
-def build_selector_cmd():
+class MG7Cmd(Cmd):
+    """The mg7 run interface: the command object that drives a launch.
+
+    It plays two roles, and they are the same object on purpose.
+
+    1. It is the *mother* of the merged switch/card question (the thing
+       ``AskRunEditCard`` calls back into for ``keep_cards``/``do_open``/
+       ``compute_widths``).
+    2. It is the child command interface MG5 registers via
+       ``define_child_cmd_interface`` when you type ``launch`` on an mg7 output.
+
+    Role 2 is what makes role 1 behave. ``Cmd.ask`` resolves a scripted answer
+    through ``self.check_answer_in_input_file``, where ``self`` is the mother --
+    so once MG5 hands us its ``inputfile`` and registers itself as our
+    ``mother``, the question reads the very lines that follow ``launch`` in the
+    user's command file, and any line it does not recognise goes back up to MG5
+    through ``store_line`` instead of being silently consumed. This is exactly
+    how a madevent output already behaves; before this class existed the mg7
+    branch shelled out to ``bin/generate_events`` and had to guess which
+    following lines belonged to the run, which quietly swallowed every ``set``.
+    """
+
+    prompt = 'MG7> '
+
+    def __init__(self, me_dir='.', options=None, *args, **opts):
+        super().__init__(*args, **opts)
+        self.me_dir = os.path.abspath(me_dir) if me_dir != '.' else '.'
+        # The rest of the launcher is written against the process directory as
+        # the working directory, so do_generate_events chdirs there; but at
+        # construction time MG5 has not moved, hence the explicit me_dir.
+        self.options = load_mg5_options(
+            self.me_dir if self.me_dir != '.' else None)
+        if options:
+            # MG5's own resolved tool paths win: they are the ones the user
+            # configured in the session that is doing the launching.
+            self.options.update({k: v for k, v in options.items()
+                                 if k in self.options and v is not None})
+        self.plugin_path = []
+        self.proc_characteristics = {'grouped_matrix': False, 'limitations': []}
+
+    # ------------------------------------------------------------------
+    # the contract the card question expects from its mother
+    # ------------------------------------------------------------------
+    def keep_cards(self, need_card=[], ignore=[]):
+        from madgraph.interface.common_run_interface import CommonRunCmd
+        return CommonRunCmd.keep_cards(self, need_card, ignore)
+
+    def do_open(self, line):
+        from madgraph.interface.common_run_interface import CommonRunCmd
+        CommonRunCmd.do_open(self, line)
+
+    def check_open(self, args):
+        from madgraph.interface.common_run_interface import CommonRunCmd
+        CommonRunCmd.check_open(self, args)
+
+    def do_compute_widths(self, line):
+        # The interactive card editor delegates 'auto' width computation to
+        # the mother interface. Reuse the runtime helper (madgraph subprocess
+        # + the model stored at output time). ``line`` looks like
+        # "<pdgs> --path=<param_card> [--nlo]"; we only need the card path.
+        m = re.search(r'--path=(\S+)', line or "")
+        path = m.group(1) if m else os.path.join("Cards", "param_card.dat")
+        compute_auto_widths(path)
+        # return an empty mapping: the caller iterates out.items() for the
+        # small-width treatment, which mg7 does not apply.
+        return {}
+
+    # ------------------------------------------------------------------
+    # running
+    # ------------------------------------------------------------------
+    def do_generate_events(self, line):
+        """generate_events [-f] [-n NAME] [--laststep=parton]
+
+        Run the mg7 generation and the selected post-processing tools."""
+
+        opts = self._parse_run_options(line)
+        cwd = os.getcwd()
+        target = self.me_dir if self.me_dir != '.' else cwd
+        try:
+            os.chdir(target)
+            _setup_logging()
+            if opts['name']:
+                self._set_run_name(opts['name'])
+            switch = {}
+            if not opts['force']:
+                switch = ask_edit_cards(mother=self)
+            switch = self._apply_laststep(switch, opts)
+            force_lhe_output_if_needed(switch)
+            _raise_open_file_limit()
+            run_generation(switch)
+        finally:
+            os.chdir(cwd)
+
+    # ``launch`` is the name MG5 users type; keep it working here too.
+    do_launch = do_generate_events
+
+    def do_quit(self, line):
+        """Leave the mg7 run interface."""
+        return super().do_quit(line)
+
+    do_exit = do_quit
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _parse_run_options(self, line):
+        """Understand the subset of MG5's `launch` options that mean something
+        for an mg7 run, and say so out loud for the ones that do not."""
+        out = {'force': False, 'name': '', 'laststep': ''}
+        args = self.split_arg(line)
+        index = 0
+        while index < len(args):
+            arg = args[index]
+            index += 1
+            if arg in ('-f', '--force'):
+                out['force'] = True
+            elif arg in ('-n', '--name') and index < len(args):
+                out['name'] = args[index]
+                index += 1
+            elif arg.startswith(('-n=', '--name=')):
+                out['name'] = arg.split('=', 1)[1]
+            elif arg in ('-s', '--laststep') and index < len(args):
+                out['laststep'] = args[index]
+                index += 1
+            elif arg.startswith(('-s=', '--laststep=')):
+                out['laststep'] = arg.split('=', 1)[1]
+            elif arg.startswith('-'):
+                logger.warning(
+                    "'%s' is not supported by the mg7 output and is ignored; "
+                    "the equivalent settings live in Cards/run_card.toml", arg)
+            elif arg and not out['name']:
+                out['name'] = arg
+        return out
+
+    def _set_run_name(self, name):
+        """Honour `launch -n NAME`: the mg7 run directory is
+        Events/<run.run_name>_NN, so the name is a run_card setting."""
+        path = os.path.join("Cards", "run_card.toml")
+        run_card = RunCardMG7(path, consistency=False)
+        if run_card["run"]["run_name"] != name:
+            run_card["run"]["run_name"] = name
+            run_card.write(path)
+            logger.info("run name set to '%s'", name)
+
+    def _apply_laststep(self, switch, opts):
+        """`--laststep=parton` means: generate the events, run nothing on them.
+
+        The mg7 tool selection is the switch dict the question returns, so
+        stopping at parton level is switching those entries off.
+        """
+        if opts['laststep'] not in ('parton', 'auto', ''):
+            logger.warning(
+                "--laststep=%s is not supported by the mg7 output; "
+                "select the programs to run in the launch question instead",
+                opts['laststep'])
+            return switch
+        if opts['laststep'] != 'parton' or not switch:
+            return switch
+        switch = dict(switch)
+        for key in ('shower', 'detector', 'analysis', 'madspin', 'reweight'):
+            if not _off(switch.get(key, 'OFF')):
+                logger.info("--laststep=parton: not running %s", key)
+                switch[key] = 'OFF'
+        return switch
+
+
+def build_selector_cmd(mother=None):
     """Build the (monkey-patched) mother command + merged switch/card selector
     used by the mg7 output.  Returns the selector *class* and a mother instance
-    understood by AskRun/AskforEditCard."""
+    understood by AskRun/AskforEditCard.
 
-    from madgraph.interface.common_run_interface import CommonRunCmd
-    from madgraph.interface.extended_cmd import Cmd
+    ``mother`` lets an in-process caller supply its own :class:`MG7Cmd` -- the
+    one MG5 registered as its child -- so that the question resolves scripted
+    answers against MG5's own command file (see :class:`MG7Cmd`). When it is
+    omitted a standalone instance is built, which is what ``bin/generate_events``
+    gets.
+    """
+
     from madgraph.interface.madevent_interface import AskRunEditCard
-
-    class MG7Cmd(Cmd):
-
-        def __init__(self):
-            super().__init__(".", {})
-            self.me_dir = "."
-            self.options = load_mg5_options()
-            self.plugin_path = []
-            self.proc_characteristics = {'grouped_matrix': False, 'limitations': []}
-
-        def keep_cards(self, need_card=[], ignore=[]):
-            return CommonRunCmd.keep_cards(self, need_card, ignore)
-
-        def do_open(self, line):
-            CommonRunCmd.do_open(self, line)
-
-        def check_open(self, args):
-            CommonRunCmd.check_open(self, args)
-
-        def do_compute_widths(self, line):
-            # The interactive card editor delegates 'auto' width computation to
-            # the mother interface. Reuse the runtime helper (madgraph subprocess
-            # + the model stored at output time). ``line`` looks like
-            # "<pdgs> --path=<param_card> [--nlo]"; we only need the card path.
-            m = re.search(r'--path=(\S+)', line or "")
-            path = m.group(1) if m else os.path.join("Cards", "param_card.dat")
-            compute_auto_widths(path)
-            # return an empty mapping: the caller iterates out.items() for the
-            # small-width treatment, which mg7 does not apply.
-            return {}
 
     from madgraph.various import banner as _banner_mod
     from madgraph.various import misc as _misc
@@ -2404,6 +2542,28 @@ def build_selector_cmd():
                         self.modified_card.add("run")
                         return
 
+                    # 'iseed' is the madevent spelling of the mg7 run.seed,
+                    # but the two disagree on how to ask for a random seed:
+                    # madevent uses 0, mg7 uses -1 (0 being a perfectly good
+                    # fixed seed there). Translate here rather than in
+                    # _LO_SCALAR_MAP, which also drives the LO -> MG7 run_card
+                    # conversion and would silently pin those runs to seed 0.
+                    if rest and nlow == 'iseed':
+                        value = run_card.evaluate(rest, masses)
+                        try:
+                            value = int(value)
+                        except (TypeError, ValueError):
+                            value = None
+                        if value is None:
+                            logger.warning("ignoring 'set iseed %s': not an integer", rest)
+                            return
+                        seed = -1 if value == 0 else value
+                        run_card.set('run.seed', seed, user=True)
+                        logger.info("set iseed (mg7 run.seed) of the run_card.toml to %s%s",
+                                    seed, " (random)" if seed == -1 else "")
+                        self.modified_card.add("run")
+                        return
+
                     # legacy madevent run_card names -> mg7 "section.key", so a
                     # madevent-style launch script ("set nevents 500", "set
                     # use_syst F", "set bwcutoff 10", ...) edits the mg7
@@ -2427,15 +2587,20 @@ def build_selector_cmd():
                                 line = "%s%s %s" % (prefix, name, resolved)
             return super().do_set(line, *args, **kwargs)
 
-    return MG7Selector, MG7Cmd()
+    return MG7Selector, (mother if mother is not None else MG7Cmd())
 
 
-def ask_edit_cards() -> dict:
+def ask_edit_cards(mother=None) -> dict:
     """Single (MadDM-style) question letting the user both pick which programs
     to run after generation and edit the associated cards.  Returns the switch
-    dict describing the selected tools."""
+    dict describing the selected tools.
 
-    selector_class, mother = build_selector_cmd()
+    ``mother`` is the :class:`MG7Cmd` asking the question. Passing the instance
+    MG5 registered as its child is what lets a scripted ``launch`` answer this
+    question from MG5's own command file.
+    """
+
+    selector_class, mother = build_selector_cmd(mother)
     # path_msg is what makes Cmd.check_answer_in_input_file accept a bare path as
     # an answer (its "elif path:" branch), so that a scripted launch can hand the
     # question a card/banner path -- as the question itself advertises -- and have
@@ -2515,6 +2680,18 @@ def _off(value) -> bool:
     return value in (None, "OFF", "Not Avail.", "Not Avail. (numpy missing)")
 
 
+def _has_effective_handler(lg) -> bool:
+    """True when ``lg`` (or an ancestor it propagates to) already has a handler,
+    i.e. some other party is already displaying these records."""
+    while lg:
+        if lg.handlers:
+            return True
+        if not lg.propagate:
+            return False
+        lg = lg.parent
+    return False
+
+
 _TOOL_LOGGING_READY = False
 
 
@@ -2529,6 +2706,13 @@ def _setup_logging():
     colored INFO console handler to them (idempotent)."""
     global _TOOL_LOGGING_READY
     if _TOOL_LOGGING_READY:
+        return
+    if _has_effective_handler(logging.getLogger("madgraph")):
+        # Someone already configured logging for us -- in practice MG5, which
+        # now runs the launch in its own process. Its configuration is
+        # authoritative (it owns stdout_level and the tutorial logger); adding
+        # a second handler here would print every line twice.
+        _TOOL_LOGGING_READY = True
         return
     try:
         import madgraph.interface.coloring_logging  # registers ColorFormatter
@@ -2991,20 +3175,26 @@ def force_lhe_output_if_needed(switch) -> None:
             "output_format set to 'lhe' (required by the selected post-processing).")
 
 
-def main() -> None:
-    _setup_logging()
+def _raise_open_file_limit() -> None:
+    """Remove the soft limit on the number of open files: it can be quite low
+    on some systems and the event-combination step opens one file per channel."""
+    soft_lim, hard_lim = resource.getrlimit(resource.RLIMIT_NOFILE)
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (hard_lim, hard_lim))
+    except (ValueError, OSError) as error:
+        logger.debug("could not raise the open-file limit: %s", error)
 
+
+def main() -> None:
+    """``bin/generate_events`` entry point.
+
+    It runs the same :class:`MG7Cmd` command MG5's in-process ``launch`` uses,
+    so the two entry points cannot drift apart; the only difference is that
+    nothing here supplies a ``mother``/``inputfile``, so the question falls back
+    to reading this process's own stdin.
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("-f", action="store_false", dest="ask_edit_cards")
     args = parser.parse_args()
-    switch = {}
 
-    if args.ask_edit_cards:
-        switch = ask_edit_cards()
-        force_lhe_output_if_needed(switch)
-
-    # Remove soft limit on number of open files as it can be quite low on some systems
-    soft_lim, hard_lim = resource.getrlimit(resource.RLIMIT_NOFILE)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (hard_lim, hard_lim))
-
-    run_generation(switch)
+    MG7Cmd().run_cmd("generate_events" if args.ask_edit_cards else "generate_events -f")

--- a/madgraph/iolibs/template_files/mg7/launch.py
+++ b/madgraph/iolibs/template_files/mg7/launch.py
@@ -2322,6 +2322,7 @@ class MG7Cmd(Cmd):
                                  if k in self.options and v is not None})
         self.plugin_path = []
         self.proc_characteristics = {'grouped_matrix': False, 'limitations': []}
+        self._model = None  # lazily imported by get_model()
 
     # ------------------------------------------------------------------
     # the contract the card question expects from its mother
@@ -2337,6 +2338,27 @@ class MG7Cmd(Cmd):
     def check_open(self, args):
         from madgraph.interface.common_run_interface import CommonRunCmd
         CommonRunCmd.check_open(self, args)
+
+    def get_model(self):
+        """The model this process was generated with (an ``import_ufo`` model).
+
+        This is the hook the card question goes through for everything that
+        needs the model rather than the card: 'update dependent' (which resets
+        the masses/widths the model computes from the free parameters) and the
+        generic auto-width handler both call ``mother_interface.get_model()``.
+        Without it the launch question could only warn that it had failed to
+        update the dependent parameters, and MadSpin/the shower then read
+        whatever inconsistent values the param_card still held.
+
+        None when the process recorded no model (an output made before
+        SubProcesses/model.txt existed) -- the caller warns in that case.
+        """
+        if self._model is None:
+            me_dir = self.me_dir if self.me_dir != '.' else None
+            # False (not None) so a model that cannot be imported is not
+            # retried at every question.
+            self._model = load_process_model(me_dir) or False
+        return self._model or None
 
     def do_compute_widths(self, line):
         # The interactive card editor delegates 'auto' width computation to
@@ -2988,6 +3010,98 @@ def run_lhe_postprocessing(process) -> None:
                         os.path.dirname(lhe_path))
 
 
+_model_hash_warned = set()
+_model_cache = {}
+
+
+def read_stored_model(me_dir=None) -> "str | None":
+    """The model this process was generated with, as recorded at output time in
+    ``SubProcesses/model.txt``: a UFO path carrying its restriction (e.g.
+    ``.../models/sm-no_b_mass``) or a model name -- in either case something
+    ``import model`` understands. Returns None when the process was written
+    without that information.
+
+    Warns (once per directory) when the model on disk no longer matches the
+    hash stored on the second line, i.e. it changed since the output was made.
+    """
+    base = me_dir or os.getcwd()
+    model_file = os.path.join(base, "SubProcesses", "model.txt")
+    if not os.path.exists(model_file):
+        return None
+    with open(model_file) as f:
+        lines = f.read().splitlines()
+    model = lines[0].strip() if lines else ""
+    stored_hash = lines[1].strip() if len(lines) > 1 else ""
+    if not model:
+        logger.warning("SubProcesses/model.txt is empty; the model of this "
+                       "process is unknown.")
+        return None
+
+    # verify the model on disk still matches the one used at output time. The
+    # reference may carry a restriction suffix ('sm-no_b_mass'); the hash was
+    # taken on the UFO directory itself ('sm').
+    model_dir = model if os.path.isdir(model) else model.rsplit('-', 1)[0]
+    if stored_hash and os.path.isdir(model_dir) \
+            and model_file not in _model_hash_warned:
+        current_hash = misc.hash_model_files(model_dir)
+        if current_hash and current_hash != stored_hash:
+            _model_hash_warned.add(model_file)
+            logger.warning(
+                "The model at %s has changed since this process was generated "
+                "(hash mismatch); anything computed from it now (the 'auto' "
+                "widths, the dependent masses/widths of the param_card) may be "
+                "inconsistent with the matrix element.", model_dir)
+    return model
+
+
+def _proc_characteristic(me_dir=None) -> dict:
+    """SubProcesses/proc_characteristics as a plain dict (empty when the file is
+    missing or unreadable). Plain, because ProcCharacteristic is a ConfigFile,
+    whose get() is the parameter accessor and takes no default."""
+    from madgraph.various import banner as _banner_mod
+    path = os.path.join(me_dir or os.getcwd(), 'SubProcesses',
+                        'proc_characteristics')
+    if os.path.exists(path):
+        try:
+            return dict(_banner_mod.ProcCharacteristic(path))
+        except Exception as error:
+            logger.debug("could not read %s: %s", path, error)
+    return {}
+
+
+def load_process_model(me_dir=None):
+    """Import the UFO model this process was generated with, as
+    :func:`models.import_ufo.import_model` builds it -- the object every
+    model-level consumer of the param_card expects (see
+    :meth:`MG7Cmd.get_model`). None when the process recorded no model, or when
+    that model no longer imports.
+
+    Cached per (reference, complex-mass-scheme): importing a model is slow and
+    the card question asks for it again at every 'update dependent'."""
+    ref = read_stored_model(me_dir)
+    if not ref:
+        return None
+    cms = _proc_characteristic(me_dir).get('complex_mass_scheme', False)
+    key = (ref, bool(cms))
+    if key not in _model_cache:
+        import models.import_ufo as import_ufo
+        try:
+            with misc.MuteLogger(['madgraph.model'], [50]):
+                _model_cache[key] = import_ufo.import_model(
+                    ref, complex_mass_scheme=bool(cms))
+        except Exception as error:
+            # 'update dependent' calls this under a SIGALRM whose handler
+            # raises a TimeOutError of its own (a class defined inside the
+            # caller, so it can only be recognised by name). Let it through:
+            # the caller then says the model took too long to load and how to
+            # force it, instead of reporting a model that does not import.
+            if type(error).__name__ == 'TimeOutError':
+                raise
+            logger.debug("could not import the model %s: %s", ref, error)
+            _model_cache[key] = None
+    return _model_cache[key]
+
+
 def compute_auto_widths(param_card_path=os.path.join("Cards", "param_card.dat")) -> None:
     """Fill any width set to ``auto`` in the param_card, using madgraph and the
     model stored at output time (``SubProcesses/model.txt``), and write the
@@ -3008,29 +3122,12 @@ def compute_auto_widths(param_card_path=os.path.join("Cards", "param_card.dat"))
         return
     pdgs = list(dict.fromkeys(pdgs))  # de-duplicate, keep order
 
-    model_file = os.path.join("SubProcesses", "model.txt")
-    if not os.path.exists(model_file):
-        logger.warning(
-            "The param_card requests 'auto' width(s) for %s but the model was "
-            "not stored with this process; leaving them as-is.", " ".join(pdgs))
-        return
-    with open(model_file) as f:
-        lines = f.read().splitlines()
-    model = lines[0].strip() if lines else ""
-    stored_hash = lines[1].strip() if len(lines) > 1 else ""
+    model = read_stored_model()
     if not model:
-        logger.warning("SubProcesses/model.txt is empty; 'auto' widths not computed.")
+        logger.warning(
+            "The param_card requests 'auto' width(s) for %s but the model of "
+            "this process is unknown; leaving them as-is.", " ".join(pdgs))
         return
-
-    # verify the model on disk still matches the one used at output time
-    if stored_hash and os.path.isdir(model):
-        current_hash = misc.hash_model_files(model)
-        if current_hash and current_hash != stored_hash:
-            logger.warning(
-                "The model at %s has changed since this process was generated "
-                "(hash mismatch); the 'auto' width(s) will be computed with the "
-                "current model, which may be inconsistent with the matrix "
-                "element.", model)
 
     mg5 = str(_MG_ROOT / "bin" / "madgraph")
     if not os.path.exists(mg5):

--- a/madgraph/iolibs/template_files/mg7/run_interface.py
+++ b/madgraph/iolibs/template_files/mg7/run_interface.py
@@ -155,6 +155,18 @@ class MG7RunCmd(madevent_interface.MadEventCmd):
         """No Fortran include files to generate for the mg7 output."""
         return
 
+    def get_model(self):
+        """The model of the process, read from ``SubProcesses/model.txt``.
+
+        The inherited version imports ``bin/internal/ufomodel``, the copy a
+        madevent output carries; the mg7 output has none, it records which
+        model it was generated with instead. Same hook, same object -- so the
+        tools this class drives (MadSpin, reweight, the auto widths and the
+        'update dependent' pass of their card questions) work here too.
+        """
+        from madgraph.iolibs.template_files.mg7.launch import load_process_model
+        return load_process_model(self.me_dir)
+
     def do_set(self, line, log=True):
         """Intercept the compiler options: the base handler patches
         ``Source/make_opts`` to switch Fortran/C++ compilers, which does not

--- a/tests/unit_tests/interface/test_mg7_launch.py
+++ b/tests/unit_tests/interface/test_mg7_launch.py
@@ -1,0 +1,489 @@
+################################################################################
+#
+# Copyright (c) 2026 The MadGraph5_aMC@NLO Development team and Contributors
+#
+# This file is a part of the MadGraph5_aMC@NLO project, an application which
+# automatically generates Feynman diagrams and matrix elements for arbitrary
+# high-energy processes in the Standard Model and beyond.
+#
+# It is subject to the MadGraph5_aMC@NLO license which should accompany this
+# distribution.
+#
+# For more information, visit madgraph.phys.ucl.ac.be and amcatnlo.web.cern.ch
+#
+################################################################################
+"""`launch` on an mg7 output.
+
+The mg7 branch of :meth:`MadGraphCmd.do_launch` used to shell out to
+``bin/generate_events`` and guess, from a hand-written prefix list, which of the
+lines following ``launch`` in the user's command file belonged to the run. It
+now builds the run interface in process and registers it through
+``define_child_cmd_interface``, exactly like a madevent output, so the run reads
+MG5's own script and hands back what it does not understand.
+
+The wiring tests here stub the launcher module, so they run without a compiled
+madspace; the tests that exercise the real :class:`MG7Cmd` are skipped when
+madspace is not installed.
+"""
+
+from __future__ import absolute_import
+
+import os
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+
+import madgraph.interface.extended_cmd as ext_cmd
+import madgraph.interface.master_interface as mgcmd
+from madgraph.iolibs.template_files.mg7 import bootstrap as mg7_bootstrap
+
+LAUNCH_MODULE = 'madgraph.iolibs.template_files.mg7.launch'
+
+
+def make_mg7_dir(root):
+    """The minimum that makes find_output_type() answer 'mg7'."""
+    os.makedirs(os.path.join(root, 'SubProcesses'))
+    os.makedirs(os.path.join(root, 'Cards'))
+    with open(os.path.join(root, 'Cards', 'run_card.toml'), 'w') as stream:
+        stream.write('[run]\nrun_name = "run"\n')
+    return root
+
+
+class FakeMG7Cmd(ext_cmd.Cmd):
+    """Stands in for the real MG7Cmd: records what it was asked to run."""
+
+    def __init__(self, me_dir='.', options=None):
+        super(FakeMG7Cmd, self).__init__()
+        self.me_dir = me_dir
+        # the real MG7Cmd layers these over the output's own configuration;
+        # keep the raw argument so the wiring can be checked
+        self.raw_options = options
+        self.options = options or {}
+        self.commands = []
+        self.raise_on_run = None
+
+    def do_generate_events(self, line):
+        self.commands.append(line)
+        if self.raise_on_run is not None:
+            raise self.raise_on_run
+
+    def do_quit(self, line):
+        self.commands.append('quit')
+        return True
+
+
+class MG7LaunchWiringTest(unittest.TestCase):
+    """do_launch's mg7 branch: what it builds and what it hands the child."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.me_dir = make_mg7_dir(os.path.join(self.tmpdir.name, 'PROC'))
+
+        self.cmd = mgcmd.MasterCmd()
+        self.cmd.use_rawinput = False
+
+        # MG5's error handling writes a 'debug' file into the working
+        # directory; keep that (and anything else a test provokes) inside the
+        # temporary directory instead of the checkout.
+        self._saved_cwd = os.getcwd()
+        os.chdir(self.tmpdir.name)
+
+        # Stub the launcher module: importing the real one needs madspace.
+        self.built = []
+        stub = types.ModuleType(LAUNCH_MODULE)
+
+        def MG7Cmd(me_dir='.', options=None):
+            child = FakeMG7Cmd(me_dir, options)
+            self.built.append(child)
+            return child
+
+        stub.MG7Cmd = MG7Cmd
+        self.stub = stub
+        self._saved_module = sys.modules.get(LAUNCH_MODULE)
+        sys.modules[LAUNCH_MODULE] = stub
+        # `from pkg import launch` resolves through the parent package's
+        # attribute when the real module has already been imported (which
+        # MG7CmdTest does), so sys.modules alone is not enough to stub it.
+        import madgraph.iolibs.template_files.mg7 as mg7_pkg
+        self.mg7_pkg = mg7_pkg
+        self._saved_attr = getattr(mg7_pkg, 'launch', None)
+        mg7_pkg.launch = stub
+
+        # Never run the real madspace bootstrap from a unit test.
+        self.bootstrap_calls = []
+        self._saved_ensure = mg7_bootstrap.ensure_madspace
+        mg7_bootstrap.ensure_madspace = \
+            lambda interactive=None: self.bootstrap_calls.append(interactive)
+
+    def tearDown(self):
+        mg7_bootstrap.ensure_madspace = self._saved_ensure
+        if self._saved_module is None:
+            sys.modules.pop(LAUNCH_MODULE, None)
+        else:
+            sys.modules[LAUNCH_MODULE] = self._saved_module
+        if self._saved_attr is None:
+            del self.mg7_pkg.launch
+        else:
+            self.mg7_pkg.launch = self._saved_attr
+        os.chdir(self._saved_cwd)
+        self.tmpdir.cleanup()
+
+    def launch(self, line, script_lines=()):
+        """Run `launch <line>` with ``script_lines`` following it in the file."""
+        self.cmd.inputfile = iter(list(script_lines))
+        self.cmd.do_launch('%s %s' % (self.me_dir, line) if line else self.me_dir)
+        return self.built[-1] if self.built else None
+
+    # -- the bug this change fixes ------------------------------------------
+    def test_set_line_is_left_for_the_question_not_scavenged(self):
+        """The lines after `launch` must stay in MG5's inputfile.
+
+        The subprocess branch consumed every following line that did not start
+        with one of a fixed list of MG5 keywords -- `set` deliberately among the
+        consumed ones -- and piped them to the child's stdin. An MG5-level
+        `set gauge Feynman` after `launch` was therefore swallowed with no
+        message from either side. In process the child shares MG5's inputfile,
+        so nothing is consumed up front.
+        """
+        remaining = ['set nevents 500\n', 'set gauge Feynman\n']
+        self.launch('', remaining)
+        # the child was handed the *same* iterator, still holding both lines
+        child = self.built[-1]
+        self.assertIs(child.inputfile, self.cmd.inputfile)
+        self.assertEqual([l.strip() for l in child.inputfile],
+                         ['set nevents 500', 'set gauge Feynman'])
+
+    def test_child_is_registered_with_mg5(self):
+        """define_child_cmd_interface is what gives the child MG5's script."""
+        self.launch('')
+        child = self.built[-1]
+        self.assertIs(child.mother, self.cmd)
+        self.assertIs(self.cmd.child, child)
+
+    def test_child_runs_generate_events_then_quits(self):
+        child = self.launch('')
+        # do_generate_events is handed the arguments, so a bare launch is ''
+        self.assertEqual(child.commands, ['', 'quit'])
+
+    def test_me_dir_and_options_are_passed(self):
+        child = self.launch('')
+        # check_launch normalises the path with realpath
+        self.assertEqual(child.me_dir, os.path.realpath(self.me_dir))
+        self.assertIs(child.raw_options, self.cmd.options)
+
+    # -- launch options, all of which the subprocess branch dropped ---------
+    def test_force_flag_is_forwarded(self):
+        child = self.launch('-f')
+        self.assertEqual(child.commands[0], '-f')
+
+    def test_run_name_is_forwarded(self):
+        child = self.launch('-n myrun')
+        self.assertEqual(child.commands[0], '--name=myrun')
+
+    def test_laststep_is_forwarded(self):
+        child = self.launch('--laststep=parton')
+        self.assertEqual(child.commands[0], '--laststep=parton')
+
+    def test_options_combine(self):
+        child = self.launch('-f -n myrun --laststep=parton')
+        self.assertEqual(child.commands[0],
+                         '-f --name=myrun --laststep=parton')
+
+    def test_interactive_hands_over_the_prompt(self):
+        """`launch -i` must give the user the child's own command loop."""
+        self.cmd.inputfile = iter([])
+        self.cmd.do_launch('%s -i' % self.me_dir)
+        child = self.built[-1]
+        self.assertIs(self.cmd.child, child)
+        # not driven with a canned command: the user drives it
+        self.assertEqual(child.commands, [])
+
+    # -- interrupts ---------------------------------------------------------
+    def test_keyboard_interrupt_reaches_the_error_handling(self):
+        """Ctrl-C used to be swallowed by `except KeyboardInterrupt: pass`.
+
+        Going through the child's run_cmd means it now reaches the standard
+        cmd error handling: stop_on_keyboard_stop runs and the interrupt then
+        stops MG5, like every other interface, rather than being dropped so the
+        rest of the script runs on as if nothing happened.
+        """
+        stopped = []
+
+        def MG7Cmd(me_dir='.', options=None):
+            child = FakeMG7Cmd(me_dir, options)
+            child.raise_on_run = KeyboardInterrupt()
+            child.stop_on_keyboard_stop = lambda: stopped.append(True)
+            self.built.append(child)
+            return child
+
+        self.stub.MG7Cmd = MG7Cmd
+        self.cmd.inputfile = iter([])
+        self.assertRaises(SystemExit, self.cmd.do_launch, self.me_dir)
+        self.assertEqual(stopped, [True])
+
+    # -- the environment the subprocess branch used to build ---------------
+    def test_environment_is_exported_in_process(self):
+        """MADGRAPH_HEPTOOLS_DIR / LHAPDF_DATA_PATH / MADGRAPH_LHAPDF_CONFIG
+        used to be put in the subprocess env; in process they have to reach
+        os.environ, which is the only channel the tools the run shells out to
+        (the madspace build, the real LHAPDF library) can read."""
+        saved = {k: os.environ.get(k) for k in
+                 ('MADGRAPH_HEPTOOLS_DIR', 'LHAPDF_DATA_PATH',
+                  'MADGRAPH_LHAPDF_CONFIG')}
+        for key in saved:
+            os.environ.pop(key, None)
+        try:
+            self.cmd.options['heptools_install_dir'] = self.tmpdir.name
+            self.cmd.setup_mg7_environment()
+            self.assertEqual(os.environ.get('MADGRAPH_HEPTOOLS_DIR'),
+                             os.path.abspath(self.tmpdir.name))
+        finally:
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+    def test_bootstrap_is_told_the_interactivity_explicitly(self):
+        """The bootstrap must not guess from sys.argv/sys.stdin in process."""
+        self.launch('')
+        self.assertEqual(self.bootstrap_calls, [False])
+
+        self.bootstrap_calls[:] = []
+        self.cmd.use_rawinput = True
+        self.cmd.inputfile = iter([])
+        self.cmd.do_launch(self.me_dir)
+        self.assertEqual(self.bootstrap_calls, [True])
+
+
+class MG7BootstrapTest(unittest.TestCase):
+    """The one-off madspace install that used to be a launch.py import side
+    effect."""
+
+    def setUp(self):
+        self.saved = (mg7_bootstrap.INSTALL_DIR, mg7_bootstrap.MADSPACE_DIR,
+                      subprocess.run)
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        (mg7_bootstrap.INSTALL_DIR, mg7_bootstrap.MADSPACE_DIR,
+         subprocess.run) = self.saved
+        sys.path[:] = [p for p in sys.path if self.tmpdir.name not in p]
+        self.tmpdir.cleanup()
+
+    def point_at_empty_install(self):
+        from pathlib import Path
+        root = Path(self.tmpdir.name)
+        mg7_bootstrap.MADSPACE_DIR = root / 'madspace'
+        mg7_bootstrap.INSTALL_DIR = root / 'madspace' / 'install'
+        return root
+
+    def record_runs(self):
+        calls = []
+
+        def fake_run(cmd, **opts):
+            calls.append((cmd, opts))
+            return types.SimpleNamespace(returncode=0)
+
+        subprocess.run = fake_run
+        return calls
+
+    @staticmethod
+    def quiet():
+        """The bootstrap narrates the install on stdout; keep it out of the
+        test output."""
+        import contextlib
+        import io
+        return contextlib.redirect_stdout(io.StringIO())
+
+    def test_no_install_when_already_present(self):
+        root = self.point_at_empty_install()
+        (root / 'madspace' / 'install' / 'madspace').mkdir(parents=True)
+        calls = self.record_runs()
+        with self.quiet():
+            mg7_bootstrap.ensure_madspace(interactive=False)
+        self.assertEqual(calls, [])
+        self.assertIn(str(mg7_bootstrap.INSTALL_DIR), sys.path)
+
+    def test_non_interactive_install_is_unattended(self):
+        self.point_at_empty_install()
+        calls = self.record_runs()
+        with self.quiet():
+            mg7_bootstrap.ensure_madspace(interactive=False)
+        self.assertEqual(len(calls), 1)
+        cmd, opts = calls[0]
+        self.assertIn('--source', cmd)
+        self.assertIn('--yes', cmd)
+        # must not eat the caller's stdin, which carries the run's script
+        self.assertEqual(opts['stdin'], subprocess.DEVNULL)
+
+    def test_interactive_install_keeps_the_terminal(self):
+        self.point_at_empty_install()
+        calls = self.record_runs()
+        with self.quiet():
+            mg7_bootstrap.ensure_madspace(interactive=True)
+        cmd, opts = calls[0]
+        self.assertNotIn('--yes', cmd)
+        self.assertIsNone(opts['stdin'])
+
+    def test_explicit_interactivity_ignores_sys_argv(self):
+        """In process, sys.argv is MG5's command line, not the run's: a `-f`
+        meant for `mg5_aMC -f` must not be read as this run's force flag."""
+        self.point_at_empty_install()
+        calls = self.record_runs()
+        saved_argv = sys.argv
+        sys.argv = ['mg5_aMC', '-f']
+        try:
+            with self.quiet():
+                mg7_bootstrap.ensure_madspace(interactive=True)
+        finally:
+            sys.argv = saved_argv
+        cmd, opts = calls[0]
+        self.assertNotIn('--yes', cmd)
+
+    def test_drop_install_path_leaves_no_shadowing_entry(self):
+        """The install dir also holds madspace's build dependencies (yaml,
+        packaging, pathspec, ...), so leaving it on sys.path would shadow the
+        caller's copies for the rest of what is now MG5's own session."""
+        root = self.point_at_empty_install()
+        (root / 'madspace' / 'install' / 'madspace').mkdir(parents=True)
+        calls = self.record_runs()
+        mg7_bootstrap.ensure_madspace(interactive=False)
+        self.assertIn(str(mg7_bootstrap.INSTALL_DIR), sys.path)
+        mg7_bootstrap.drop_install_path()
+        self.assertNotIn(str(mg7_bootstrap.INSTALL_DIR), sys.path)
+        self.assertEqual(calls, [])
+
+    def test_failure_is_reported(self):
+        self.point_at_empty_install()
+
+        def failing_run(cmd, **opts):
+            return types.SimpleNamespace(returncode=1)
+
+        subprocess.run = failing_run
+        with self.quiet():
+            self.assertRaises(RuntimeError,
+                              mg7_bootstrap.ensure_madspace, interactive=False)
+
+
+@unittest.skipUnless(mg7_bootstrap.madspace_is_installed(),
+                     'madspace is not installed')
+class MG7CmdTest(unittest.TestCase):
+    """The real run interface (needs a compiled madspace to import)."""
+
+    def setUp(self):
+        from madgraph.iolibs.template_files.mg7 import launch as mg7_launch
+        self.launch = mg7_launch
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.me_dir = make_mg7_dir(os.path.join(self.tmpdir.name, 'PROC'))
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def make_cmd(self):
+        return self.launch.MG7Cmd(me_dir=self.me_dir)
+
+    def test_option_parsing(self):
+        cmd = self.make_cmd()
+        self.assertEqual(cmd._parse_run_options('-f'),
+                         {'force': True, 'name': '', 'laststep': ''})
+        self.assertEqual(cmd._parse_run_options('--name=abc')['name'], 'abc')
+        self.assertEqual(cmd._parse_run_options('--laststep=parton')['laststep'],
+                         'parton')
+        self.assertEqual(
+            cmd._parse_run_options('-f --name=abc --laststep=parton'),
+            {'force': True, 'name': 'abc', 'laststep': 'parton'})
+        # space-separated forms, as typed at the MG7> prompt
+        self.assertEqual(cmd._parse_run_options('-n abc'),
+                         {'force': False, 'name': 'abc', 'laststep': ''})
+        self.assertEqual(cmd._parse_run_options('-s parton')['laststep'],
+                         'parton')
+        # a bare word is the run name
+        self.assertEqual(cmd._parse_run_options('myrun')['name'], 'myrun')
+
+    def test_laststep_parton_switches_every_tool_off(self):
+        cmd = self.make_cmd()
+        switch = {'shower': 'Pythia8', 'madspin': 'ON', 'reweight': 'OFF'}
+        out = cmd._apply_laststep(switch, {'laststep': 'parton'})
+        self.assertEqual(out, {'shower': 'OFF', 'madspin': 'OFF',
+                               'reweight': 'OFF'})
+
+    def test_laststep_empty_leaves_the_switch_alone(self):
+        cmd = self.make_cmd()
+        switch = {'shower': 'Pythia8'}
+        self.assertEqual(cmd._apply_laststep(switch, {'laststep': ''}), switch)
+
+    def test_run_name_is_written_to_the_run_card(self):
+        cmd = self.make_cmd()
+        cwd = os.getcwd()
+        os.chdir(self.me_dir)
+        try:
+            cmd._set_run_name('myrun')
+            with open(os.path.join('Cards', 'run_card.toml')) as stream:
+                self.assertIn('myrun', stream.read())
+        finally:
+            os.chdir(cwd)
+
+    def test_options_come_from_the_output_dir_not_the_cwd(self):
+        """Cards/me5_configuration.txt of the *output* has the last word.
+
+        bin/generate_events chdirs into the output first, so reading the config
+        relative to the working directory was right there. In process MG5 has
+        not moved when the interface is built, so the directory has to be
+        passed explicitly or the output's own configuration is ignored.
+        """
+        with open(os.path.join(self.me_dir, 'Cards',
+                               'me5_configuration.txt'), 'w') as stream:
+            stream.write('delphes_path = /somewhere/delphes\n')
+        cmd = self.make_cmd()
+        self.assertNotEqual(os.getcwd(), self.me_dir)
+        self.assertEqual(cmd.options['delphes_path'], '/somewhere/delphes')
+
+    def test_status_file_path_is_absolute(self):
+        """The status file must not depend on the working directory.
+
+        ms.StatusFile finishes its write from a C++ destructor, which runs when
+        Python collects the process object -- for an interrupted run, that is
+        after the launch command has restored the working directory. A relative
+        path there throws a filesystem_error out of a destructor, i.e. aborts
+        the whole of MG5.
+        """
+        recorded = []
+        ms = self.launch.ms
+        saved = ms.StatusFile
+        ms.StatusFile = lambda path: recorded.append(path)
+        cwd = os.getcwd()
+        os.chdir(self.me_dir)
+        try:
+            process = self.launch.MadgraphProcess.__new__(
+                self.launch.MadgraphProcess)
+            process.run_card = {"run": {"run_name": "run"}}
+            process.init_event_dir()
+        finally:
+            os.chdir(cwd)
+            ms.StatusFile = saved
+        self.assertEqual(len(recorded), 1)
+        self.assertTrue(os.path.isabs(recorded[0]), recorded[0])
+
+    def test_setup_logging_defers_to_an_existing_handler(self):
+        """In process MG5 owns the loggers; adding a second handler would print
+        every line twice."""
+        import logging
+        lg = logging.getLogger('madgraph')
+        handler = logging.NullHandler()
+        lg.addHandler(handler)
+        saved = self.launch._TOOL_LOGGING_READY
+        self.launch._TOOL_LOGGING_READY = False
+        try:
+            before = list(lg.handlers)
+            self.launch._setup_logging()
+            self.assertEqual(list(lg.handlers), before)
+        finally:
+            self.launch._TOOL_LOGGING_READY = saved
+            lg.removeHandler(handler)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests/interface/test_mg7_launch.py
+++ b/tests/unit_tests/interface/test_mg7_launch.py
@@ -29,17 +29,20 @@ madspace is not installed.
 from __future__ import absolute_import
 
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
 import types
 import unittest
+from unittest import mock
 
 import madgraph.interface.extended_cmd as ext_cmd
 import madgraph.interface.master_interface as mgcmd
 from madgraph.iolibs.template_files.mg7 import bootstrap as mg7_bootstrap
 
 LAUNCH_MODULE = 'madgraph.iolibs.template_files.mg7.launch'
+_MG_ROOT = str(mg7_bootstrap.MG_ROOT)
 
 
 def make_mg7_dir(root):
@@ -466,6 +469,107 @@ class MG7CmdTest(unittest.TestCase):
             ms.StatusFile = saved
         self.assertEqual(len(recorded), 1)
         self.assertTrue(os.path.isabs(recorded[0]), recorded[0])
+
+    # ------------------------------------------------------------------
+    # the model of the process (SubProcesses/model.txt)
+    # ------------------------------------------------------------------
+    def write_model_txt(self, reference, model_hash=''):
+        with open(os.path.join(self.me_dir, 'SubProcesses', 'model.txt'),
+                  'w') as stream:
+            stream.write('%s\n%s\n' % (reference, model_hash))
+
+    def test_get_model_returns_the_model_of_the_process(self):
+        """The hook 'update dependent' and the auto-width handler go through.
+
+        Without it the card question could only warn that it had failed to
+        update the dependent parameters of the param_card.
+        """
+        self.write_model_txt(os.path.join(_MG_ROOT, 'models', 'sm'))
+        cmd = self.make_cmd()
+        model = cmd.get_model()
+        self.assertTrue(model)
+        self.assertEqual(model.get('name'), 'sm')
+        # imported once: the question asks again at every 'update dependent'
+        self.assertIs(cmd.get_model(), model)
+
+    def test_get_model_keeps_the_restriction(self):
+        """'sm-no_b_mass' is not 'sm': the restriction is part of the model the
+        process was generated with, so the reference recorded at output time
+        carries it and reloading has to honour it."""
+        self.write_model_txt(os.path.join(_MG_ROOT, 'models', 'sm-no_b_mass'))
+        model = self.make_cmd().get_model()
+        self.assertTrue(model)
+        self.assertEqual(model.get('name'), 'sm-no_b_mass')
+
+    def test_get_model_reads_the_process_characteristics(self):
+        """The complex-mass scheme is a property of the process, not of the
+        card, so it comes from SubProcesses/proc_characteristics -- which is a
+        ConfigFile, whose get() is the parameter accessor and takes no
+        default."""
+        with open(os.path.join(self.me_dir, 'SubProcesses',
+                               'proc_characteristics'), 'w') as stream:
+            stream.write('complex_mass_scheme = False\nnexternal = 4\n')
+        self.write_model_txt(os.path.join(_MG_ROOT, 'models', 'sm'))
+        self.assertIs(self.launch._proc_characteristic(
+            self.me_dir)['complex_mass_scheme'], False)
+        self.assertEqual(self.make_cmd().get_model().get('name'), 'sm')
+
+    def test_get_model_is_none_without_a_recorded_model(self):
+        """An output written before SubProcesses/model.txt existed: the caller
+        warns, nothing raises."""
+        self.assertIsNone(self.make_cmd().get_model())
+
+    def test_update_dependent_uses_the_model(self):
+        """End to end: the dependent parameters of the param_card are the ones
+        the model computes from the free ones (here M_W from G_F/M_Z/alpha)."""
+        from madgraph.interface.common_run_interface import AskforEditCard
+        from models.check_param_card import ParamCard
+
+        self.write_model_txt(os.path.join(_MG_ROOT, 'models', 'sm'))
+        path = os.path.join(self.me_dir, 'Cards', 'param_card.dat')
+        shutil.copyfile(os.path.join(_MG_ROOT, 'tests', 'input_files',
+                                     'param_card_sm.dat'), path)
+        card = ParamCard(path)
+        self.assertRaises(KeyError, card['mass'].get, (24,))
+
+        modified = AskforEditCard.update_dependent(
+            self.make_cmd(), self.me_dir, card, path, timer=0)
+
+        self.assertTrue(modified)
+        self.assertAlmostEqual(ParamCard(path)['mass'].get((24,)).value,
+                               80.419, places=2)
+
+    def test_a_slow_model_stays_a_timeout(self):
+        """'update dependent' loads the model under an alarm whose handler
+        raises a TimeOutError defined inside the caller. Swallowing it would
+        report a model that does not import instead of one that is slow (which
+        the caller knows how to explain, and how to force)."""
+        class TimeOutError(Exception):
+            pass
+
+        self.write_model_txt(os.path.join(_MG_ROOT, 'models', 'sm'))
+        self.launch._model_cache.clear()
+        with mock.patch('models.import_ufo.import_model',
+                        side_effect=TimeOutError):
+            self.assertRaises(TimeOutError, self.launch.load_process_model,
+                              self.me_dir)
+        # ... and it is not remembered as a model that cannot be imported
+        self.assertFalse(self.launch._model_cache)
+
+    def test_a_changed_model_is_reported(self):
+        """The hash on the second line is what tells a model that moved on from
+        the one the matrix element was written for."""
+        self.write_model_txt(os.path.join(_MG_ROOT, 'models', 'sm'),
+                             'not-the-hash-of-that-model')
+        self.launch._model_hash_warned.clear()
+        with mock.patch.object(self.launch.logger, 'warning') as warning:
+            self.assertEqual(self.launch.read_stored_model(self.me_dir),
+                             os.path.join(_MG_ROOT, 'models', 'sm'))
+            self.assertEqual(warning.call_count, 1)
+            self.assertIn('has changed', warning.call_args[0][0])
+            # only once per directory: this runs on every card question
+            self.launch.read_stored_model(self.me_dir)
+            self.assertEqual(warning.call_count, 1)
 
     def test_setup_logging_defers_to_an_existing_handler(self):
         """In process MG5 owns the loggers; adding a second handler would print


### PR DESCRIPTION
## The bug

Launching an mg7 output ends with:

```
INFO: Update the dependent parameter of the param_card.dat
DEBUG: 'MG7Cmd' object has no attribute 'get_model'
WARNING: Failed to update dependent parameter. This might create trouble for external program (like MadSpin/shower/...)
```

`AskforEditCard.do_update('dependent')` asks its mother interface for the model whenever it needs the model rather than the card -- the dependent masses/widths and the generic auto-width handler both go through `mother_interface.get_model()`. `MG7Cmd` had no such method, so the param_card was left holding whatever inconsistent values had been typed, which MadSpin and the shower then read.

## The fix

An mg7 output has no `bin/internal/ufomodel` (the copy the inherited `CommonRunCmd.get_model` imports); it records the model it was generated with in `SubProcesses/model.txt` instead.

* `launch.read_stored_model()` / `launch.load_process_model()` reload it from there -- cached per (reference, complex-mass-scheme), and `compute_auto_widths` now shares the reader instead of duplicating the parsing. A `TimeOutError` raised by the caller's own alarm is re-raised rather than swallowed, so a slow model is still reported as slow ("the model takes too long to load") instead of as one that does not import.
* `MG7Cmd.get_model()` and `MG7RunCmd.get_model()` (whose inherited version looks for that same missing directory) hand it back.
* `model.txt` kept only the bare UFO path, which silently reloads the **default** restriction: an `sm-no_b_mass` process would have had its masses "corrected" by the wrong model. It now stores `modelpath+restriction`; the hash on the second line still covers the UFO directory, and the reader strips the suffix.

## Validation

On a real `output mg7` of `e+ e- > mu+ mu-` in `sm-no_b_mass`: the model reloads as `sm-no_b_mass` (MB stays 0), and a W mass tampered to 79 is put back to 80.4190 by `update dependent`, with no warning.

Six new cases in `MG7CmdTest`. They are skipped without a compiled madspace, so they were also run locally against a stubbed madspace (14/14). `./tests/test_manager.py -p U test_mg7_launch` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
