### PR TITLE
ci: gate releases on main's CI instead of re-running the suite

### DIFF
--- a/.github/workflows/IOtest.yml
+++ b/.github/workflows/IOtest.yml
@@ -4,10 +4,11 @@
 name: running IOTests
 on:
   push:
-    # Tags are excluded: a release tag points at a commit that already ran
-    # this suite when it was pushed to main, and release.yml gates on that
-    # main run rather than re-testing the same tree.
-    tags-ignore:
+    # All branches, no tags: a release tag points at a commit that already
+    # ran this suite when it was pushed to main, and release.yml gates on
+    # that main run rather than re-testing the same tree. '**' is needed
+    # over '*' so branch names containing a slash still match.
+    branches:
       - '**'
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/IOtest.yml
+++ b/.github/workflows/IOtest.yml
@@ -4,6 +4,11 @@
 name: running IOTests
 on:
   push:
+    # Tags are excluded: a release tag points at a commit that already ran
+    # this suite when it was pushed to main, and release.yml gates on that
+    # main run rather than re-testing the same tree.
+    tags-ignore:
+      - '**'
     paths-ignore:
       - 'docs/**'
 #      - '.github/**'
@@ -14,9 +19,6 @@ on:
       message:
         description: 'running IOTests'
         required: true
-
-  # Allows release.yml to run this as part of the release test suite
-  workflow_call:
 
 env:
   commitmsg: ${{ github.event.head_commit.message }}

--- a/.github/workflows/acceptancetest.yml
+++ b/.github/workflows/acceptancetest.yml
@@ -6,6 +6,11 @@ name: running acceptance test (rest)
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
+    # Tags are excluded: a release tag points at a commit that already ran
+    # this suite when it was pushed to main, and release.yml gates on that
+    # main run rather than re-testing the same tree.
+    tags-ignore:
+      - '**'
     paths-ignore:
       - 'docs/**'
 #      - '.github/**'
@@ -19,9 +24,6 @@ on:
       message:
         description: 'running acceptance test'
         required: true
-
-  # Allows release.yml to run this as part of the release test suite
-  workflow_call:
 
 env:
   commitmsg: ${{ github.event.head_commit.message }}
@@ -38,7 +40,7 @@ jobs:
     # (restore_data default + chmod -R 555 madevent) and run it from several
     # empty directories simultaneously.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +57,7 @@ jobs:
   acceptancetest_5:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -78,7 +80,7 @@ jobs:
   acceptancetest_10:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -96,7 +98,7 @@ jobs:
   acceptancetest_11:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -116,7 +118,7 @@ jobs:
   acceptancetest_12:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -136,7 +138,7 @@ jobs:
   acceptancetest_13:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -156,7 +158,7 @@ jobs:
   acceptancetest_14:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -177,7 +179,7 @@ jobs:
   acceptancetest_15:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -198,7 +200,7 @@ jobs:
   acceptancetest_16:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -218,7 +220,7 @@ jobs:
   acceptancetest_18:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -239,7 +241,7 @@ jobs:
   acceptancetest_26:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -260,7 +262,7 @@ jobs:
   acceptancetest_29:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -281,7 +283,7 @@ jobs:
   acceptancetest_30:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -302,7 +304,7 @@ jobs:
   acceptancetest_31:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -328,7 +330,7 @@ jobs:
   acceptancetest_32:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -350,7 +352,7 @@ jobs:
   acceptancetest_33:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -374,7 +376,7 @@ jobs:
     # caller's wavefunction slot when TXXXXX writes 16 complex into
     # a 4-complex aloha element.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v4
@@ -392,7 +394,7 @@ jobs:
   acceptancetest_34:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -435,7 +437,7 @@ jobs:
   acceptancetest_67:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -456,7 +458,7 @@ jobs:
   acceptancetest_68:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -476,7 +478,7 @@ jobs:
   acceptancetest_69:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -498,7 +500,7 @@ jobs:
   acceptancetest_71:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -521,7 +523,7 @@ jobs:
   acceptancetest_72:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -541,7 +543,7 @@ jobs:
   acceptancetest_73:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -562,7 +564,7 @@ jobs:
   acceptancetest_74:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -582,7 +584,7 @@ jobs:
   acceptancetest_75:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -604,7 +606,7 @@ jobs:
   acceptancetest_76:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -625,7 +627,7 @@ jobs:
   acceptancetest_78:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -646,7 +648,7 @@ jobs:
   acceptancetest_79:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -667,7 +669,7 @@ jobs:
   acceptancetest_80:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -692,7 +694,7 @@ jobs:
   acceptancetest_81:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -713,7 +715,7 @@ jobs:
   acceptancetest_82:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -734,7 +736,7 @@ jobs:
   acceptancetest_83:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -757,7 +759,7 @@ jobs:
   acceptancetest_emela:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -775,7 +777,7 @@ jobs:
   acceptancetest_emela2:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -793,7 +795,7 @@ jobs:
   acceptancetest_emela3:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -810,7 +812,7 @@ jobs:
   acceptancetest_emela4:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -827,7 +829,7 @@ jobs:
   acceptancetest_88:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -852,7 +854,7 @@ jobs:
   acceptancetest_93:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -873,7 +875,7 @@ jobs:
   acceptancetest_94:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -894,7 +896,7 @@ jobs:
   acceptancetest_95:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -914,7 +916,7 @@ jobs:
   acceptancetest_96:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -934,7 +936,7 @@ jobs:
   acceptancetest_97:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -955,7 +957,7 @@ jobs:
   acceptancetest_98:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -976,7 +978,7 @@ jobs:
   acceptancetest_99:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -994,7 +996,7 @@ jobs:
 
   acceptancetest_100:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5 
@@ -1007,7 +1009,7 @@ jobs:
 
   acceptancetest_100_2:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5 
@@ -1021,7 +1023,7 @@ jobs:
   
   acceptancetest_101:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5 
@@ -1034,7 +1036,7 @@ jobs:
   
   acceptancetest_102:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5 
@@ -1054,7 +1056,7 @@ jobs:
   
   acceptancetest_104:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -1068,7 +1070,7 @@ jobs:
   
   acceptancetest_103_polarization:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       # kept previous version (checkout@v2)
       - uses: actions/checkout@v2
@@ -1082,7 +1084,7 @@ jobs:
   acceptancetest_ewsudakov:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -1101,7 +1103,7 @@ jobs:
     # Previously uncovered acceptance tests in tests/acceptance_tests/test_cmd.py
     # related to the merged/ufo_aloha pipelines and decay-chain ordering
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -1117,7 +1119,7 @@ jobs:
   acceptancetest_uncovered_madloop:
     # Previously uncovered acceptance test in tests/acceptance_tests/test_cmd_madloop.py
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -1134,7 +1136,7 @@ jobs:
     # element is evaluated in a frame where the selected leg has an exactly
     # zero three-momentum, and HELAS reads its spin axis off that zero.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -1149,7 +1151,7 @@ jobs:
   acceptancetest_check_madevent_me_vs_standalone:
     # Previously uncovered acceptance test in tests/acceptance_tests/test_cmd_madloop.py
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -1163,7 +1165,7 @@ jobs:
   acceptancetest_check_mlm_rwgt:
     # Previously uncovered acceptance test in tests/acceptance_tests/test_MLM_reweight.py
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -1178,7 +1180,7 @@ jobs:
   acceptancetest_density:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -1224,7 +1226,7 @@ jobs:
   acceptancetest_density_decay2:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -1242,7 +1244,7 @@ jobs:
   acceptancetest_density_tttbartbar:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -1261,7 +1263,7 @@ jobs:
   acceptancetest_density_LI_standalone1:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -1279,7 +1281,7 @@ jobs:
   acceptancetest_density_LI_standalone2:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -1298,7 +1300,7 @@ jobs:
   acceptancetest_density_LI_standalone3:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -1316,7 +1318,7 @@ jobs:
   acceptancetest_density_LI_f2py:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -1345,7 +1347,7 @@ jobs:
   acceptancetest_delphes_parallel:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -1366,7 +1368,7 @@ jobs:
   acceptancetest_check_gauge:
     # gauge/lorentz check commands that were not listed in any workflow (CI coverage audit)
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
@@ -1385,7 +1387,7 @@ jobs:
   acceptancetest_decay_chain_outoforder:
     # decay chain with identical particles out of order (CI coverage audit)
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
@@ -1407,7 +1409,7 @@ jobs:
   acceptancetest_dy3j_mlm:
     # DY+3j with MLM matching (CI coverage audit)
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
@@ -1423,7 +1425,7 @@ jobs:
   acceptancetest_PA_decay:
     # w production with PA decay modes (CI coverage audit)
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
@@ -1440,7 +1442,7 @@ jobs:
   acceptancetest_wj_ms_decay:
     # wj production with madspin decay (CI coverage audit)
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
@@ -1456,7 +1458,7 @@ jobs:
   acceptancetest_density_LI_convolution:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -1474,7 +1476,7 @@ jobs:
   acceptancetest_madspin_tree:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -1491,7 +1493,7 @@ jobs:
   acceptancetest_madspin_LI:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/acceptancetest.yml
+++ b/.github/workflows/acceptancetest.yml
@@ -6,10 +6,11 @@ name: running acceptance test (rest)
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
-    # Tags are excluded: a release tag points at a commit that already ran
-    # this suite when it was pushed to main, and release.yml gates on that
-    # main run rather than re-testing the same tree.
-    tags-ignore:
+    # All branches, no tags: a release tag points at a commit that already
+    # ran this suite when it was pushed to main, and release.yml gates on
+    # that main run rather than re-testing the same tree. '**' is needed
+    # over '*' so branch names containing a slash still match.
+    branches:
       - '**'
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/acceptancetest_madevent.yml
+++ b/.github/workflows/acceptancetest_madevent.yml
@@ -6,10 +6,11 @@ name: running acceptance test (madevent)
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
-    # Tags are excluded: a release tag points at a commit that already ran
-    # this suite when it was pushed to main, and release.yml gates on that
-    # main run rather than re-testing the same tree.
-    tags-ignore:
+    # All branches, no tags: a release tag points at a commit that already
+    # ran this suite when it was pushed to main, and release.yml gates on
+    # that main run rather than re-testing the same tree. '**' is needed
+    # over '*' so branch names containing a slash still match.
+    branches:
       - '**'
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/acceptancetest_madevent.yml
+++ b/.github/workflows/acceptancetest_madevent.yml
@@ -6,6 +6,11 @@ name: running acceptance test (madevent)
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
+    # Tags are excluded: a release tag points at a commit that already ran
+    # this suite when it was pushed to main, and release.yml gates on that
+    # main run rather than re-testing the same tree.
+    tags-ignore:
+      - '**'
     paths-ignore:
       - 'docs/**'
 #      - '.github/**'
@@ -20,9 +25,6 @@ on:
         description: 'running acceptance test'
         required: true
 
-  # Allows release.yml to run this as part of the release test suite
-  workflow_call:
-
 env:
   commitmsg: ${{ github.event.head_commit.message }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -36,7 +38,7 @@ jobs:
   acceptancetest_0:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -63,7 +65,7 @@ jobs:
   acceptancetest_10:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -81,7 +83,7 @@ jobs:
   acceptancetest_17:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -102,7 +104,7 @@ jobs:
   acceptancetest_19:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -123,7 +125,7 @@ jobs:
   acceptancetest_20:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -143,7 +145,7 @@ jobs:
   acceptancetest_21:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -164,7 +166,7 @@ jobs:
   acceptancetest_22:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -185,7 +187,7 @@ jobs:
   acceptancetest_23:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -206,7 +208,7 @@ jobs:
   acceptancetest_24:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -228,7 +230,7 @@ jobs:
   acceptancetest_25:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -249,7 +251,7 @@ jobs:
   acceptancetest_35:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -270,7 +272,7 @@ jobs:
   acceptancetest_37:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -289,7 +291,7 @@ jobs:
   acceptancetest_38:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -309,7 +311,7 @@ jobs:
   test_oneloop_reweighting:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -343,7 +345,7 @@ jobs:
   acceptancetest_42:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -364,7 +366,7 @@ jobs:
   acceptancetest_43:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -385,7 +387,7 @@ jobs:
   acceptancetest_44:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -406,7 +408,7 @@ jobs:
   acceptancetest_45:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -427,7 +429,7 @@ jobs:
   acceptancetest_46:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -448,7 +450,7 @@ jobs:
   acceptancetest_47:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -469,7 +471,7 @@ jobs:
   acceptancetest_48:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -491,7 +493,7 @@ jobs:
   acceptancetest_49:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -512,7 +514,7 @@ jobs:
   acceptancetest_50:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -533,7 +535,7 @@ jobs:
   acceptancetest_51:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -554,7 +556,7 @@ jobs:
   acceptancetest_52:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -575,7 +577,7 @@ jobs:
   acceptancetest_53:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -597,7 +599,7 @@ jobs:
   acceptancetest_54:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -618,7 +620,7 @@ jobs:
   acceptancetest_55:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -639,7 +641,7 @@ jobs:
   acceptancetest_56:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -659,7 +661,7 @@ jobs:
   acceptancetest_contur:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -676,7 +678,7 @@ jobs:
   acceptancetest_contur2:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -693,7 +695,7 @@ jobs:
   acceptancetest_59:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -714,7 +716,7 @@ jobs:
   acceptancetest_60:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -736,7 +738,7 @@ jobs:
   acceptancetest_100_2:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -756,7 +758,7 @@ jobs:
   acceptancetest_101:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -776,7 +778,7 @@ jobs:
     # The type of runner that the job will run on
 
     runs-on: ${{ matrix.os }}
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -805,7 +807,7 @@ jobs:
   acceptancetest_103_polarization:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -823,7 +825,7 @@ jobs:
   acceptancetest_heft:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -841,7 +843,7 @@ jobs:
   acceptancetest_flavor:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -861,7 +863,7 @@ jobs:
     # Previously uncovered acceptance tests in tests/acceptance_tests/test_cmd.py
     # related to the merged/ufo_aloha pipelines and decay-chain ordering
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -878,7 +880,7 @@ jobs:
     # Previously uncovered acceptance tests in tests/acceptance_tests/test_cmd_madevent.py
     # Includes test_madevent_dy3j_mlm after reopening/owning stdout safely.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -894,7 +896,7 @@ jobs:
   acceptancetest_madevent_vbf_merged_flavor:
     # Previously uncovered acceptance test in tests/acceptance_tests/test_cmd_madloop.py
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -907,7 +909,7 @@ jobs:
   acceptancetest_madevent_flavor_zud:
     # Flavor-grouped u q > Z u q QCD=0 tests (grouped and ungrouped).
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -920,7 +922,7 @@ jobs:
   acceptancetest_density_interface:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -940,7 +942,7 @@ jobs:
   acceptancetest_density_ttbar:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -958,7 +960,7 @@ jobs:
   acceptancetest_density_wpwm:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -976,7 +978,7 @@ jobs:
   acceptancetest_density_decay1:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -994,7 +996,7 @@ jobs:
   acceptancetest_density_decay2:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -1012,7 +1014,7 @@ jobs:
   acceptancetest_density_tttbartbar:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -1036,7 +1038,7 @@ jobs:
     # vertices); the mg7/madmatrix counterpart now also supports it and is
     # checked per-flavor (test_madmatrix_mssm_gogo in acceptancetest_mg7.yml).
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5

--- a/.github/workflows/acceptancetest_mg7.yml
+++ b/.github/workflows/acceptancetest_mg7.yml
@@ -6,10 +6,11 @@ name: running acceptance test (mg7)
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
-    # Tags are excluded: a release tag points at a commit that already ran
-    # this suite when it was pushed to main, and release.yml gates on that
-    # main run rather than re-testing the same tree.
-    tags-ignore:
+    # All branches, no tags: a release tag points at a commit that already
+    # ran this suite when it was pushed to main, and release.yml gates on
+    # that main run rather than re-testing the same tree. '**' is needed
+    # over '*' so branch names containing a slash still match.
+    branches:
       - '**'
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/acceptancetest_mg7.yml
+++ b/.github/workflows/acceptancetest_mg7.yml
@@ -6,6 +6,11 @@ name: running acceptance test (mg7)
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
+    # Tags are excluded: a release tag points at a commit that already ran
+    # this suite when it was pushed to main, and release.yml gates on that
+    # main run rather than re-testing the same tree.
+    tags-ignore:
+      - '**'
     paths-ignore:
       - 'docs/**'
 #      - '.github/**'
@@ -19,9 +24,6 @@ on:
       message:
         description: 'running acceptance test'
         required: true
-
-  # Allows release.yml to run this as part of the release test suite
-  workflow_call:
 
 env:
   commitmsg: ${{ github.event.head_commit.message }}
@@ -42,7 +44,7 @@ jobs:
   # composite action so it stays in sync with check_xsec_processes_mg7.yml.
   build_madspace:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build_madspace
@@ -50,7 +52,7 @@ jobs:
   acceptancetest_mg7_ufo_aloha:
     needs: build_madspace
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -68,7 +70,7 @@ jobs:
   acceptancetest_mg7_fd_gauge:
     needs: build_madspace
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -83,7 +85,7 @@ jobs:
   acceptancetest_mg7_output_directory:
     needs: build_madspace
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -98,7 +100,7 @@ jobs:
   acceptancetest_mg7_gridpack:
     needs: build_madspace
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -113,7 +115,7 @@ jobs:
   acceptancetest_mg7_ungroup_decay:
     needs: build_madspace
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -128,7 +130,7 @@ jobs:
   acceptancetest_mg7_e_p_collision:
     needs: build_madspace
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -144,7 +146,7 @@ jobs:
     needs: build_madspace
     # xfail: mg7 does not yet generate leshouche.inc (kept on the to-do list)
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -163,7 +165,7 @@ jobs:
     # launch command interface. restore_heptools provides LHAPDF and the mg7
     # default PDF set for the u u~ > z g generation.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -181,7 +183,7 @@ jobs:
     # processes (u q > u q must not mirror any flavor; q q > q q must mirror only
     # the mixed one). No event generation, so no madspace runtime needed.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -198,7 +200,7 @@ jobs:
     # reconstruct the LO reweighting info. No event generation, so no madspace
     # runtime needed.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -214,7 +216,7 @@ jobs:
     # question prunes the cards of the unselected tools. Output-level (drives the
     # question twice), so no madspace runtime needed.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -231,7 +233,7 @@ jobs:
     # LHAPDF (incl. NNPDF40MC_lo_as_01180) comes from the heptools cache.
     # The test self-skips if that stack is unavailable.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -256,7 +258,7 @@ jobs:
     # in acceptancetest_madevent.yml. Self-skips if the madspace +
     # LHAPDF(NNPDF23) stack is absent.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -364,7 +366,7 @@ jobs:
     # acceptancetest_mg7_merged_flavor_mirroring, which guards that flag directly.
     # The test self-skips if the madspace + LHAPDF(NNPDF23) stack is unavailable.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -385,7 +387,7 @@ jobs:
     # them used to double the result to ~81 pb.
     # Self-skips if the madspace + LHAPDF(NNPDF23) stack is unavailable.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -405,7 +407,7 @@ jobs:
     # until the mg7 normalisation for the effective ggH coupling is fixed.
     # Self-skips if the madspace + LHAPDF(NNPDF23) stack is unavailable.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -429,7 +431,7 @@ jobs:
     # acceptancetest_madevent.yml.
     needs: build_madspace
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -450,7 +452,7 @@ jobs:
     # Self-skips if the madspace + LHAPDF(NNPDF23) stack is absent.
     needs: build_madspace
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -484,7 +486,7 @@ jobs:
     # time-of-flight is a pure-python LHE post-processing (no external tool); it
     # only needs the madspace + LHAPDF(NNPDF23) stack.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -500,7 +502,7 @@ jobs:
   acceptancetest_mg7_pythia8:
     needs: build_madspace
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -516,7 +518,7 @@ jobs:
   acceptancetest_mg7_rivet:
     needs: build_madspace
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -535,7 +537,7 @@ jobs:
     # the madspace + LHAPDF(NNPDF23) stack (and a Fortran compiler for the
     # standalone reweighting matrix element, which the runner provides).
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -554,7 +556,7 @@ jobs:
     # <mgrwt>, so the LO reweighting info is reconstructed from single_qcd_order.
     # Needs the madspace + LHAPDF(NNPDF23) stack (systematics reads the PDF).
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5
@@ -572,7 +574,7 @@ jobs:
     # MadSpin ships with MG5 (no external tool); it only needs the madspace +
     # LHAPDF(NNPDF23) stack.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout_mg5

--- a/.github/workflows/aloha.yml
+++ b/.github/workflows/aloha.yml
@@ -6,10 +6,11 @@ name: running test for aloha
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
-    # Tags are excluded: a release tag points at a commit that already ran
-    # this suite when it was pushed to main, and release.yml gates on that
-    # main run rather than re-testing the same tree.
-    tags-ignore:
+    # All branches, no tags: a release tag points at a commit that already
+    # ran this suite when it was pushed to main, and release.yml gates on
+    # that main run rather than re-testing the same tree. '**' is needed
+    # over '*' so branch names containing a slash still match.
+    branches:
       - '**'
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/aloha.yml
+++ b/.github/workflows/aloha.yml
@@ -6,6 +6,11 @@ name: running test for aloha
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
+    # Tags are excluded: a release tag points at a commit that already ran
+    # this suite when it was pushed to main, and release.yml gates on that
+    # main run rather than re-testing the same tree.
+    tags-ignore:
+      - '**'
     paths-ignore:
       - 'docs/**'
 #      - '.github/**'
@@ -19,9 +24,6 @@ on:
       message:
         description: 'running aloha test'
         required: true
-
-  # Allows release.yml to run this as part of the release test suite
-  workflow_call:
 
 env:
   commitmsg: ${{ github.event.head_commit.message }}
@@ -38,7 +40,7 @@ jobs:
   test_aloha:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -57,7 +59,7 @@ jobs:
     # excluded due to side effect
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/check_xsec_processes_mg7.yml
+++ b/.github/workflows/check_xsec_processes_mg7.yml
@@ -18,6 +18,11 @@ name: systematic cross-section tests (mg7)
 
 on:
   push:
+    # Tags are excluded: a release tag points at a commit that already ran
+    # this suite when it was pushed to main, and release.yml gates on that
+    # main run rather than re-testing the same tree.
+    tags-ignore:
+      - '**'
     paths-ignore:
       - 'docs/**'
 #      - '.github/**'
@@ -39,9 +44,6 @@ on:
         description: 'Events per process (reference used 1M; reduced here for CI)'
         required: false
         default: '100000'
-
-  # Allows release.yml to run this as part of the release test suite
-  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/check_xsec_processes_mg7.yml
+++ b/.github/workflows/check_xsec_processes_mg7.yml
@@ -18,10 +18,11 @@ name: systematic cross-section tests (mg7)
 
 on:
   push:
-    # Tags are excluded: a release tag points at a commit that already ran
-    # this suite when it was pushed to main, and release.yml gates on that
-    # main run rather than re-testing the same tree.
-    tags-ignore:
+    # All branches, no tags: a release tag points at a commit that already
+    # ran this suite when it was pushed to main, and release.yml gates on
+    # that main run rather than re-testing the same tree. '**' is needed
+    # over '*' so branch names containing a slash still match.
+    branches:
       - '**'
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/madspace.yml
+++ b/.github/workflows/madspace.yml
@@ -2,10 +2,11 @@ name: MadSpace
 
 on:
   push:
-    # Tags are excluded: a release tag points at a commit that already ran
-    # this suite when it was pushed to main, and release.yml gates on that
-    # main run rather than re-testing the same tree.
-    tags-ignore:
+    # All branches, no tags: a release tag points at a commit that already
+    # ran this suite when it was pushed to main, and release.yml gates on
+    # that main run rather than re-testing the same tree. '**' is needed
+    # over '*' so branch names containing a slash still match.
+    branches:
       - '**'
   pull_request:
   # Called from release.yml once main's CI for the tagged commit is green.

--- a/.github/workflows/madspace.yml
+++ b/.github/workflows/madspace.yml
@@ -2,8 +2,15 @@ name: MadSpace
 
 on:
   push:
+    # Tags are excluded: a release tag points at a commit that already ran
+    # this suite when it was pushed to main, and release.yml gates on that
+    # main run rather than re-testing the same tree.
+    tags-ignore:
+      - '**'
   pull_request:
-  # Called from release.yml once the full test suite has passed. madspace is
+  # Called from release.yml once main's CI for the tagged commit is green.
+  # This is the one suite release.yml still runs itself, because the CI build
+  # on main produces wheels but never publishes them. madspace is
   # never released on its own -- its version always matches the MadGraph
   # release, so publishing only happens through that call.
   workflow_call:

--- a/.github/workflows/madspin_parallel.yml
+++ b/.github/workflows/madspin_parallel.yml
@@ -32,9 +32,6 @@ on:
         required: false
         default: '800'
 
-  # Allows release.yml to run this as part of the release test suite
-  workflow_call:
-
 env:
   MADSPIN_TEST_NEVENTS: ${{ github.event.inputs.nevents || '10000' }}
   MADSPIN_TEST_EFF_TOL: ${{ github.event.inputs.eff_tol || '0.15' }}

--- a/.github/workflows/parralel.yml
+++ b/.github/workflows/parralel.yml
@@ -6,10 +6,11 @@ name: running parralel test
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
-    # Tags are excluded: a release tag points at a commit that already ran
-    # this suite when it was pushed to main, and release.yml gates on that
-    # main run rather than re-testing the same tree.
-    tags-ignore:
+    # All branches, no tags: a release tag points at a commit that already
+    # ran this suite when it was pushed to main, and release.yml gates on
+    # that main run rather than re-testing the same tree. '**' is needed
+    # over '*' so branch names containing a slash still match.
+    branches:
       - '**'
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/parralel.yml
+++ b/.github/workflows/parralel.yml
@@ -6,6 +6,11 @@ name: running parralel test
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
+    # Tags are excluded: a release tag points at a commit that already ran
+    # this suite when it was pushed to main, and release.yml gates on that
+    # main run rather than re-testing the same tree.
+    tags-ignore:
+      - '**'
     paths-ignore:
       - 'docs/**'
 #      - '.github/**'
@@ -19,9 +24,6 @@ on:
       message:
         description: 'running parralel test'
         required: true
-
-  # Allows release.yml to run this as part of the release test suite
-  workflow_call:
 
 env:
   commitmsg: ${{ github.event.head_commit.message }}
@@ -38,7 +40,7 @@ jobs:
   test_short_cross_sqso1:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -61,7 +63,7 @@ jobs:
   test_gauge_4_e500:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -83,7 +85,7 @@ jobs:
   test_gauge_6_e500:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -105,7 +107,7 @@ jobs:
   test_gauge_6_e90:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -128,7 +130,7 @@ jobs:
   test_short_cross_pol:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -151,7 +153,7 @@ jobs:
   test_short_cross_sm1:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -174,7 +176,7 @@ jobs:
   test_short_ppgogo_amcatnlo_nlo:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -196,7 +198,7 @@ jobs:
   test_short_softcol_nlo:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -218,7 +220,7 @@ jobs:
   test_short_cross_gauge:
     # Short gauge cross-section comparison (tests/parallel_tests/compare_gauge.py)
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -237,7 +239,7 @@ jobs:
   test_short_gauge:
     # Short LO gauge-invariance comparison (tests/parallel_tests/compare_gauge.py)
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -256,7 +258,7 @@ jobs:
   test_short_gauge_loop:
     # Short loop gauge-invariance comparison (tests/parallel_tests/compare_gauge.py)
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -283,7 +285,7 @@ jobs:
 
   test_short_sm:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -301,7 +303,7 @@ jobs:
 
   test_short_sqso:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -319,7 +321,7 @@ jobs:
 
   test_short_polarization:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -338,7 +340,7 @@ jobs:
   test_short_mssm:
     # Needs MSSM_SLHA2 UFO model from the UFOmodeldb cache.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -358,7 +360,7 @@ jobs:
   test_short_heft:
     # Needs heft UFO model from the UFOmodeldb cache.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -378,7 +380,7 @@ jobs:
   test_short_cross_sm2:
     # Compares MadEvent cross-section against hard-coded u j > W+ g / g g > W+ j j values.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -397,7 +399,7 @@ jobs:
   test_short_cross_sm3:
     # Compares MadEvent cross-section against hard-coded g g > t t~ decay-chain values.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -416,7 +418,7 @@ jobs:
   test_short_cross_mssm1:
     # Compares MadEvent cross-section against hard-coded g g > go go (MSSM) values.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -444,7 +446,7 @@ jobs:
   test_short_check_eejjj_lo_lhapdf:
     # e+ e- > p p p [real=QCD] at LO with pdlabel='lhapdf'.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -461,7 +463,7 @@ jobs:
   test_short_split_evt_gen_zeroev:
     # p p > e+ e- [real=QCD] with split event generation when a channel has zero events.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -478,7 +480,7 @@ jobs:
   test_short_check_ppwy:
     # p p > w+ y [QCD] using the loop_smgrav model (spin-2 graviton wavefunction).
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -495,7 +497,7 @@ jobs:
   test_short_launch_amcatnlo_name:
     # p p > e+ ve [QCD] launched via aMC@NLO with an explicit run name.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -512,7 +514,7 @@ jobs:
   test_short_calculate_xsect_script:
     # Cross-section computation driven by bin/calculate_xsect for p p > e+ ve [QCD].
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -534,7 +536,7 @@ jobs:
 
   test_short_ML5_sm_vs_stored_ML5:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -550,7 +552,7 @@ jobs:
 
   test_short_ML5_sm_vs_stored_ML4:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -573,7 +575,7 @@ jobs:
   test_short_generate_events_nlo_hw6_stdhep:
     # NLO event generation, showered with HERWIG6, output as StdHEP.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -591,7 +593,7 @@ jobs:
   test_short_generate_events_nlo_hw6_split:
     # NLO event generation split into multiple HERWIG6 shower sub-jobs.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -609,7 +611,7 @@ jobs:
   test_short_generate_events_nlo_py6_stdhep:
     # NLO event generation, showered with PYTHIA6 (PYTHIA6Q), output as StdHEP.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -627,7 +629,7 @@ jobs:
   test_short_generate_events_nlo_py6pt_stdhep:
     # NLO event generation, showered with PYTHIA6PT, output as StdHEP.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -645,7 +647,7 @@ jobs:
   test_short_check_generate_events_nlo_py6pt_fsr:
     # Negative test: PYTHIA6PT must refuse to shower a process with final-state radiation.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -664,7 +666,7 @@ jobs:
     # Exercises bin/generate_events + bin/shower with HERWIG6 hep and top output,
     # including nsplit_jobs > 1 splitting.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -682,7 +684,7 @@ jobs:
   test_short_generate_events_name:
     # bin/generate_events with an explicit run name, default HERWIG6 shower.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -701,7 +703,7 @@ jobs:
   test_decay_comparator_mssm:
     # bin/generate_events with an explicit run name, default HERWIG6 shower.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -718,7 +720,7 @@ jobs:
   test_decay_comparator_heft:
     # bin/generate_events with an explicit run name, default HERWIG6 shower.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -735,7 +737,7 @@ jobs:
   test_decay_comparator_nmssm1:
     # bin/generate_events with an explicit run name, default HERWIG6 shower.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -752,7 +754,7 @@ jobs:
   test_decay_comparator_nmssm2:
     # bin/generate_events with an explicit run name, default HERWIG6 shower.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -769,7 +771,7 @@ jobs:
   test_decay_comparator_nmssm3:
     # bin/generate_events with an explicit run name, default HERWIG6 shower.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -786,7 +788,7 @@ jobs:
   test_ML5_uux_ddx:
     # bin/generate_events with an explicit run name, default HERWIG6 shower.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -803,7 +805,7 @@ jobs:
   test_long_sm_vs_stored_ML5_sqso_ddx_ddx_WEIGHTEDgt6:
     # bin/generate_events with an explicit run name, default HERWIG6 shower.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -820,7 +822,7 @@ jobs:
   test_long_sm_vs_stored_ML5_gg_zccx:
     # bin/generate_events with an explicit run name, default HERWIG6 shower.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -837,7 +839,7 @@ jobs:
   test_long_sm_vs_stored_HCR_uxu_zz_QED:
     # bin/generate_events with an explicit run name, default HERWIG6 shower.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -854,7 +856,7 @@ jobs:
   test_long_sm_vs_stored_HCR_uxu_zz_QCD:
     # bin/generate_events with an explicit run name, default HERWIG6 shower.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,17 @@
 name: Release
 
 # Fires once a GitHub Release is published (draft -> Publish release), never on
-# a tag push by itself. Runs the full test suite, publishes madspace to PyPI
-# with the same version as the MadGraph release, and attaches the MadGraph
-# tarball to the release. If anything fails, the release is reverted to draft
-# so a half-published version never stays public.
+# a tag push by itself. Checks that main's CI was green for the tagged commit,
+# publishes madspace to PyPI with the same version as the MadGraph release, and
+# attaches the MadGraph tarball to the release. If anything fails, the release
+# is reverted to draft so a half-published version never stays public.
+#
+# The test suites are deliberately NOT re-run here. Every commit on main is
+# already tested by the push-triggered workflows, and the release tag points at
+# one of those commits, so re-running them would test the same tree a second
+# time for ~250 duplicated jobs. require_green_ci below gates on that existing
+# run instead. (The suites also no longer trigger on tag pushes, for the same
+# reason -- see the tags-ignore note in each of them.)
 on:
   release:
     types: [published]
@@ -16,7 +23,7 @@ concurrency:
 permissions:
   contents: write
   id-token: write
-  actions: write
+  actions: read
 
 jobs:
   check_version:
@@ -30,54 +37,113 @@ jobs:
       - name: Check VERSION / madspace/pyproject.toml agree with the release tag
         run: python3 bin/create_release.py --version "${{ steps.version.outputs.value }}" --check-only
 
-  # Warm the HEPTools/UFO/pip caches first: restore_heptools (used throughout
-  # the test suites below) hard-fails on a cache miss, and a release should not
-  # depend on a cache having been kept warm by chance.
-  warm_cache:
+  # The release gate: main's CI for the exact commit being released must have
+  # finished and be green. Waits if it is still running, so publishing a release
+  # straight after a merge works without having to watch CI by hand.
+  require_green_ci:
     needs: check_version
-    uses: ./.github/workflows/warm_cache.yml
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # merge-base below needs history
 
-  test_unit:
-    needs: warm_cache
-    uses: ./.github/workflows/unittest.yml
-  test_acceptance:
-    needs: warm_cache
-    uses: ./.github/workflows/acceptancetest.yml
-  test_madevent:
-    needs: warm_cache
-    uses: ./.github/workflows/acceptancetest_madevent.yml
-  test_mg7:
-    needs: warm_cache
-    uses: ./.github/workflows/acceptancetest_mg7.yml
-  test_parallel:
-    needs: warm_cache
-    uses: ./.github/workflows/parralel.yml
-  test_io:
-    needs: warm_cache
-    uses: ./.github/workflows/IOtest.yml
-  test_aloha:
-    needs: warm_cache
-    uses: ./.github/workflows/aloha.yml
-  test_madspin:
-    needs: warm_cache
-    uses: ./.github/workflows/madspin_parallel.yml
-  test_xsec:
-    needs: warm_cache
-    uses: ./.github/workflows/check_xsec_processes_mg7.yml
+      - name: Check the release commit is on main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::${GITHUB_REF_NAME} points at $GITHUB_SHA, which is not on main."
+            echo "::error::Releases are gated on main's CI run for the tagged commit, so the tag has to be on main."
+            exit 1
+          fi
+
+      - name: Require main's CI for this commit to be green
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # The full suite takes a few hours from cold; stay under the job's
+          # own timeout-minutes so we report which suite hung rather than
+          # having the runner killed out from under us.
+          POLL_TIMEOUT_MINUTES: '330'
+          POLL_INTERVAL_SECONDS: '60'
+        run: |
+          set -uo pipefail
+
+          # Every suite that runs on a push to main. Kept as an explicit list
+          # on purpose: "all runs for this commit were green" is vacuously true
+          # when no run exists at all, which is exactly the failure mode that
+          # let v0.2.0 publish untested.
+          #
+          # madspin_parallel.yml is knowingly absent -- its push filter is
+          # branches: ['3.x'], so it never runs on main and there is nothing to
+          # gate on. See the tracking issue linked in the PR that added this.
+          REQUIRED="
+          .github/workflows/unittest.yml
+          .github/workflows/acceptancetest.yml
+          .github/workflows/acceptancetest_madevent.yml
+          .github/workflows/acceptancetest_mg7.yml
+          .github/workflows/parralel.yml
+          .github/workflows/IOtest.yml
+          .github/workflows/aloha.yml
+          .github/workflows/check_xsec_processes_mg7.yml
+          .github/workflows/madspace.yml
+          "
+
+          deadline=$(( $(date +%s) + POLL_TIMEOUT_MINUTES * 60 ))
+          while :; do
+            runs=$(gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$GITHUB_SHA&event=push&branch=main&per_page=100" \
+              --jq '.workflow_runs[]' | jq -s '.')
+
+            pending=0 bad=0 total=0 summary=""
+            for wf in $REQUIRED; do
+              total=$((total + 1))
+              # The same commit can have several runs of one workflow (a re-run
+              # of the merge, say), so take the newest; run ids are monotonic.
+              read -r status conclusion url <<<"$(jq -r --arg p "$wf" '
+                [.[] | select(.path == $p)] | sort_by(.id) | last
+                | if . == null then "absent - -"
+                  else "\(.status) \(.conclusion // "-") \(.html_url)" end' <<<"$runs")"
+
+              case "$status:$conclusion" in
+                completed:success) state="ok" ;;
+                absent:*)          state="never ran"; bad=$((bad + 1)) ;;
+                completed:*)       state="$conclusion"; bad=$((bad + 1)) ;;
+                *)                 state="$status"; pending=$((pending + 1)) ;;
+              esac
+              summary+="  $(printf '%-12s' "$state") ${wf##*/}  ${url}"$'\n'
+            done
+
+            # A failed or cancelled run will not become green by waiting.
+            if [ "$bad" -gt 0 ]; then
+              printf '%s' "$summary"
+              echo "::error::main's CI for $GITHUB_SHA is not green -- $bad required workflow(s) failed, were cancelled, or never ran."
+              echo "::error::Re-run the workflow(s) above on main, then re-publish ${GITHUB_REF_NAME}."
+              exit 1
+            fi
+
+            if [ "$pending" -eq 0 ]; then
+              printf '%s' "$summary"
+              echo "main's CI for $GITHUB_SHA is green across all $total required workflows."
+              break
+            fi
+
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              printf '%s' "$summary"
+              echo "::error::timed out after ${POLL_TIMEOUT_MINUTES}m waiting for $pending workflow(s) on $GITHUB_SHA."
+              exit 1
+            fi
+
+            echo "waiting on $pending workflow(s) for $GITHUB_SHA..."
+            sleep "$POLL_INTERVAL_SECONDS"
+          done
 
   # Builds the full wheel matrix and publishes to PyPI. madspace is never
   # released standalone, so this is the only path that ever sets publish: true.
+  # This one does have to run here: the CI build on main does not publish.
   madspace:
-    needs:
-      - test_unit
-      - test_acceptance
-      - test_madevent
-      - test_mg7
-      - test_parallel
-      - test_io
-      - test_aloha
-      - test_madspin
-      - test_xsec
+    needs: require_green_ci
     uses: ./.github/workflows/madspace.yml
     with:
       publish: true
@@ -138,19 +204,17 @@ jobs:
   revert_to_draft:
     needs:
       - check_version
-      - warm_cache
-      - test_unit
-      - test_acceptance
-      - test_madevent
-      - test_mg7
-      - test_parallel
-      - test_io
-      - test_aloha
-      - test_madspin
-      - test_xsec
+      - require_green_ci
       - madspace
       - tarball
-    if: failure() || cancelled()
+    # 'skipped' has to count as a failure here: a job whose own guard is false,
+    # or one whose dependency was skipped, is neither failure() nor cancelled(),
+    # so the old condition let a run in which nothing but check_version executed
+    # report success and leave the release published untested.
+    if: >-
+      always() && (contains(needs.*.result, 'failure')
+      || contains(needs.*.result, 'cancelled')
+      || contains(needs.*.result, 'skipped'))
     runs-on: ubuntu-24.04
     steps:
       - name: Revert the release to draft
@@ -159,3 +223,7 @@ jobs:
         run: |
           gh release edit '${{ github.ref_name }}' --draft --repo '${{ github.repository }}'
           echo "::error::Release checks failed -- '${{ github.ref_name }}' was reverted to draft. Fix the issue and re-publish."
+          # An ::error:: annotation does not set an exit code. Without this the
+          # run is still green when the trigger was skipped jobs rather than a
+          # failed one, which is exactly the case this job now catches.
+          exit 1

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,10 +6,11 @@ name: running unittest
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
-    # Tags are excluded: a release tag points at a commit that already ran
-    # this suite when it was pushed to main, and release.yml gates on that
-    # main run rather than re-testing the same tree.
-    tags-ignore:
+    # All branches, no tags: a release tag points at a commit that already
+    # ran this suite when it was pushed to main, and release.yml gates on
+    # that main run rather than re-testing the same tree. '**' is needed
+    # over '*' so branch names containing a slash still match.
+    branches:
       - '**'
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,12 +6,14 @@ name: running unittest
 on:
   # Triggers the workflow on push or pull request events but only for the 3.4.0 branch
   push:
+    # Tags are excluded: a release tag points at a commit that already ran
+    # this suite when it was pushed to main, and release.yml gates on that
+    # main run rather than re-testing the same tree.
+    tags-ignore:
+      - '**'
     paths-ignore:
       - 'docs/**'
 # - '.github/**'
-
-  # Allows release.yml to run this as part of the release test suite
-  workflow_call:
 
   pull_request:
     types: [opened, synchronize, reopened]
@@ -38,7 +40,7 @@ jobs:
   test_additional_unittest:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -55,7 +57,7 @@ jobs:
   unittest_0:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -73,7 +75,7 @@ jobs:
   unittest_1:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -91,7 +93,7 @@ jobs:
   unittest_2:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -109,7 +111,7 @@ jobs:
   unittest_3:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -127,7 +129,7 @@ jobs:
   unittest_4:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -145,7 +147,7 @@ jobs:
   unittest_5:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -163,7 +165,7 @@ jobs:
   unittest_6:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -181,7 +183,7 @@ jobs:
   unittest_7:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -199,7 +201,7 @@ jobs:
   unittest_8:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -217,7 +219,7 @@ jobs:
   unittest_9:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -235,7 +237,7 @@ jobs:
   unittest_10:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -258,7 +260,7 @@ jobs:
   unittest_11:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -276,7 +278,7 @@ jobs:
   unittest_12:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -294,7 +296,7 @@ jobs:
   unittest_13:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -312,7 +314,7 @@ jobs:
   unittest_14:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -330,7 +332,7 @@ jobs:
   unittest_15:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -348,7 +350,7 @@ jobs:
   unittest_16:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -366,7 +368,7 @@ jobs:
   unittest_17:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -384,7 +386,7 @@ jobs:
   unittest_18_1:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -400,7 +402,7 @@ jobs:
   unittest_18_2:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -416,7 +418,7 @@ jobs:
   unittest_18_3:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -436,7 +438,7 @@ jobs:
   unittest_19:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -454,7 +456,7 @@ jobs:
   unittest_20:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -472,7 +474,7 @@ jobs:
   unittest_21:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -491,7 +493,7 @@ jobs:
   unittest_22:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -510,7 +512,7 @@ jobs:
   unittest_23:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -528,7 +530,7 @@ jobs:
   unittest_24:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -546,7 +548,7 @@ jobs:
   unittest_25:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -564,7 +566,7 @@ jobs:
   unittest_26:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -582,7 +584,7 @@ jobs:
   unittest_27:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -600,7 +602,7 @@ jobs:
   unittest_28:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -619,7 +621,7 @@ jobs:
   unittest_density_29:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -639,7 +641,7 @@ jobs:
   unittest_new_coverage:
     # New unit tests added in 3.7.1: q_polynomial and hepmc_parser
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
     permissions:
       contents: read
 
@@ -657,7 +659,7 @@ jobs:
     # color algebra, base/diagram object merging, miscellaneous I/O and drawing
     # Includes test_fks_ppzz_in_RS using the restored RS UFO model cache.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -673,7 +675,7 @@ jobs:
   unittest_30:
     # Uncovered unit tests in tests/unit_tests/various/test_lhe_parser.py
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -687,7 +689,7 @@ jobs:
   unittest_31:
     # Uncovered unit tests in tests/unit_tests/various/test_process_checks.py
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -701,7 +703,7 @@ jobs:
   unittest_32:
     # Uncovered unit tests in tests/unit_tests/various/test_import_ufo.py
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -715,7 +717,7 @@ jobs:
   unittest_33:
     # Uncovered unit tests in tests/unit_tests/fks/test_ewsudakov.py
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -731,7 +733,7 @@ jobs:
     # plus the lhe_parser split/merge of the unweighted output. These modules were
     # not covered by any workflow.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -748,7 +750,7 @@ jobs:
     # unit tests that were not listed in any workflow (CI coverage audit).
     # test_fks_ppzz_in_RS is left out: the RS UFO model is still python2 only.
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -763,7 +765,7 @@ jobs:
     # tests/unit_tests/various/test_lhapdf_resolve.py: where the configuration
     # files live ($MADGRAPH_BASE, per-user, install) and how LHAPDF is resolved
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5
@@ -777,7 +779,7 @@ jobs:
   unittest_write_model:
     # runs alone: excluded from the shared unittest jobs due to side effects
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' || github.event_name == 'workflow_call' || github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/warm_cache.yml
+++ b/.github/workflows/warm_cache.yml
@@ -44,10 +44,6 @@ on:
       reset_pip:
         type: boolean
         default: false
-
-  # Called from release.yml to warm caches before the release test suite runs,
-  # so restore_heptools's fail-on-cache-miss doesn't abort the release.
-  workflow_call:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
@@ -203,7 +199,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   rebuild-numpy-cache:
-    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'schedule')
+    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -244,7 +240,7 @@ jobs:
           key: pip-numpy-${{ env.CACHE_KEY }}-${{ github.run_id }}
 
   ufo_cache:
-    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'schedule')
+    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
     runs-on: ubuntu-24.04
     needs: delete-cache
 
@@ -289,7 +285,7 @@ jobs:
           key: ufomodel-${{ github.run_id }}
            
   lhapdf_cache:
-    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && github.event_name != 'schedule'
+    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch') && github.event_name != 'schedule'
     needs: delete-cache
     runs-on: ${{ matrix.os }}
     strategy:
@@ -359,7 +355,7 @@ jobs:
            tools: lhapdf
 
   pythia8_cache:
-    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && github.event_name != 'schedule'
+    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch') && github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
     needs: lhapdf_cache
     strategy:
@@ -470,7 +466,7 @@ jobs:
            tools: boost
 
   emela_cache:
-    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && github.event_name != 'schedule'
+    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch') && github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
     needs: boost_cache
     strategy:
@@ -545,7 +541,7 @@ jobs:
 #             GH_TOKEN: ${{ github.token }}
 
   contur_cache:
-    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && github.event_name != 'schedule'
+    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch') && github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
     needs: pythia8_cache
     strategy:
@@ -611,7 +607,7 @@ jobs:
        #     GH_TOKEN: ${{ github.token }}
 
   looptools_cache:
-    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && github.event_name != 'schedule'
+    if: (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch') && github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
     strategy:
      matrix:
@@ -705,7 +701,7 @@ jobs:
   # their exact key when that run is re-run.
   # ---------------------------------------------------------------------------
   heptools_cache:
-    if: always() && (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && github.event_name != 'schedule'
+    if: always() && (github.ref_name == 'main' || github.ref_name == 'test_ci' || github.event_name == 'workflow_dispatch') && github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}       
     strategy:
       matrix:


### PR DESCRIPTION
Fixes the silent failure in [run 34676103099](https://github.com/MadGraphTeam/MadGraph7/actions/runs/34676103099), which reported **success** for the v0.2.0 release while running nothing but `check_version`. The full test suite, the PyPI publish and the tarball were all skipped, and the release stayed published untested.

## The bug

Every job guard in the workflows `release.yml` calls tested:

```yaml
if: github.event_name == 'push' || github.event_name == 'workflow_call' || ...
```

`github.event_name == 'workflow_call'` **is never true**. A called reusable workflow sees the *caller's* `github` context, so during the release run `event_name` was `release` and `ref_name` was `v0.2.0`, not `main`. Every branch of every guard was false:

1. all `warm_cache` jobs skip → the `warm_cache` job reports `skipped`
2. the nine `needs: warm_cache` test jobs skip (a skipped dependency propagates through `needs:`)
3. `madspace` (PyPI publish) and `tarball` skip
4. `revert_to_draft` has `if: failure() || cancelled()` — skipped is neither, so it never fires

A run of only-skipped jobs has conclusion `success`, which is why nothing flagged it.

## The fix

Rather than repair the guards and keep testing the same tree twice, this gates on the CI that already ran. The tagged commit is on main, and main's push CI covers it:

```
sha 567b26596 (= main tip = v0.2.0)
  34614775616  branch=main    success   ← merge to main
  34676102739  branch=v0.2.0  success   ← tag push
release run 34676103099 started 05:45   ← would have run it a third time
```

- **`require_green_ci` replaces `warm_cache` + the nine `test_*` jobs.** It checks the tag is on main, then polls the main-branch runs for that exact SHA and requires each required workflow to be a completed success, waiting if CI is still in flight. The required workflows are an **explicit list** on purpose: *"all runs for this commit were green"* is vacuously true when no run exists, which is precisely the bug being fixed.
- **The suites no longer trigger on tag pushes** (`branches: ['**']`, which matches every branch and no tag), so publishing a release no longer runs CI a second time on the tag push and a third time from `release.yml`. Net saving is roughly 250 duplicated jobs per release.
- **Dead `workflow_call` plumbing removed** from the workflows `release.yml` no longer calls — the triggers and the `|| github.event_name == 'workflow_call'` clauses, which were broken as written and would trap the next person to add a `uses:`. `madspace` keeps its `workflow_call`: the CI build on main produces wheels but never publishes them, so that one still runs at release time.
- **`revert_to_draft` now counts `skipped` as a failure**, and ends in `exit 1` — an `::error::` annotation sets no exit code, so without it the run stays green even as the release is reverted.

## Verification

The gate script was extracted and run against the live API on three real commits:

| commit | main CI state | result |
| --- | --- | --- |
| `567b26596` (main tip) | all 9 green | exit 0, correctly picked the `branch=main` runs over the `v0.2.0` tag runs |
| `3dd0965db` | 8 `cancelled`, 1 green | exit 1, each cancelled run named with its URL |
| nonexistent SHA | no runs | exit 1, reported as `never ran` rather than passing vacuously |

All 13 workflow files parse, and no job in the release path is left gated off.

The tag-exclusion filter was verified on this branch: the first attempt used `tags-ignore: ['**']`, which produced **zero** push runs — defining only `tags-ignore` leaves branches undefined, so GitHub stops running the workflow for branch pushes entirely. Fixed in b554c7d and re-verified: the push of `b554c7d37` queued all nine required workflows.

## Known trade-offs

- **`cancel-in-progress` remains a live hazard.** The suites use `group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`, so a merge landing after yours cancels your commit's main run — 2 of the last 6 main commits are in exactly that state. The gate detects this and names the runs to re-run, but it will block a release until someone re-runs them. Worth considering a `cancel-in-progress: false` on main separately.
- **`warm_cache` no longer runs as part of a release.** It could not have helped anyway once the suites are not called from `release.yml` — a cold cache now surfaces as a red main CI and a blocked release rather than being warmed on demand. The twice-weekly schedule is unchanged.
- **A docs-only tip commit gets no CI** (`paths-ignore: docs/**`) and so cannot be released without re-running something. This fails loudly rather than passing silently.

## Follow-up

`madspin_parallel` is knowingly outside the gate — its push filter is `branches: ['3.x']`, a branch that does not exist in this repo, so it never runs on main. It was reachable only through the `release.yml` call path, which was itself broken. Tracked in #146.
