### PR TITLE
Integrate a channel whose matrix element is identically zero

### DIFF
--- a/madgraph/iolibs/template_files/madmatrix/process_function_definitions.inc
+++ b/madgraph/iolibs/template_files/madmatrix/process_function_definitions.inc
@@ -715,7 +715,12 @@ namespace mg5amcCpu
       if( mulChannelWeight )
       {
         unsigned int channelId = allChannelIds[ievt];
-        allMEs[ievt] *= numerators[channelId - 1] / denominator;
+        // denominator == 0 means every diagram's |amp|^2 vanishes for this event (a
+        // subprocess whose matrix element is identically zero); 0/0 would turn a zero
+        // matrix element into a nan. Floored rather than tested, so that -ffast-math
+        // cannot drop the guard -- see process_sigmaKin_function.inc for the reasoning.
+        allMEs[ievt] *= numerators[channelId - 1] /
+                        ( denominator + std::numeric_limits<fptype>::min() );
       }
     }
     return;

--- a/madgraph/iolibs/template_files/madmatrix/process_sigmaKin_function.inc
+++ b/madgraph/iolibs/template_files/madmatrix/process_sigmaKin_function.inc
@@ -312,7 +312,23 @@
         if( mulChannelWeight && allChannelIds != nullptr )
         {
           const unsigned int channelId = getChannelId( allChannelIds, ievt0, false );
-          MEs_sv *= numerators_sv[channelId - 1] / denominators_sv;
+          // A vanishing denominator means every diagram's |amp|^2 is zero for this
+          // event, which is what a subprocess whose matrix element is identically zero
+          // looks like (an FCNC channel with all its Wilson coefficients at zero, say).
+          // The channel weight would then be 0/0 = nan, turning a matrix element that
+          // is simply zero into a nan that reaches the event weight and aborts the
+          // integration. Clamping the (non-negative) denominator to the smallest
+          // normal value keeps that division finite -- 0/tiny is 0 -- and is a no-op
+          // for any denominator a real amplitude produces. Note this must NOT be
+          // written as a test for zero: this file is compiled with -ffast-math, whose
+          // -ffinite-math-only lets the compiler assume the quotient is finite and so
+          // drop the guard as dead (the same trap as #117/#516).
+          // (fpmax is SIMD-only, so the floor is added rather than max'ed: the
+          // denominator is a sum of |amp|^2 and so never negative, and adding the
+          // smallest normal leaves every denominator a real amplitude produces
+          // bit-for-bit unchanged.)
+          const fptype_sv safe_den = denominators_sv + std::numeric_limits<fptype>::min();
+          MEs_sv *= numerators_sv[channelId - 1] / safe_den;
         }
       }
       //for( int ieppV = 0; ieppV < neppV; ieppV++ )

--- a/madgraph/iolibs/template_files/madmatrix/umami.cc
+++ b/madgraph/iolibs/template_files/madmatrix/umami.cc
@@ -12,6 +12,7 @@
 #include "MemoryBuffers.h"
 
 #include <cmath>
+#include <limits>
 #include <vector>
 #include <array>
 #include <utility>
@@ -24,6 +25,26 @@ using namespace mg5amcCpu;
 
 namespace
 {
+
+  // The per-diagram channel weight handed to madspace as amp2. A subprocess whose
+  // matrix element is identically zero -- an FCNC channel with every Wilson
+  // coefficient at zero, say -- has all numerators at zero, so their sum, the
+  // denominator, is zero too. Dividing would give 0/0 = nan for every diagram, and
+  // that nan becomes the amp2 madspace builds its channel weights from, turning a
+  // channel that should simply contribute nothing into a non-finite event weight
+  // that aborts the whole integration.
+  //
+  // The denominator is a sum of |amp|^2 and so never negative: adding the smallest
+  // normal double floors it away from zero (0/tiny is 0, no channel preferred) while
+  // leaving every denominator a real amplitude produces bit-for-bit unchanged. This
+  // must NOT be written as a test for zero -- this is compiled with -ffast-math, and
+  // its -ffinite-math-only lets the compiler assume the quotient is finite and drop
+  // such a guard as dead code (the trap behind #117 and #516).
+  inline double channel_amp2( double numerator, double denominator )
+  {
+    return numerator / ( denominator + std::numeric_limits<double>::min() );
+  }
+
 
   void* initialize_impl(
     const fptype* momenta,
@@ -146,7 +167,7 @@ namespace
       double denominator = denominators[i_event];
       for( std::size_t i_diag = 0; i_diag < CPPProcess::ndiagrams; ++i_diag )
       {
-        amp2_out[stride * i_diag + i_event + offset] = numerators[i_event * CPPProcess::ndiagrams + i_diag] / denominator;
+        amp2_out[stride * i_diag + i_event + offset] = channel_amp2( numerators[i_event * CPPProcess::ndiagrams + i_diag], denominator );
       }
     }
     if( diagram_out ) diagram_out[i_event + offset] = diagram_index[i_event] - 1;
@@ -607,7 +628,7 @@ extern "C"
         {
           for( std::size_t i_diag = 0; i_diag < CPPProcess::ndiagrams; ++i_diag )
           {
-            amp2_out[stride * i_diag + i_event + offset] = numerators[i_page * page_size * CPPProcess::ndiagrams + i_diag * page_size + i_vector] / denominator;
+            amp2_out[stride * i_diag + i_event + offset] = channel_amp2( numerators[i_page * page_size * CPPProcess::ndiagrams + i_diag * page_size + i_vector], denominator );
           }
         }
         if( diagram_out != nullptr )
@@ -639,7 +660,7 @@ extern "C"
         {
           for( std::size_t i_diag = 0; i_diag < CPPProcess::ndiagrams; ++i_diag )
           {
-            amp2_out[stride * i_diag + i_event + offset] = numerators[i_page * page_size * CPPProcess::ndiagrams + i_diag * page_size + i_vector] / denominator;
+            amp2_out[stride * i_diag + i_event + offset] = channel_amp2( numerators[i_page * page_size * CPPProcess::ndiagrams + i_diag * page_size + i_vector], denominator );
           }
         }
         if( diagram_out != nullptr )

--- a/madgraph/iolibs/template_files/mg7/launch.py
+++ b/madgraph/iolibs/template_files/mg7/launch.py
@@ -812,7 +812,12 @@ class MadgraphProcess:
                 mean += status.mean_abs
                 variance += status.error_abs**2
                 count_opt += status.count_opt
-            rsd = (variance * count_opt)**0.5 / mean
+            # A subprocess whose matrix element is identically zero (an FCNC
+            # channel with every Wilson coefficient at zero, say) integrates to
+            # exactly zero, so there is no relative spread to speak of. Report 0
+            # rather than dividing by it: that asks for the smallest networks and
+            # leaves MadNIS off, which is what an empty subprocess wants.
+            rsd = (variance * count_opt)**0.5 / mean if mean else 0.
             subproc.set_madnis_auto_settings(rsd)
             chan_offset += len(ps.channels)
             if subproc.madnis_settings["enable"]:

--- a/madspace/src/kernels/multichannel.hpp
+++ b/madspace/src/kernels/multichannel.hpp
@@ -25,8 +25,22 @@ KERNELSPEC void kernel_collect_channel_weights(
         norm = norm + amp2_val;
         channel_weights[chan_index] += amp2_val;
     }
+    // Every amplitude can vanish at once -- a channel whose matrix element is
+    // identically zero (an FCNC subprocess whose Wilson coefficients are all zero,
+    // say) has amp2 == 0 for every diagram, so norm == 0. Dividing by it would give
+    // 0/0 = nan for every channel weight, and that nan reaches the event weight and
+    // aborts the whole integration instead of contributing nothing. Fall back to the
+    // uniform distribution: the channel weights have to stay a normalised
+    // distribution over the channels, and with no amplitude to prefer one, none is
+    // preferred. The event weight is zero either way, since the amplitudes are.
+    // norm is substituted before the division rather than the result being repaired
+    // after it, so that the degenerate 0/0 is never formed in the first place.
+    auto degenerate = norm == 0.;
+    auto safe_norm = where(degenerate, FVal<T>(1.), norm);
+    FVal<T> uniform_weight(1. / static_cast<double>(channel_weights.size()));
     for (std::size_t i = 0; i < channel_weights.size(); ++i) {
-        channel_weights[i] = channel_weights[i] / norm;
+        channel_weights[i] =
+            where(degenerate, uniform_weight, channel_weights[i] / safe_norm);
     }
 }
 


### PR DESCRIPTION
## The bug

`p p > t t~ DIM6=0` in `dim6top_LO_UFO` aborted the mg7/madspace survey:

```
RuntimeError: non-finite integral in channel '2.0' after 1000 samples
(mean=nan, variance=nan)
```

`output madevent` integrated the same process fine.

dim6top carries an `FCNC` coupling order that `DIM6=0` does not constrain, so MG5 keeps the four flavour-off-diagonal channels (`u c~`, `c u~`, `d s~`, `s d~ > t t~`). Each has 7 diagrams but an amplitude of exactly zero, because their Wilson coefficients are zero in the default param card. A channel like that should contribute nothing; instead it poisoned the whole run.

This is not specific to dim6top — any process with a subprocess whose matrix element vanishes identically hits it.

## Three 0/0 divisions in series

All of them on a channel with no amplitude anywhere, each only visible once the one before it was fixed:

1. **`umami.cc`** builds the per-diagram `amp2` that madspace samples from as `numerator/denominator`, the denominator being the sum of the numerators.
2. **`kernel_collect_channel_weights`** normalises the channel weights by the sum of those `amp2`.
3. **`survey()`** divides by the subprocess mean to get its relative spread — a plain `ZeroDivisionError` once the nan is gone and the channel correctly integrates to zero.

The matrix-element multichannel weights in `process_sigmaKin_function.inc` and `process_function_definitions.inc` carry the same division and are guarded too, for the consumers that ask for `mulChannelWeight`. mg7 does not, so only the three above were load-bearing for this reproducer.

## Reviewers: the C++ guards must not become a test for zero

This is the part that will look wrong and isn't.

The generated code is compiled with `-ffast-math`, and its `-ffinite-math-only` lets the compiler assume the quotient is finite — and therefore delete a zero-check as dead code. An explicit `denominator == 0. ? 0. : ...` in `umami.cc` **was** silently removed, and only began working when a debug `printf` next to it perturbed the optimiser. That is the same trap as #117 and #516, which is why `CrossSectionKernels.o` is already built `-fno-fast-math`.

These denominators are sums of `|amp|^2` and so never negative, so they are floored by adding the smallest normal instead:

```cpp
numerator / ( denominator + std::numeric_limits<double>::min() )
```

`0/tiny` is `0`, and every denominator a real amplitude produces is unchanged bit for bit. That keeps the guard robust without taking `-ffast-math` off a hot file. Rewriting it as an `if` would compile to nothing and silently reintroduce the bug.

`madspace`'s own kernel is not built that way, so it substitutes the norm and falls back to the uniform distribution — the channel weights have to remain a normalised distribution over the channels, and with no amplitude to prefer one, none is preferred.

## Verification

dim6top, `ctG = 1`, 13 TeV, fixed `mu = 91.188`, `NNPDF23_lo_as_0130_qed`:

| | mg7 / madspace | madevent |
|---|---|---|
| `p p > t t~ DIM6=0` (9 subprocesses, 4 identically zero) | **736.223 +- 1.686 pb** | 736.2 +- 0.61 pb |

Each guard was confirmed load-bearing by reverting it and rebuilding — reverting the madspace one alone brings the nan straight back.

**No regression:** plain `sm` `p p > t t~` gives `718.8675807362097 pb`, bit-identical to the same run before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)