### PR TITLE
Resolve the tutorial's madspace import through the mg7 bootstrap

### DIFF
--- a/madgraph/interface/tutorials/lo.py
+++ b/madgraph/interface/tutorials/lo.py
@@ -27,7 +27,6 @@ import json
 import math
 import os
 
-import madgraph
 import madgraph.interface.tutorials as tutorials
 from madgraph.interface.tutorials.session import (Step, Tutorial,
                                                   describe_applied_orders,
@@ -39,19 +38,62 @@ P = 'MG7>'
 RUN = 'MY_FIRST_LO_RUN'
 
 
-def madspace_is_installed():
-    """True if this MG7 already has a usable madspace build.
+def _mg7_bootstrap():
+    """The mg7 bootstrap module, or None if it cannot be imported.
 
-    Mirrors what the generated bin/generate_events checks before bootstrapping
-    one for itself (see iolibs/template_files/mg7/launch.py).
+    Everything the tutorial wants to know about madspace goes through it, so
+    the tutorial cannot disagree with the launcher about where madspace is or
+    whether it is there (see iolibs/template_files/mg7/bootstrap.py).
     """
 
     try:
-        root = os.path.dirname(os.path.dirname(os.path.abspath(
-            madgraph.__file__)))
+        from madgraph.iolibs.template_files.mg7 import bootstrap
+    except Exception:
+        return None
+    return bootstrap
+
+
+def madspace_is_installed():
+    """True if this MG7 already has a usable madspace build."""
+
+    bootstrap = _mg7_bootstrap()
+    if bootstrap is None:
+        return False
+    try:
+        return bootstrap.madspace_is_installed()
     except Exception:
         return False
-    return os.path.isdir(os.path.join(root, 'madspace', 'install', 'madspace'))
+
+
+def _import_madspace():
+    """This MG7's own compiled madspace, or None if it has none.
+
+    A bare ``import madspace`` here would resolve against whatever happens to
+    be importable -- a system-wide copy, or the repo's own madspace/ source
+    directory as a namespace package -- and cache that wrong module in
+    sys.modules, where mg7/launch.py's ``import madspace as ms`` would then
+    pick it up and fail on the first attribute the real package has. So only
+    import when the bundled build is actually installed, and with its install
+    prefix on sys.path, exactly as the launcher does.
+    """
+
+    bootstrap = _mg7_bootstrap()
+    if bootstrap is None or not madspace_is_installed():
+        return None
+    try:
+        # Already installed, so this only prepends the install directory.
+        bootstrap.ensure_madspace()
+        import madspace
+    except Exception:
+        return None
+    finally:
+        # Same reason launch.py drops it: the install directory also carries
+        # madspace's build dependencies and would shadow the caller's.
+        try:
+            bootstrap.drop_install_path()
+        except Exception:
+            pass
+    return madspace
 
 
 # Shown under the card question `launch` asks, in place of the generic
@@ -149,13 +191,14 @@ def _result_row(info):
         return '503.1(1.4)'
     if not mean:
         return '503.1(1.4)'
-    try:
-        import madspace
-
-        return madspace.format_with_error(mean, error)
-    except Exception:
-        # madspace not importable here: say the same thing the long way
-        return '%.4g +- %.2g' % (mean, error)
+    madspace = _import_madspace()
+    if madspace is not None:
+        try:
+            return madspace.format_with_error(mean, error)
+        except Exception:
+            pass
+    # madspace not importable here: say the same thing the long way
+    return '%.4g +- %.2g' % (mean, error)
 
 
 def _systematics_rows(info):


### PR DESCRIPTION
## The bug

`madgraph/interface/tutorials/lo.py` did a bare `import madspace` inside a `try/except`, *without* `madspace/install` on `sys.path` — that prepend only happens in `mg7/bootstrap.ensure_madspace`.

So the import resolved against whatever `madspace` happened to be importable: a system-wide copy, or the repo's own `madspace/` source directory as a namespace package. It *succeeded*, so the `except` fallback never ran, and it cached the wrong module in `sys.modules`. `mg7/launch.py`'s later `import madspace as ms` then got that cached module and blew up:

```
File "madgraph/iolibs/template_files/mg7/launch.py", line 45, in <module>
  if _source_hash != ms.SOURCE_HASH:
AttributeError: module 'madspace' has no attribute 'SOURCE_HASH'
```

18 errors in `tests.unit_tests.interface.test_mg7_launch.MG7CmdTest`. Either module alone passes — only the combination fails, and only when a compiled madspace exists (otherwise `MG7CmdTest` is skipped). On the reporting machine the stale copy at `/opt/homebrew/lib/python3.14/site-packages/madspace` *has* `format_with_error` (so the old `try` succeeded) but no `SOURCE_HASH`.

Pre-existing on `main`, independent of the madspace parallel-build work it was found alongside.

## The fix

Resolve madspace the same way every other consumer does, through `mg7/bootstrap.py`, so the tutorial and the launcher cannot disagree about where madspace is:

- `madspace_is_installed()` delegates to `bootstrap.madspace_is_installed()` instead of repeating the path check by hand.
- A new `_import_madspace()` returns `None` unless the bundled build really is installed; when it is, it calls `ensure_madspace()` (already installed, so this only prepends the install prefix), imports, then `drop_install_path()` — the install directory also carries madspace's build dependencies and would otherwise shadow the caller's `yaml`/`packaging`/…, which is exactly why `launch.py` drops it too.
- Dropped the now-unused `import madgraph`.

The `'%.4g +- %.2g'` fallback in `_result_row` and the "install madspace" branch of `intro()` are unchanged, and still exercised when madspace is genuinely absent.

## Testing

| Command | Before | After |
|---|---|---|
| `./tests/test_manager.py -p U test_tutorials test_mg7_launch` | 18 errors | Ran 160, **OK** |
| `./tests/test_manager.py -p U test_cmd test_mg7_launch test_tutorials` | 18 errors | Ran 179, **OK** |
| `./tests/test_manager.py -p U test_mg7_launch` | OK | Ran 40, **OK** |

Also checked directly that after `_import_madspace()` the module is `madspace/install/madspace/__init__.py`, it has `SOURCE_HASH`, `sys.modules['madspace']` holds that module, and the install dir is not left on `sys.path`; and with madspace forced absent, `_result_row` returns `503.1 +- 1.4` and `intro()` renders the "install madspace" branch, with `sys.modules` untouched.

Full `-p U` run: 1848 tests, 93 errors + 1 failure, all in `madspin.test_madspin`, `test_density_library` (tracebacks in `madgraph/various/Density_functions.py`) and one `IOExportMadLoopUnitTest` golden. Untouched by this one-file change and pre-existing in this checkout.

## Not addressed here

The general gap is still open: `bootstrap.ensure_madspace()` only prepends `sys.path`, so *any* caller that does a bare `import madspace` first would still poison `sys.modules` for `launch.py`. Hardening bootstrap to evict a wrongly-cached module would cover that in general, but it changes shared launcher behaviour and could mask real build problems — worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
