### PR TITLE
Fall back to mg5_configuration.txt inside $MADGRAPH_BASE

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -759,6 +759,21 @@ jobs:
             ./tests/test_manager.py test_CF_simple test_cf_computation test_generate_ewsud_ttbar test_generate_ewsud_ww test_generate_ewsud_zz testIO_test_pptt_ewsudakovSA testIO_test_ppzz_ewsudakov testIO_test_ppw_fksall testIO_Loop_sqso_uux_ddx test_check_import_model test_schedular test_dummy_fcts test_UFO_Python_helas_call_writer_fd test_get_symmetric_color test_get_symmetric_lorentz test_remove_interactions2 test_remove_interactions3 test_fd_python_value_matches_unitary_fixed_point test_shower_card_write -t0
 
 
+  unittest_config_location:
+    # tests/unit_tests/various/test_lhapdf_resolve.py: where the configuration
+    # files live ($MADGRAPH_BASE, per-user, install) and how LHAPDF is resolved
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: run the configuration-location and lhapdf-resolve unit tests
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./tests/test_manager.py test_xdg_config_home_wins test_home_fallback test_never_mg5 test_no_home test_no_base test_mg7_file_wins test_mg5_fallback test_neither_file test_absolute_lhapdf test_python_filter_is_not_part_of_the_path test_relative_value_roots_at_the_install test_bare_name_from_path test_missing_executable_does_not_raise test_no_lhapdf_at_all test_lhapdf5_pdfsets_path test_datadir_list_is_split test_env_data_path_comes_first test_env_config_wins_over_options test_lhapdf_py3_fallback test_none_and_auto_are_not_paths test_heptools_fallback_when_datadir_is_read_only test_create_makes_the_download_directory test_cvmfs_mirror_is_searched_last_and_never_downloaded_into test_with_data_path_promotes_a_directory -t0
+
+
   unittest_write_model:
     # runs alone: excluded from the shared unittest jobs due to side effects
     runs-on: ubuntu-24.04

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -4451,8 +4451,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             self.options.update(self.options_madevent)
 
         if not config_path:
-            if 'MADGRAPH_BASE' in os.environ:
-                config_path = pjoin(os.environ['MADGRAPH_BASE'], misc.CONFIG_NAME)
+            config_path = misc.base_config_file()
+            if config_path:
                 self.set_configuration(config_path=config_path, final=False)
             config_path = misc.user_config_file()
             if config_path and os.path.exists(config_path):

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -8130,8 +8130,8 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
             self.options.update(self.options_madevent)
 
         if not config_path:
-            if 'MADGRAPH_BASE' in os.environ:
-                config_path = pjoin(os.environ['MADGRAPH_BASE'], misc.CONFIG_NAME)
+            config_path = misc.base_config_file()
+            if config_path:
                 self.set_configuration(config_path, final=False)
             config_path = misc.user_config_file()
             if config_path and os.path.exists(config_path):

--- a/madgraph/interface/master_interface.py
+++ b/madgraph/interface/master_interface.py
@@ -791,7 +791,11 @@ class MasterCmdWeb(MGcmd.MadGraphCmdWeb, Switcher, LoopCmd.LoopInterfaceWeb):
     def set_configuration(self, config_path=None, final=False):
         
         """Force to use the web configuration file only"""
-        config_path = pjoin(os.environ['MADGRAPH_BASE'], misc.CONFIG_NAME)
+        config_path = misc.base_config_file()
+        if not config_path:
+            # on the web MADGRAPH_BASE is always set: never silently fall back
+            # to the local configuration files.
+            raise KeyError('MADGRAPH_BASE')
         return Switcher.set_configuration(self, config_path=config_path, final=final)
     
     def do_save(self, line, check=True, **opt):

--- a/madgraph/iolibs/template_files/mg7/launch.py
+++ b/madgraph/iolibs/template_files/mg7/launch.py
@@ -2666,9 +2666,9 @@ def load_mg5_options(me_dir=None) -> dict:
         'mg5amc_py8_interface_path': None, 'heptools_install_dir': None,
     }
     config_files = []
-    if os.environ.get('MADGRAPH_BASE'):
-        config_files.append((os.path.join(os.environ['MADGRAPH_BASE'],
-                                          misc.CONFIG_NAME), mg5dir))
+    base_config = misc.base_config_file()
+    if base_config:
+        config_files.append((base_config, mg5dir))
     user_config = misc.user_config_file()
     if user_config:
         config_files.append((user_config, mg5dir))

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -57,12 +57,32 @@ misc = locals
 # configuration file locations
 #===============================================================================
 CONFIG_NAME = 'mg7_configuration.txt'
+LEGACY_CONFIG_NAME = 'mg5_configuration.txt'
 CONFIG_TEMPLATE_NAME = '.mg7_configuration_default.txt'
 
 def install_config_file(root):
     """The configuration file of the MadGraph installation rooted at *root*."""
 
     return pjoin(root, 'input', CONFIG_NAME)
+
+def base_config_file():
+    """The $MADGRAPH_BASE configuration file, or None if that is not set.
+
+    A base directory set up for MadGraph5_aMC@NLO holds mg5_configuration.txt
+    rather than the MadGraph7 name, so fall back to it when only that one is
+    there. With neither present the MadGraph7 name is returned, which is what
+    the callers that create a missing file need.
+    """
+
+    base = os.environ.get('MADGRAPH_BASE')
+    if not base:
+        return None
+    config_path = pjoin(base, CONFIG_NAME)
+    if not os.path.exists(config_path):
+        legacy_path = pjoin(base, LEGACY_CONFIG_NAME)
+        if os.path.exists(legacy_path):
+            return legacy_path
+    return config_path
 
 def user_config_dir(create=False):
     """MadGraph7's per-user configuration directory.

--- a/tests/unit_tests/various/test_lhapdf_resolve.py
+++ b/tests/unit_tests/various/test_lhapdf_resolve.py
@@ -70,6 +70,45 @@ class TestUserConfigLocation(unittest.TestCase):
         self.assertIsNone(misc.user_config_file())
 
 
+class TestBaseConfigLocation(unittest.TestCase):
+    """$MADGRAPH_BASE may have been set up for MadGraph5_aMC@NLO, in which case
+    it holds mg5_configuration.txt and not the MadGraph7 name."""
+
+    def setUp(self):
+        self.saved = os.environ.get('MADGRAPH_BASE')
+        self.tmpdir = tempfile.mkdtemp(prefix='mg7_base_test')
+
+    def tearDown(self):
+        if self.saved is None:
+            os.environ.pop('MADGRAPH_BASE', None)
+        else:
+            os.environ['MADGRAPH_BASE'] = self.saved
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_no_base(self):
+        os.environ.pop('MADGRAPH_BASE', None)
+        self.assertIsNone(misc.base_config_file())
+
+    def test_mg7_file_wins(self):
+        os.environ['MADGRAPH_BASE'] = self.tmpdir
+        for name in ('mg7_configuration.txt', 'mg5_configuration.txt'):
+            open(pjoin(self.tmpdir, name), 'w').close()
+        self.assertEqual(misc.base_config_file(),
+                         pjoin(self.tmpdir, 'mg7_configuration.txt'))
+
+    def test_mg5_fallback(self):
+        os.environ['MADGRAPH_BASE'] = self.tmpdir
+        open(pjoin(self.tmpdir, 'mg5_configuration.txt'), 'w').close()
+        self.assertEqual(misc.base_config_file(),
+                         pjoin(self.tmpdir, 'mg5_configuration.txt'))
+
+    def test_neither_file(self):
+        """With nothing there the MadGraph7 name is the one to create."""
+        os.environ['MADGRAPH_BASE'] = self.tmpdir
+        self.assertEqual(misc.base_config_file(),
+                         pjoin(self.tmpdir, 'mg7_configuration.txt'))
+
+
 class TestResolveLhapdf(unittest.TestCase):
     """misc.resolve_lhapdf is the single place both 'launch' and a standalone
     bin/generate_events use to locate LHAPDF, so it carries all the awkward


### PR DESCRIPTION
## Problem

When `MADGRAPH_BASE` is set, every configuration lookup built the path by hand as `$MADGRAPH_BASE/mg7_configuration.txt`. A base directory set up for MadGraph5_aMC@NLO holds `mg5_configuration.txt` instead, so such a base contributed nothing — and in `madgraph_interface.set_configuration` the missing-file branch went on to copy the template there, creating an empty `mg7_configuration.txt` next to the file it should have read.

## Change

New `misc.base_config_file()`: `None` when `MADGRAPH_BASE` is unset, the mg7 file when it exists, the mg5 file when only that one does, and the mg7 name when neither is there (what the callers that create a missing file need).

All four hand-built paths now go through it:

- `madgraph/interface/madgraph_interface.py`
- `madgraph/interface/common_run_interface.py`
- `madgraph/interface/master_interface.py` — web mode; keeps raising `KeyError('MADGRAPH_BASE')` when the variable is unset rather than silently dropping to the local configuration chain, as the bare `os.environ[...]` did before
- `madgraph/iolibs/template_files/mg7/launch.py` — also reaches the copy shipped into process directories as `bin/internal`

## Tests

`TestBaseConfigLocation` in `tests/unit_tests/various/test_lhapdf_resolve.py` covers unset base, both files present (mg7 wins), mg5-only fallback, and neither present.

A CI audit showed that file was bound to no workflow job at all, so this also adds `unittest_config_location` to `.github/workflows/unittest.yml`, running all 24 of its tests (configuration locations + LHAPDF resolution). Verified locally with the job's exact command: `Ran 24 tests ... OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
