### PR TITLE
Compile madspace in parallel when ninja is missing

### DIFF
--- a/madgraph/interface/extended_cmd.py
+++ b/madgraph/interface/extended_cmd.py
@@ -1740,12 +1740,17 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         if self.log:
             logger.info("History written to " + output_file.name)
 
+    def get_nb_core(self):
+        """Number of cores available for parallel tasks: the nb_core option,
+        resolved to the machine's core count when it was left unset."""
+        import multiprocessing
+        if not self.options.get('nb_core') or self.options['nb_core'] == 'None':
+            self.options['nb_core'] = multiprocessing.cpu_count()
+        return int(self.options['nb_core'])
+
     def compile(self, *args, **opts):
         """ """
-        import multiprocessing
-        if not self.options['nb_core'] or self.options['nb_core'] == 'None':
-            self.options['nb_core'] = multiprocessing.cpu_count()
-        return misc.compile(nb_core=self.options['nb_core'], *args, **opts)
+        return misc.compile(nb_core=self.get_nb_core(), *args, **opts)
 
     def avoid_history_duplicate(self, line, no_break=[]):
         """remove all line in history (but the last) starting with line.

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -440,6 +440,8 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("     --bin          Install pre-compiled package from PyPI (non-interactive;")
         logger.info("                    only guaranteed to match this checkout in a release tarball).")
         logger.info("     --source       Build from source (non-interactive).")
+        logger.info("     -j N/--jobs=N  Parallel compilation jobs (source build;")
+        logger.info("                    defaults to the 'nb_core' option).")
         logger.info("     --cuda         Enable CUDA GPU backend (source build).")
         logger.info("     --hip          Enable HIP/ROCm GPU backend (source build).")
         logger.info("     --openblas     Build OpenBLAS from source (default on Linux/Windows, source build).")
@@ -7311,7 +7313,14 @@ MadGraph7 that supports quadruple precision (typically g++ based on gcc 4.6+).""
             return
         elif args[0] == 'madspace':
             install_script = pjoin(MG5DIR, 'madspace', 'install.py')
-            subprocess.run([sys.executable, install_script] + args[1:])
+            install_args = args[1:]
+            # The source build compiles in parallel only if it is told how many
+            # jobs it may use (see set_build_parallelism in install.py), so hand
+            # it MG5's nb_core unless an explicit -j was given on the line.
+            if not any(a == '-j' or a.startswith('-j') or a.startswith('--jobs')
+                       for a in install_args):
+                install_args = install_args + ['-j', str(self.get_nb_core())]
+            subprocess.run([sys.executable, install_script] + install_args)
             return
 
         plugin = self.install_plugin
@@ -8479,7 +8488,8 @@ in the MadGraph7 option 'samurai' (instead of leaving it to its default 'auto').
             # sys.argv/sys.stdin, but in process those describe MG5, not the run.
             from madgraph.iolibs.template_files.mg7 import bootstrap as mg7_bootstrap
             mg7_bootstrap.ensure_madspace(
-                interactive=bool(self.use_rawinput) and not options['force'])
+                interactive=bool(self.use_rawinput) and not options['force'],
+                jobs=self.get_nb_core())
             from madgraph.iolibs.template_files.mg7 import launch as mg7_launch
 
             MG7 = mg7_launch.MG7Cmd(me_dir=me_dir, options=self.options)

--- a/madgraph/iolibs/template_files/mg7/bootstrap.py
+++ b/madgraph/iolibs/template_files/mg7/bootstrap.py
@@ -39,13 +39,16 @@ def madspace_is_installed() -> bool:
     return (INSTALL_DIR / "madspace").is_dir()
 
 
-def ensure_madspace(interactive=None) -> None:
+def ensure_madspace(interactive=None, jobs=None) -> None:
     """Install madspace if needed, then put it on ``sys.path``.
 
     ``interactive`` says whether the installer may take over the terminal and
     ask questions. ``None`` falls back to auto-detection from ``sys.stdin``,
     which is only correct for ``bin/generate_events``; every in-process caller
     should pass the value explicitly.
+
+    ``jobs`` is the number of parallel compilation jobs for the source build
+    (MG5's ``nb_core``); ``None`` lets the installer use every core.
     """
     if not madspace_is_installed():
         if interactive is None:
@@ -64,6 +67,8 @@ def ensure_madspace(interactive=None) -> None:
         install_stdin = None if interactive else subprocess.DEVNULL
         if not interactive:
             install_cmd += ["--source", "--yes"]
+        if jobs:
+            install_cmd += ["-j", str(jobs)]
         # Expose madgraph on PYTHONPATH so the installer subprocess can import
         # cmd.ask for its prompts.
         install_env = os.environ.copy()

--- a/madspace/install.py
+++ b/madspace/install.py
@@ -10,6 +10,7 @@ Non-interactive examples:
   python install.py --bin
   python install.py --source
   python install.py --source --cuda --cuda-arch "75;80;86"
+  python install.py --source -j 8
   python install.py --source --cuda --hip --simd --debug
 """
 
@@ -387,6 +388,39 @@ def add_cmake_to_path(env: dict) -> dict:
     return env
 
 
+def default_jobs() -> int:
+    """Number of compilation jobs to use when none was requested."""
+    try:
+        return len(os.sched_getaffinity(0))  # Linux: respects cgroup/taskset
+    except AttributeError:
+        return os.cpu_count() or 1
+
+
+def set_build_parallelism(env: dict, jobs: int | None) -> dict:
+    """Tell CMake how many compilation jobs it may run in parallel.
+
+    scikit-build-core calls ``cmake --build`` without any ``-j``, so the job
+    count comes entirely from the environment. With the Ninja generator that
+    goes unnoticed (ninja parallelises on its own), but whenever ninja is
+    missing scikit-build-core falls back to "Unix Makefiles", and make without
+    ``-j`` compiles one file at a time -- which is why a gcc/make build took
+    minutes while the ninja one did not.
+
+    ``CMAKE_BUILD_PARALLEL_LEVEL`` is read by ``cmake --build`` itself, so it
+    works for either generator, and being an environment variable it is also
+    inherited by the nested OpenBLAS build.
+    """
+    if jobs is not None and jobs <= 0:
+        jobs = None  # 0 / negative = "as many as there are cores"
+    if jobs is None:
+        if env.get("CMAKE_BUILD_PARALLEL_LEVEL"):
+            return env  # an explicit setting in the caller's environment wins
+        jobs = default_jobs()
+    env["CMAKE_BUILD_PARALLEL_LEVEL"] = str(jobs)
+    print(f"Compiling with {jobs} parallel job(s) (-j to change).")
+    return env
+
+
 # Command execution
 
 
@@ -534,6 +568,16 @@ def main() -> None:
         default=False,
         help="Non-interactive: accept defaults / reuse saved settings, no prompts. "
         "Combine with --source/--bin to force the install mode.",
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Number of parallel compilation jobs for the source build "
+        f"(default: every available core, {default_jobs()} here). MG5's "
+        "'nb_core' option is forwarded here by 'install madspace'.",
     )
     parser.add_argument(
         "--system",
@@ -796,6 +840,7 @@ def main() -> None:
     cmd.append(f"-Ccmake.build-type={build_type}")
 
     env = install_build_deps(system=args.system)
+    env = set_build_parallelism(env, args.jobs)
     run(cmd, env=env)
     save_settings(
         {

--- a/tests/unit_tests/interface/test_mg7_launch.py
+++ b/tests/unit_tests/interface/test_mg7_launch.py
@@ -29,6 +29,7 @@ madspace is not installed.
 from __future__ import absolute_import
 
 import logging
+import multiprocessing
 import os
 import shutil
 import subprocess
@@ -117,9 +118,14 @@ class MG7LaunchWiringTest(unittest.TestCase):
 
         # Never run the real madspace bootstrap from a unit test.
         self.bootstrap_calls = []
+        self.bootstrap_jobs = []
         self._saved_ensure = mg7_bootstrap.ensure_madspace
-        mg7_bootstrap.ensure_madspace = \
-            lambda interactive=None: self.bootstrap_calls.append(interactive)
+
+        def fake_ensure(interactive=None, jobs=None):
+            self.bootstrap_calls.append(interactive)
+            self.bootstrap_jobs.append(jobs)
+
+        mg7_bootstrap.ensure_madspace = fake_ensure
 
     def tearDown(self):
         mg7_bootstrap.ensure_madspace = self._saved_ensure
@@ -261,6 +267,20 @@ class MG7LaunchWiringTest(unittest.TestCase):
         self.cmd.do_launch(self.me_dir)
         self.assertEqual(self.bootstrap_calls, [True])
 
+    def test_bootstrap_gets_nb_core_for_the_madspace_build(self):
+        """A source build of madspace is only parallel when it is told how many
+        jobs it may use, so the launch path must pass MG5's nb_core on."""
+        self.cmd.options['nb_core'] = 3
+        self.launch('')
+        self.assertEqual(self.bootstrap_jobs, [3])
+
+        # left unset, nb_core resolves to the machine's core count
+        self.bootstrap_jobs[:] = []
+        self.cmd.options['nb_core'] = None
+        self.launch('')
+        self.assertEqual(self.bootstrap_jobs,
+                         [multiprocessing.cpu_count()])
+
 
 class MG7BootstrapTest(unittest.TestCase):
     """The one-off madspace install that used to be a launch.py import side
@@ -323,6 +343,25 @@ class MG7BootstrapTest(unittest.TestCase):
         # must not eat the caller's stdin, which carries the run's script
         self.assertEqual(opts['stdin'], subprocess.DEVNULL)
 
+    def test_jobs_is_forwarded_to_the_installer(self):
+        """Without a job count the installer's cmake build falls back to a
+        serial make whenever ninja is missing."""
+        self.point_at_empty_install()
+        calls = self.record_runs()
+        with self.quiet():
+            mg7_bootstrap.ensure_madspace(interactive=False, jobs=4)
+        cmd, _ = calls[0]
+        self.assertIn('-j', cmd)
+        self.assertEqual(cmd[cmd.index('-j') + 1], '4')
+
+    def test_no_jobs_leaves_the_installer_default(self):
+        self.point_at_empty_install()
+        calls = self.record_runs()
+        with self.quiet():
+            mg7_bootstrap.ensure_madspace(interactive=False)
+        cmd, _ = calls[0]
+        self.assertNotIn('-j', cmd)
+
     def test_interactive_install_keeps_the_terminal(self):
         self.point_at_empty_install()
         calls = self.record_runs()
@@ -370,6 +409,40 @@ class MG7BootstrapTest(unittest.TestCase):
         with self.quiet():
             self.assertRaises(RuntimeError,
                               mg7_bootstrap.ensure_madspace, interactive=False)
+
+
+class MadspaceInstallCommandTest(unittest.TestCase):
+    """`install madspace` at the MG5 prompt: it runs madspace/install.py."""
+
+    def setUp(self):
+        self.cmd = mgcmd.MasterCmd()
+
+    def installer_args(self, line):
+        with mock.patch('subprocess.run') as run:
+            self.cmd.do_install(line)
+        return [str(a) for a in run.call_args[0][0]]
+
+    def test_nb_core_is_forwarded_as_the_job_count(self):
+        """Without it the installer's cmake build is serial whenever ninja is
+        missing, whatever nb_core says."""
+        self.cmd.options['nb_core'] = 5
+        args = self.installer_args('madspace --source -y')
+        self.assertIn('install.py', args[1])
+        self.assertEqual(args[-2:], ['-j', '5'])
+
+    def test_unset_nb_core_uses_every_core(self):
+        self.cmd.options['nb_core'] = None
+        args = self.installer_args('madspace --source -y')
+        self.assertEqual(args[-2:], ['-j', str(multiprocessing.cpu_count())])
+
+    def test_an_explicit_job_count_is_left_alone(self):
+        self.cmd.options['nb_core'] = 5
+        for line in ('madspace --source -j 2', 'madspace --source -j2',
+                     'madspace --source --jobs=2'):
+            args = self.installer_args(line)
+            self.assertEqual(len([a for a in args if a.startswith('-j')
+                                  or a.startswith('--jobs')]), 1, args)
+            self.assertNotIn('5', args)
 
 
 @unittest.skipUnless(mg7_bootstrap.madspace_is_installed(),


### PR DESCRIPTION
## The bug

`madspace/install.py` builds through `pip` → scikit-build-core, and **scikit-build-core runs `cmake --build` with no `-j` and never sets `CMAKE_BUILD_PARALLEL_LEVEL`** (only its legacy setuptools shim has a `--parallel`). So the job count has to come from the environment, and nothing supplied one:

- **with ninja**: invisible — ninja parallelises on its own;
- **without ninja**: scikit-build-core falls back to the `Unix Makefiles` generator, and `make` with no `-j` compiles one file at a time.

That is the "compiling madspace with GCC is not done in parallel" report.

## The fix

`install.py` gains `-j/--jobs N` (default: every available core) and sets `CMAKE_BUILD_PARALLEL_LEVEL` in the environment handed to pip. That variable is honoured by `cmake --build` for *either* generator and, being an environment variable, is inherited by the nested OpenBLAS `ExternalProject` too. An explicit value already in the caller's environment still wins.

From the MadGraph prompt the count is the `nb_core` option:

- `install madspace` appends `-j <nb_core>` unless the line carries its own `-j`/`--jobs` (also documented in `help install`);
- the in-process `launch mg7` passes it through `bootstrap.ensure_madspace(..., jobs=)`;
- `nb_core` is read straight from `self.options`: `set_configuration` already resolves an unset value to the machine's core count (via `set2_nb_core`);
- the standalone `bin/generate_events` bootstrap runs before any option is read, so it keeps the all-cores default.

## Measurements

18-core macOS, no ninja, generator confirmed `Unix Makefiles`, clean build dir each time:

| build | wall |
|---|---|
| serial (pre-fix behaviour, `-j 1`) | **2m50s** |
| new default (`-j 18`) | **1m05s** |

2.6x rather than more because there are only 58 objects and two dominate the critical path (`src/cpu/runtime.cpp`, `src/python/madspace.cpp`). Propagation through the full `pip --no-build-isolation` → scikit-build-core → `cmake --build` chain was checked separately on a 6-job probe project: 16.4s → 3.0s.

CI is untouched: `.github/actions/build_madspace` calls `pip` with build isolation, which pulls the ninja wheel.

## Tests

6 new tests in `tests/unit_tests/interface/test_mg7_launch.py` (nb_core forwarded by `install madspace` and by the mg7 launch path, an explicit `-j` left alone, `-j` reaching the installer command line). `./tests/test_manager.py -p U test_mg7_launch` → 46/46 OK.

Note for whoever runs the wider set: `test_manager.py -p U test_tutorials test_mg7_launch` reports 18 errors (`module 'madspace' has no attribute 'SOURCE_HASH'`) both with and without this branch — `tutorials/lo.py:153` does a bare `import madspace` that can bind a stale copy and caches it for `launch.py`. Pre-existing, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
