### PR TITLE
Let a sqrt_s minimum bound the integration instead of only filtering it

### DIFF
--- a/madgraph/iolibs/template_files/mg7/run_card.toml
+++ b/madgraph/iolibs/template_files/mg7/run_card.toml
@@ -117,7 +117,10 @@ $multiparticles
 # A pair_mass minimum is also used to bound the integration: where the pair
 # is what a propagator decays into, the cut becomes that propagator's minimum
 # invariant mass, so the forbidden region is never generated rather than
-# generated and thrown away.
+# generated and thrown away. A sqrt_s minimum bounds it the same way, as the
+# minimum partonic energy the luminosity is sampled from, and so does a
+# pair_mass minimum that no single propagator carries. The integral is
+# unaffected either way -- only how much of the sampling is wasted.
 # for all cuts, min or max can be specified
 $cuts
 

--- a/madgraph/iolibs/template_files/mg7/run_card.toml
+++ b/madgraph/iolibs/template_files/mg7/run_card.toml
@@ -114,12 +114,8 @@ $multiparticles
 #      pair_mass is the invariant mass of a pair, taken over every pair the
 #      named groups can form, so "lepton-pair_mass" is the same cut as
 #      "lepton-lepton-sum-mass". sqrt_s is for all outgoing particles)
-# A pair_mass minimum is also used to bound the integration: where the pair
-# is what a propagator decays into, the cut becomes that propagator's minimum
-# invariant mass, so the forbidden region is never generated rather than
-# generated and thrown away. A sqrt_s minimum bounds it the same way, as the
-# minimum partonic energy the luminosity is sampled from, and so does a
-# pair_mass minimum that no single propagator carries. The integral is
+# A pair_mass minimum is also used to bound the integration.
+# A sqrt_s minimum bounds it the same way. The integral is
 # unaffected either way -- only how much of the sampling is wasted.
 # for all cuts, min or max can be specified
 $cuts

--- a/madspace/src/phasespace/phasespace.cpp
+++ b/madspace/src/phasespace/phasespace.cpp
@@ -248,6 +248,53 @@ PhaseSpaceMapping::PhaseSpaceMapping(
             }
         }
     }
+
+    // The same thing one level up: a floor on the total invariant mass of the
+    // final state is a floor on the root propagator, which is the s-hat the
+    // luminosity mapping samples. Handing it over is the difference between
+    // sampling the region the cut allows and sampling everything and throwing
+    // nearly all of it away; the Invariant's Jacobian follows the range it is
+    // given, so the integral is unchanged and only the efficiency moves.
+    //
+    // Two sources of such a floor:
+    //   * a cut on sqrt(s_hat) itself, and
+    //   * a two-particle invariant mass cut that no single propagator carries,
+    //     which still bounds the total: the pair contributes at least the cut
+    //     and everything else at least its mass. The smallest such bound over
+    //     the pairs the cut names is the one that holds whether the cut has to
+    //     be satisfied by all of them or by only one, so it is the safe choice.
+    double sqrt_s_hat_min = _cuts.sqrt_s_min();
+    {
+        const auto& masses = _topology.outgoing_masses();
+        double pair_floor = 0.;
+        for (std::size_t i = 0; i < m_inv_min.size(); ++i) {
+            for (std::size_t j = i + 1; j < m_inv_min.at(i).size(); ++j) {
+                double cut = m_inv_min.at(i).at(j);
+                if (cut <= 0.) {
+                    continue;
+                }
+                double floor = cut;
+                for (std::size_t k = 0; k < masses.size(); ++k) {
+                    if (k != i && k != j) {
+                        floor += masses.at(k);
+                    }
+                }
+                if (pair_floor == 0. || floor < pair_floor) {
+                    pair_floor = floor;
+                }
+            }
+        }
+        sqrt_s_hat_min = std::max(sqrt_s_hat_min, pair_floor);
+    }
+    // Only the luminosity mapping samples the root virtuality. A leptonic
+    // collision has s_hat fixed at s_lab and chili reconstructs it from the
+    // momenta it has already generated, so in neither case is there a range to
+    // narrow -- the cut stays a filter there. A floor at or above the beam
+    // energy leaves nothing to sample at all, and is left to the filter too
+    // rather than handed on as an empty range.
+    if (_map_luminosity && sqrt_s_hat_min > 0. && sqrt_s_hat_min < _sqrt_s_lab) {
+        _topology.raise_decay_e_min(0, sqrt_s_hat_min);
+    }
     for (auto [decay, info] :
          zip(std::views::reverse(_topology.decays()),
              std::views::reverse(decay_info))) {
@@ -289,40 +336,6 @@ PhaseSpaceMapping::PhaseSpaceMapping(
         }
     }
 
-    double total_mass = 0.;
-    for (std::size_t index : topology.decays().at(0).child_indices) {
-        total_mass += decay_info.at(index).m_min;
-    }
-    double sqrt_s_hat_min = _cuts.sqrt_s_min();
-    // Even when no single propagator carries the pair, the cut still bounds
-    // the total invariant mass: the pair contributes at least the cut and
-    // everything else at least its mass. The smallest such bound over the
-    // pairs the cut names is the one that holds whether the cut has to be
-    // satisfied by all of them or by only one, so it is the safe choice.
-    {
-        const auto& masses = _topology.outgoing_masses();
-        double pair_floor = 0.;
-        for (std::size_t i = 0; i < m_inv_min.size(); ++i) {
-            for (std::size_t j = i + 1; j < m_inv_min.at(i).size(); ++j) {
-                double cut = m_inv_min.at(i).at(j);
-                if (cut <= 0.) {
-                    continue;
-                }
-                double floor = cut;
-                for (std::size_t k = 0; k < masses.size(); ++k) {
-                    if (k != i && k != j) {
-                        floor += masses.at(k);
-                    }
-                }
-                if (pair_floor == 0. || floor < pair_floor) {
-                    pair_floor = floor;
-                }
-            }
-        }
-        sqrt_s_hat_min = std::max(sqrt_s_hat_min, pair_floor);
-    }
-    double s_hat_min =
-        std::max(total_mass * total_mass, sqrt_s_hat_min * sqrt_s_hat_min);
     if (has_t_channel) {
         // Per-child pt_min (and eta_max), ordered to match the mass conditions
         // handed to the t-channel mapping (leaf children carry their pt cut;

--- a/madspace/tests/test_sqrt_s_cut.py
+++ b/madspace/tests/test_sqrt_s_cut.py
@@ -1,0 +1,211 @@
+"""A minimum on the partonic sqrt(s), and the phase-space boundary it implies.
+
+A cut on sqrt(s_hat) is a statement about the whole final state: nothing below
+it can ever be generated, so the root propagator -- the virtuality the
+luminosity mapping samples -- has a floor. Handing that floor to the sampler is
+the difference between generating the region the cut allows and generating
+everything and throwing nearly all of it away.
+
+The process is g g > t t~, which has a kinematic threshold of its own at
+2 m_t = 346 GeV. That threshold is what makes the central invariant testable:
+a cut placed *below* it cannot remove a single point, so it must leave the
+integral -- and here even the sampled points themselves -- untouched. A cut
+placed above it must move the boundary without moving the integral.
+
+Pinned down here:
+
+  * obs_sqrt_s is the invariant mass of the two incoming partons,
+  * a cut below the kinematic threshold changes nothing at all,
+  * with a cut above it, no point below the cut is generated,
+  * and doing so does not change the volume of the cut region, i.e. the
+    boundary is a consequence of the cut and not an extra cut of its own,
+  * a cut above the beam energy leaves an empty, finite result rather than an
+    inverted sampling range.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+import madspace as ms
+
+CM_ENERGY = 13000.0
+M_TOP = 173.0
+BATCH_SIZE = 100_000
+SEED = 20260912
+
+# g g > t t~
+PIDS = [21, 21, 6, -6]
+MASSES = [0.0, 0.0, M_TOP, M_TOP]
+# the process cannot produce less than this, whatever the cut says
+THRESHOLD = 2 * M_TOP
+# below the threshold: the cut cannot bite, so nothing may change
+NO_OP_CUT = 300.0
+# above it: the cut removes half the points and a large enough part of the
+# volume that a boundary which failed to compensate could not hide in the
+# statistics (see test_the_cut_removes_more_than_the_comparison_could_hide)
+BITING_CUT = 4000.0
+
+
+def sqrt_s_cuts(minimum):
+    O = ms.Observable
+    return ms.Cuts([ms.CutItem(O(PIDS, O.obs_sqrt_s, []), min=minimum)])
+
+
+def mapping(cuts=None, leptonic=False):
+    return ms.PhaseSpaceMapping(MASSES, CM_ENERGY, cuts=cuts, leptonic=leptonic)
+
+
+def sample(mapping, seed=SEED, n=BATCH_SIZE):
+    rng = np.random.default_rng(seed)
+    p_ext, _x1, _x2, det = mapping.map_forward([rng.random((n, mapping.random_dim()))])
+    return np.asarray(p_ext), np.asarray(det)
+
+
+def s_hat(p):
+    """sqrt of the partonic Mandelstam s, from the two incoming momenta."""
+    total = p[:, 0, :] + p[:, 1, :]
+    m2 = total[:, 0] ** 2 - np.sum(total[:, 1:] ** 2, axis=1)
+    return np.sqrt(np.maximum(m2, 0.0))
+
+
+def volume(det, p):
+    """The integral the mapping estimates, with non-finite points dropped."""
+    finite = np.isfinite(det) & np.all(np.isfinite(p), axis=(1, 2))
+    return np.where(finite, det, 0.0)
+
+
+# --------------------------------------------------------------------------
+# the observable itself
+# --------------------------------------------------------------------------
+
+
+def test_obs_sqrt_s_is_the_partonic_invariant_mass():
+    p_ext, _ = sample(mapping())
+    O = ms.Observable
+    computed = np.asarray(O(PIDS, O.obs_sqrt_s, [])(p_ext)).reshape(-1)
+    assert computed == pytest.approx(s_hat(p_ext), rel=1e-9)
+    # and it is the invariant mass of the final state too, i.e. it really is
+    # the quantity the whole event has to clear
+    out = p_ext[:, 2, :] + p_ext[:, 3, :]
+    m_out = np.sqrt(
+        np.maximum(out[:, 0] ** 2 - np.sum(out[:, 1:] ** 2, axis=1), 0.0)
+    )
+    assert computed == pytest.approx(m_out, rel=1e-6)
+
+
+def test_the_process_has_a_threshold_of_its_own():
+    """The rest of the file leans on this: 2 m_t is a floor the mapping already
+    respects, so a cut below it has nothing left to forbid."""
+    p_ext, _ = sample(mapping())
+    assert s_hat(p_ext).min() >= THRESHOLD - 1e-6
+    assert NO_OP_CUT < THRESHOLD < BITING_CUT
+
+
+# --------------------------------------------------------------------------
+# a cut that cannot bite
+# --------------------------------------------------------------------------
+
+
+def test_a_cut_below_the_threshold_changes_nothing():
+    """The invariant the boundary must respect: the floor is allowed to narrow
+    the sampled range only as far as the cut actually forbids something. Below
+    the kinematic threshold it forbids nothing, so the same random numbers must
+    give back the very same points with the very same weights -- which makes
+    the integral unchanged in the sharpest possible sense."""
+    p_free, det_free = sample(mapping())
+    p_cut, det_cut = sample(mapping(cuts=sqrt_s_cuts(NO_OP_CUT)))
+    assert np.array_equal(det_free, det_cut)
+    assert np.array_equal(p_free, p_cut)
+
+
+def test_a_cut_at_zero_changes_nothing():
+    """The same statement for the value the run card ships with."""
+    p_free, det_free = sample(mapping())
+    p_cut, det_cut = sample(mapping(cuts=sqrt_s_cuts(0.0)))
+    assert np.array_equal(det_free, det_cut)
+    assert np.array_equal(p_free, p_cut)
+
+
+# --------------------------------------------------------------------------
+# the boundary a cut above the threshold implies
+# --------------------------------------------------------------------------
+
+
+def test_cut_bounds_the_sampled_s_hat():
+    """With the cut handed to the mapping nothing below it is generated, and
+    nothing generated has to be thrown away either."""
+    p_ext, det = sample(mapping(cuts=sqrt_s_cuts(BITING_CUT)))
+    s = s_hat(p_ext)
+    assert s.min() >= BITING_CUT - 1e-6
+    # the region has not collapsed onto its own boundary
+    assert s.max() > 2 * BITING_CUT
+    # and the cut is no longer filtering anything out
+    assert np.all(det != 0.0)
+
+
+def test_without_the_bound_the_same_region_is_wasted():
+    """The counterpart of the test above: without the boundary the sampler puts
+    a real fraction of its points where the cut throws them away. That waste is
+    what the boundary removes, so if it ever stops being true the test above
+    has stopped proving anything."""
+    p_ext, _ = sample(mapping())
+    assert np.mean(s_hat(p_ext) < BITING_CUT) > 0.25
+
+
+def test_cut_volume_is_unchanged_by_the_boundary():
+    """The boundary must follow from the cut, not add to it: integrating the
+    cut region has to give the same answer whether the mapping knows about the
+    cut or only the filtering does."""
+    p_free, det_free = sample(mapping(), seed=SEED)
+    passes = s_hat(p_free) >= BITING_CUT
+    external = np.where(passes, volume(det_free, p_free), 0.0)
+
+    p_cut, det_cut = sample(mapping(cuts=sqrt_s_cuts(BITING_CUT)), seed=SEED + 1)
+    piped = volume(det_cut, p_cut)
+
+    error = math.sqrt(
+        external.std() ** 2 / len(external) + piped.std() ** 2 / len(piped)
+    )
+    assert error > 0.0
+    assert abs(external.mean() - piped.mean()) < 5.0 * error
+
+
+def test_the_cut_removes_more_than_the_comparison_could_hide():
+    """Keeps the comparison above honest: if the volume the cut removes were
+    smaller than the precision of that comparison, the two numbers would agree
+    for uninteresting reasons. It has to be well outside the tolerance used
+    there, not merely nonzero."""
+    p_free, det_free = sample(mapping())
+    total = volume(det_free, p_free)
+    removed = np.where(s_hat(p_free) < BITING_CUT, total, 0.0)
+    error = total.std() / math.sqrt(len(total))
+    assert error > 0.0
+    assert removed.mean() > 10.0 * error
+
+
+# --------------------------------------------------------------------------
+# the cases where there is no range to narrow
+# --------------------------------------------------------------------------
+
+
+def test_a_cut_above_the_beam_energy_is_empty_and_finite():
+    """Such a cut leaves nothing to sample at all. It must come out as an empty
+    result, not as an inverted sampling range with nan weights."""
+    p_ext, det = sample(mapping(cuts=sqrt_s_cuts(2 * CM_ENERGY)))
+    assert np.all(det == 0.0)
+    assert np.all(np.isfinite(det))
+    assert np.all(np.isfinite(p_ext))
+
+
+def test_leptonic_s_hat_is_fixed_so_the_cut_only_filters():
+    """A leptonic collision has s_hat fixed at the beam energy: there is no
+    luminosity to sample and hence no range to narrow, so the cut stays a plain
+    filter and must still be applied as one."""
+    p_ext, det = sample(mapping(leptonic=True))
+    assert s_hat(p_ext) == pytest.approx(CM_ENERGY, rel=1e-9)
+    _, det_kept = sample(mapping(cuts=sqrt_s_cuts(BITING_CUT), leptonic=True))
+    assert np.array_equal(det_kept, det)
+    _, det_gone = sample(mapping(cuts=sqrt_s_cuts(2 * CM_ENERGY), leptonic=True))
+    assert np.all(det_gone == 0.0)


### PR DESCRIPTION
## What this fixes

`madspace/src/phasespace/phasespace.cpp` computed the floor that a `sqrt_s` minimum puts on s-hat and then dropped it on the floor: `sqrt_s_hat_min` and `s_hat_min` were assigned and never read again. The only thing `[cuts] sqrt_s.min` ever did was multiply finished phase-space points by zero, so every point below the cut was generated and thrown away. The `pair_floor` block added above it in ec820297a — the bound that applies when no single propagator carries the cut pair — fed the same dead variable.

The fix hands the floor to the sampler the way a `pair_mass` cut already is, by raising the **root** propagator's `e_min`. `update_mass_min_max` carries `e_min` into the `s_min` the luminosity's `Invariant` is sampled from, and that `Invariant`'s Jacobian follows whatever range it is given — so the integral is unchanged and only the waste moves. Guarded to `_map_luminosity`: a leptonic collision has s-hat fixed at s_lab and `chili` reconstructs it from momenta it has already generated, so in neither case is there a range to narrow, and a floor at or above the beam energy would be an empty range. Those cases stay pure filtering.

## Measurements

`p p > t t~`, fixed mu_R = mu_F = 173, lhaid 247000 (NNPDF23_lo_as_0130_qed), mt = 173, 100k events. The integrals agree and the sampling stops being discarded:

| `sqrt_s.min` | before | after | unweighting eff. | samples |
|---|---|---|---|---|
| 900 | 28.073(18) | 28.043(27) | 0.288 → 0.433 | 760k → 628k |
| 6000 | 2.39845(99)e-05 | 2.4000(14)e-05 | 0.036 → 0.493 | 3.49M → 880k |
| 12000 | 5.5789(27)e-14 | 5.5834(27)e-14 | 0.106 → 0.552 | 1.47M → 538k |

The no-op control — a cut at 347, just above the `2 m_t = 346` kinematic threshold, where it can remove almost nothing — reproduces the inclusive 559.22(42) as 558.88(42).

A ladder check on an s-channel-resonance topology (`p p > e+ e-`, lepton cuts relaxed) is self-consistent too: the run at `sqrt_s.min = 100` implies 2.319(53) above 200 GeV and 0.109(11) above 500, against direct runs of 2.3925(33) and 0.10405(15).

## A correction to the record

This was reported as a **~10% cross-section loss** — a cut removing 0.05% of events costing 10.6% of the integral. That does not reproduce, and could not have: the line was dead code, so it could not bias anything. Controlled runs of that exact reproducer give 559.22(42) inclusive and 558.86(42) at `sqrt_s.min = 347` on `main`, and 558.24(39) / 558.34(39) on `feat-mlm`; `sqrt_s.min = 900` gives 28.05, not 20.85. At the mapping level, handing the cut to `PhaseSpaceMapping` before this change left the sampled momenta and weights bit-identical to no cut.

So this PR is an efficiency fix, not a physics fix. No previously published `sqrt_s.min` number is invalidated.

## Test

`madspace/tests/test_sqrt_s_cut.py`, 10 tests. The sharpest assertion uses the `2 m_t` threshold: a cut placed **below** it cannot forbid a single point, so the same random numbers must give back bit-identical momenta and weights — the integral unchanged in the strongest available sense. Alongside it, a phase-space-volume comparison at a cut that removes half the points and 62 sigma of volume, so a boundary that failed to compensate its own Jacobian could not hide in the statistics. Verified to fail on the unpatched build.

Full madspace suite: 1541 passed, 11 skipped, 4 failed — the four pre-existing `test_double_t.py` failures (`ModuleNotFoundError: scipy`), unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
